### PR TITLE
[BUG] Allow BaseEstimator in OrdinalDecomposition and resolve SVC warning in test file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 # Profiling
 *.lprof
 *.prof
+
+# Tests
+results/

--- a/examples/recipes/full_demo.py
+++ b/examples/recipes/full_demo.py
@@ -2,6 +2,7 @@
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import SVC
+from sklearn.calibration import CalibratedClassifierCV
 
 from skordinal.classifiers import REDSVM, SVOREX, OrdinalDecomposition
 from skordinal.experiments import ModelConfig
@@ -31,11 +32,11 @@ RECIPE = {
             OrdinalDecomposition(
                 dtype="ordered_partitions",
                 decision_method="frank_hall",
-                base_classifier=SVC(probability=True),
+                base_classifier=CalibratedClassifierCV(estimator=SVC(), ensemble=False),
             ),
             param_grid={
-                "base_classifier__C": [0.01, 0.1, 1, 10],
-                "base_classifier__gamma": [0.01, 0.1, 1, 10],
+                "base_classifier__estimator__C": [0.01, 0.1, 1, 10],
+                "base_classifier__estimator__gamma": [0.01, 0.1, 1, 10],
             },
         ),
         "LR": ModelConfig(

--- a/skordinal/classifiers/_ordinal_decomposition.py
+++ b/skordinal/classifiers/_ordinal_decomposition.py
@@ -107,7 +107,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
                 {"exponential_loss", "hinge_loss", "logarithmic_loss", "frank_hall"}
             )
         ],
-        "base_classifier": [str],
+        "base_classifier": [str, BaseEstimator],
         "parameters": [dict, None],
     }
 

--- a/skordinal/model_selection/_loaders.py
+++ b/skordinal/model_selection/_loaders.py
@@ -7,7 +7,7 @@ from importlib import import_module
 from typing import Any
 
 import numpy as np
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, clone
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import get_ordinal_scorer
@@ -126,6 +126,14 @@ def load_classifier(
     'GridSearchCV'
 
     """
+
+    # Check if the classifier_name is already an instance of BaseEstimator
+    if isinstance(classifier_name, BaseEstimator):
+        estimator = clone(classifier_name)
+        if param_grid:
+            estimator.set_params(**param_grid)
+        return estimator
+
     classifier_cls = get_classifier_by_name(classifier_name)
 
     if param_grid is None:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #92

#### Description
This PR resolves a compatibility issue where `OrdinalDecomposition` and its internal loader failed when receiving an instantiated `BaseEstimator` (since they strictly expected a string). It also updates the demo to comply with upcoming scikit-learn changes.

#### Changes made
* **`skordinal/classifiers/_ordinal_decomposition.py`:** updated `_parameter_constraints` so the `base_classifier` parameter accepts both `BaseEstimator` and `str`.
* **`skordinal/model_selection/_loaders.py`:** patched `load_classifier` to successfully intercept and handle `BaseEstimator` objects.
* **`examples/recipes/full_demo.py`:** replaced `SVC(probability=True)` with `CalibratedClassifierCV(estimator=SVC(), ensemble=False)` to prevent the scikit-learn 1.11 warning.

#### Testing
- [x] Verified that `examples/recipes/full_demo.py` now successfully completes its execution without crashing during `SVMOP` resampling.