### PR TITLE
ENH: Add LogisticIT and LogisticAT

### DIFF
--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -3,6 +3,7 @@
 from ._cost_sensitive_wrapper import CostSensitiveWrapper
 from ._elmop import ELMOP
 from ._kdlor import KDLOR
+from ._logistic_it import LogisticIT
 from ._nnop import NNOP
 from ._nnpom import NNPOM
 from ._orboost import ORBoost
@@ -16,6 +17,7 @@ __all__ = [
     "CostSensitiveWrapper",
     "ELMOP",
     "KDLOR",
+    "LogisticIT",
     "NNOP",
     "NNPOM",
     "ORBoost",

--- a/skordinal/classifiers/__init__.py
+++ b/skordinal/classifiers/__init__.py
@@ -3,6 +3,7 @@
 from ._cost_sensitive_wrapper import CostSensitiveWrapper
 from ._elmop import ELMOP
 from ._kdlor import KDLOR
+from ._logistic_at import LogisticAT
 from ._logistic_it import LogisticIT
 from ._nnop import NNOP
 from ._nnpom import NNPOM
@@ -17,6 +18,7 @@ __all__ = [
     "CostSensitiveWrapper",
     "ELMOP",
     "KDLOR",
+    "LogisticAT",
     "LogisticIT",
     "NNOP",
     "NNPOM",

--- a/skordinal/classifiers/_logistic_at.py
+++ b/skordinal/classifiers/_logistic_at.py
@@ -1,0 +1,341 @@
+"""All-Threshold logistic ordinal classifier (LogisticAT)."""
+
+import warnings
+from numbers import Integral, Real
+
+import numpy as np
+import scipy.optimize
+import scipy.special
+from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.class_weight import compute_sample_weight
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from skordinal.utils.extmath import (
+    cumproba_to_proba,
+    params_to_thresholds,
+    repair_cumproba,
+    thresholds_grad,
+    thresholds_to_params,
+)
+from skordinal.utils.validation import check_ordinal_targets
+
+
+class LogisticAT(ClassifierMixin, BaseEstimator):
+    """All-Threshold logistic ordinal classifier.
+
+    ``LogisticAT`` [1]_ fits a shared linear projection ``f(x) = w^T x`` and
+    ``K-1`` ordered thresholds ``b_1 <= ... <= b_{K-1}`` by minimising a
+    margin-based surrogate of the absolute error.  For every (sample,
+    threshold) pair ``(i, k)`` the model incurs a logistic loss that
+    penalises the projection ``f(x_i)`` for being on the wrong side of
+    threshold ``b_k``.  Optimisation uses L-BFGS-B over an unconstrained
+    reparametrisation that keeps the thresholds ordered.
+
+    Parameters
+    ----------
+    alpha : float, default=1.0
+        L2 regularisation strength applied to ``w`` only; thresholds are
+        unpenalised.  Must be >= 0.
+
+    max_iter : int, default=1000
+        Maximum number of L-BFGS-B iterations.
+
+    tol : float, default=1e-5
+        Convergence tolerance forwarded to L-BFGS-B as both ``ftol`` and
+        ``gtol``.  Must be strictly positive.
+
+    class_weight : dict, "balanced", or None, default=None
+        Per-class weights applied to each sample's loss contribution.
+        Supply a dict ``{class_label: weight}`` to set weights manually,
+        or ``"balanced"`` to let the estimator compute weights
+        proportional to ``n_samples / (n_classes * np.bincount(y))``.
+        ``None`` assigns weight 1 to every sample.  The L2 penalty on
+        ``w`` and the threshold parameters are not affected.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Unique class labels seen during ``fit``, sorted in ascending order.
+
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,), dtype object
+        Feature names seen during ``fit``.  Defined only when ``X`` is a
+        ``pandas.DataFrame``.
+
+    coef_ : ndarray of shape (n_features_in_,)
+        Linear projection weights ``w``.  No bias term — per-class biases
+        are absorbed into ``thresholds_``.
+
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Fitted ordered thresholds ``b_1 <= ... <= b_{K-1}``.
+
+    n_iter_ : int
+        Number of L-BFGS-B iterations executed during ``fit``.
+
+    loss_ : float
+        Final objective value (All-Threshold loss + L2 penalty) at
+        convergence.
+
+    Notes
+    -----
+    The All-Threshold loss sums, over all ``(i, k)`` pairs, a logistic
+    surrogate of the absolute error:
+
+    .. math::
+
+        J(w, t) = \\frac{1}{n} \\sum_{i,k}
+                  \\log\\bigl(1 + \\exp(-s_{i,k}(b_k - w^T x_i))\\bigr)
+                  + \\frac{\\alpha}{2n} \\|w\\|^2
+
+    where ``s_{i,k} = +1`` if ``y_i <= k`` else ``-1``.  The formula is
+    shown unweighted; ``class_weight`` multiplies each sample's term.
+    L-BFGS-B optimises the packed vector ``[w; t]`` where ``t`` is the
+    unconstrained representation of the thresholds; ``b[0] = t[0]``,
+    ``b[k] = t[0] + t[1]^2 + ... + t[k]^2`` for ``k >= 1``.
+
+    Standardising features (zero mean, unit variance) is recommended;
+    extreme feature scales can degrade the fit under the fixed solver
+    tolerance.
+
+    ``predict`` uses the cumulative-median rule, which is not in general
+    equal to the modal prediction ``classes_[argmax(predict_proba(X),
+    axis=1)]``; see ``predict`` for the exact rule and its rationale.
+
+    References
+    ----------
+    .. [1] F. Pedregosa, F. Bach, and A. Gramfort,
+       "On the Consistency of Ordinal Regression Methods,"
+       Journal of Machine Learning Research, vol. 18, no. 55,
+       pp. 1-35, 2017.
+       http://jmlr.org/papers/v18/15-495.html
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.classifiers import LogisticAT
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((80, 4))
+    >>> y = np.repeat([1, 2, 3, 4], 20)
+    >>> clf = LogisticAT(alpha=1.0).fit(X, y)
+    >>> clf.predict(X[:5])  # doctest: +SKIP
+    array([1, 2, 3, 4, ...])
+    """
+
+    _parameter_constraints: dict = {
+        "alpha": [Interval(Real, 0.0, None, closed="left")],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
+        "tol": [Interval(Real, 0.0, None, closed="neither")],
+        "class_weight": [StrOptions({"balanced"}), dict, None],
+    }
+
+    def __init__(
+        self,
+        alpha=1.0,
+        max_iter=1000,
+        tol=1e-5,
+        class_weight=None,
+    ):
+        self.alpha = alpha
+        self.max_iter = max_iter
+        self.tol = tol
+        self.class_weight = class_weight
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y):
+        """Fit the All-Threshold logistic model to training data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training patterns.
+
+        y : array-like of shape (n_samples,)
+            Ordinal target labels. Must contain at least 2 unique classes.
+
+        Returns
+        -------
+        self : LogisticAT
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` contains fewer than 2 unique classes.
+        """
+        X, y = validate_data(self, X, y, dtype=np.float64)
+        self.classes_, y_enc = check_ordinal_targets(y)
+        sample_weight = compute_sample_weight(self.class_weight, y)
+
+        n_features = X.shape[1]
+        n_classes = len(self.classes_)
+
+        params0 = self._init_params(n_features, n_classes)
+
+        result = scipy.optimize.minimize(
+            fun=self._objective,
+            x0=params0,
+            args=(X, y_enc, sample_weight, n_features, n_classes),
+            method="L-BFGS-B",
+            jac=True,
+            options={
+                "maxiter": self.max_iter,
+                "ftol": self.tol,
+                "gtol": self.tol,
+            },
+        )
+
+        if not result.success:
+            warnings.warn(
+                f"LogisticAT failed to converge after {self.max_iter} "
+                "iterations. Increase max_iter or set alpha > 0.",
+                ConvergenceWarning,
+                stacklevel=2,
+            )
+
+        self.coef_ = result.x[:n_features]
+        self.thresholds_ = params_to_thresholds(result.x[n_features:])
+        self.n_iter_ = int(result.nit)
+        self.loss_ = float(result.fun)
+
+        return self
+
+    def _project(self, X):
+        """Compute the raw latent projection for pre-validated X."""
+        return X @ self.coef_
+
+    def _cumproba(self, X):
+        """Compute raw cumulative probabilities on pre-validated X."""
+        f = self._project(X)
+        eta = self.thresholds_[None, :] - f[:, None]
+        return scipy.special.expit(eta)
+
+    def predict_cumproba(self, X):
+        """Return cumulative class probabilities ``P(Y <= k | x)``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        F : ndarray of shape (n_samples, n_classes - 1)
+            ``F[:, k]`` equals ``P(Y <= k+1 | x)`` for ``k = 0, ..., K-2``.
+            Columns are non-decreasing along the class axis; isotonic repair
+            is applied to enforce strict validity.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return repair_cumproba(self._cumproba(X))
+
+    def predict_proba(self, X):
+        """Return per-class probability estimates.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Non-negative class probabilities; each row sums to 1.0.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return cumproba_to_proba(self._cumproba(X), repair=True)
+
+    def predict(self, X):
+        """Predict ordinal class labels for patterns in X.
+
+        The predicted class follows the cumulative-median rule: the number
+        of fitted thresholds the projection ``f(x) = w^T x`` exceeds,
+        equivalently the first class whose cumulative probability
+        ``P(Y <= k | x)`` reaches 0.5.  This median is the risk-minimising
+        decision for the absolute-error surrogate the model optimises, and
+        unlike the mode (``argmax(predict_proba(X))``) it can differ when
+        adjacent thresholds are close.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels drawn from ``self.classes_``.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        f = self._project(X)
+        labels_enc = (f[:, np.newaxis] > self.thresholds_[np.newaxis, :]).sum(axis=1)
+        return self.classes_[labels_enc]
+
+    def _init_params(self, n_features, n_classes):
+        """Build the initial packed parameter vector ``[w; t]``."""
+        w = np.zeros(n_features)
+
+        quantiles = np.arange(1, n_classes) / n_classes
+        b_init = np.log(quantiles / (1.0 - quantiles))
+
+        t = thresholds_to_params(b_init)
+
+        return np.concatenate([w, t])
+
+    def _objective(
+        self,
+        params,
+        X,
+        y_enc,
+        sample_weight,
+        n_features,
+        n_classes,
+    ):
+        """Return the All-Threshold loss + L2 objective and gradient."""
+        w = params[:n_features]
+        t = params[n_features:]
+        thresholds = params_to_thresholds(t)
+
+        n = X.shape[0]
+        f = X @ w
+        k_idx = np.arange(n_classes - 1)
+        # All (sample, threshold) pairs: s = +1 when y_i <= k else -1
+        s = np.where(y_enc[:, None] <= k_idx[None, :], 1.0, -1.0)
+        margin = s * (thresholds[None, :] - f[:, None])
+
+        # Per-pair logistic loss: softplus(-margin)
+        J_pairs = np.logaddexp(0.0, -margin)
+        J = (J_pairs * sample_weight[:, None]).sum() / n + (self.alpha / (2 * n)) * (
+            w @ w
+        )
+
+        sigma = scipy.special.expit(-margin)
+
+        sw_col = sample_weight[:, None]
+        grad_f = ((s * sigma) * sw_col).sum(axis=1) / n
+        grad_w = X.T @ grad_f + (self.alpha / n) * w
+
+        grad_b = -((s * sigma) * sw_col).sum(axis=0) / n
+        grad_t = thresholds_grad(t, grad_b)
+
+        return float(J), np.concatenate([grad_w, grad_t])

--- a/skordinal/classifiers/_logistic_it.py
+++ b/skordinal/classifiers/_logistic_it.py
@@ -1,0 +1,354 @@
+"""Immediate-Threshold logistic ordinal classifier (LogisticIT)."""
+
+import warnings
+from numbers import Integral, Real
+
+import numpy as np
+import scipy.optimize
+import scipy.special
+from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.class_weight import compute_sample_weight
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from skordinal.utils.extmath import (
+    cumproba_to_proba,
+    params_to_thresholds,
+    repair_cumproba,
+    thresholds_grad,
+    thresholds_to_params,
+)
+from skordinal.utils.validation import check_ordinal_targets
+
+
+class LogisticIT(ClassifierMixin, BaseEstimator):
+    """Immediate-Threshold logistic ordinal classifier.
+
+    ``LogisticIT`` [1]_ fits a shared linear projection ``f(x) = w^T x`` and
+    ``K-1`` ordered thresholds ``b_1 <= ... <= b_{K-1}`` by minimising a
+    margin-based surrogate of the 0-1 loss.  For each sample only the two
+    thresholds immediately adjacent to its true class contribute to the
+    loss — the left threshold enforces ``f(x_i) > b_{y_i - 1}`` and the
+    right threshold enforces ``f(x_i) < b_{y_i}``.  Boundary classes
+    contribute only one term.  Optimisation uses L-BFGS-B over an
+    unconstrained reparametrisation that keeps the thresholds ordered.
+
+    Parameters
+    ----------
+    alpha : float, default=1.0
+        L2 regularisation strength applied to ``w`` only; thresholds are
+        unpenalised.  Must be >= 0.
+
+    max_iter : int, default=1000
+        Maximum number of L-BFGS-B iterations.
+
+    tol : float, default=1e-5
+        Convergence tolerance forwarded to L-BFGS-B as both ``ftol`` and
+        ``gtol``.  Must be strictly positive.
+
+    class_weight : dict, "balanced", or None, default=None
+        Per-class weights applied to each sample's loss contribution.
+        Supply a dict ``{class_label: weight}`` to set weights manually,
+        or ``"balanced"`` to let the estimator compute weights
+        proportional to ``n_samples / (n_classes * np.bincount(y))``.
+        ``None`` assigns weight 1 to every sample.  The L2 penalty on
+        ``w`` and the threshold parameters are not affected.
+
+    Attributes
+    ----------
+    classes_ : ndarray of shape (n_classes,)
+        Unique class labels seen during ``fit``, sorted in ascending order.
+
+    n_features_in_ : int
+        Number of features seen during ``fit``.
+
+    feature_names_in_ : ndarray of shape (n_features_in_,), dtype object
+        Feature names seen during ``fit``.  Defined only when ``X`` is a
+        ``pandas.DataFrame``.
+
+    coef_ : ndarray of shape (n_features_in_,)
+        Linear projection weights ``w``.  No bias term — per-class biases
+        are absorbed into ``thresholds_``.
+
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Fitted ordered thresholds ``b_1 <= ... <= b_{K-1}``.
+
+    n_iter_ : int
+        Number of L-BFGS-B iterations executed during ``fit``.
+
+    loss_ : float
+        Final objective value (Immediate-Threshold loss + L2 penalty) at
+        convergence.
+
+    Notes
+    -----
+    The Immediate-Threshold loss sums, over all samples, logistic margin
+    terms for the two thresholds adjacent to each sample's true class:
+
+    .. math::
+
+        J(w, t) = \\frac{1}{n} \\sum_i \\Bigl[
+                  \\mathbf{1}[y_i > 1] \\log(1 + e^{-(f(x_i) - b_{y_i-1})})
+                  + \\mathbf{1}[y_i < K] \\log(1 + e^{-(b_{y_i} - f(x_i))})
+                  \\Bigr]
+                  + \\frac{\\alpha}{2n} \\|w\\|^2
+
+    The formula is shown unweighted; ``class_weight`` multiplies each
+    sample's term.  The threshold gradient is sparse: each sample
+    contributes only to the two threshold bins adjacent to its class.
+    L-BFGS-B optimises the packed vector ``[w; t]`` where ``b[0] = t[0]``,
+    ``b[k] = t[0] + t[1]^2 + ... + t[k]^2`` for ``k >= 1``.
+
+    Standardising features (zero mean, unit variance) is recommended;
+    extreme feature scales can degrade the fit under the fixed solver
+    tolerance.
+
+    ``predict`` returns the most probable class,
+    ``classes_[argmax(predict_proba(X), axis=1)]``.  Because the loss is a
+    0-1 surrogate, this mode is also the risk-minimising decision, so
+    ``predict`` and the training objective agree.
+
+    References
+    ----------
+    .. [1] F. Pedregosa, F. Bach, and A. Gramfort,
+       "On the Consistency of Ordinal Regression Methods,"
+       Journal of Machine Learning Research, vol. 18, no. 55,
+       pp. 1-35, 2017.
+       http://jmlr.org/papers/v18/15-495.html
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skordinal.classifiers import LogisticIT
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((80, 4))
+    >>> y = np.repeat([1, 2, 3, 4], 20)
+    >>> clf = LogisticIT(alpha=1.0).fit(X, y)
+    >>> clf.predict(X[:5])  # doctest: +SKIP
+    array([1, 2, 3, 4, ...])
+    """
+
+    _parameter_constraints: dict = {
+        "alpha": [Interval(Real, 0.0, None, closed="left")],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
+        "tol": [Interval(Real, 0.0, None, closed="neither")],
+        "class_weight": [StrOptions({"balanced"}), dict, None],
+    }
+
+    def __init__(
+        self,
+        alpha=1.0,
+        max_iter=1000,
+        tol=1e-5,
+        class_weight=None,
+    ):
+        self.alpha = alpha
+        self.max_iter = max_iter
+        self.tol = tol
+        self.class_weight = class_weight
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y):
+        """Fit the Immediate-Threshold logistic model to training data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training patterns.
+
+        y : array-like of shape (n_samples,)
+            Ordinal target labels. Must contain at least 2 unique classes.
+
+        Returns
+        -------
+        self : LogisticIT
+            Fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` contains fewer than 2 unique classes.
+        """
+        X, y = validate_data(self, X, y, dtype=np.float64)
+        self.classes_, y_enc = check_ordinal_targets(y)
+        sample_weight = compute_sample_weight(self.class_weight, y)
+
+        n_features = X.shape[1]
+        n_classes = len(self.classes_)
+
+        params0 = self._init_params(n_features, n_classes)
+
+        result = scipy.optimize.minimize(
+            fun=self._objective,
+            x0=params0,
+            args=(X, y_enc, sample_weight, n_features, n_classes),
+            method="L-BFGS-B",
+            jac=True,
+            options={
+                "maxiter": self.max_iter,
+                "ftol": self.tol,
+                "gtol": self.tol,
+            },
+        )
+
+        if not result.success:
+            warnings.warn(
+                f"LogisticIT failed to converge after {self.max_iter} "
+                "iterations. Increase max_iter or set alpha > 0.",
+                ConvergenceWarning,
+                stacklevel=2,
+            )
+
+        self.coef_ = result.x[:n_features]
+        self.thresholds_ = params_to_thresholds(result.x[n_features:])
+        self.n_iter_ = int(result.nit)
+        self.loss_ = float(result.fun)
+
+        return self
+
+    def _project(self, X):
+        """Compute the raw latent projection for pre-validated X."""
+        return X @ self.coef_
+
+    def _cumproba(self, X):
+        """Compute raw cumulative probabilities on pre-validated X."""
+        f = self._project(X)
+        eta = self.thresholds_[None, :] - f[:, None]
+        return scipy.special.expit(eta)
+
+    def predict_cumproba(self, X):
+        """Return cumulative class probabilities ``P(Y <= k | x)``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        F : ndarray of shape (n_samples, n_classes - 1)
+            ``F[:, k]`` equals ``P(Y <= k+1 | x)`` for ``k = 0, ..., K-2``.
+            Columns are non-decreasing along the class axis; isotonic repair
+            is applied to enforce strict validity.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return repair_cumproba(self._cumproba(X))
+
+    def predict_proba(self, X):
+        """Return per-class probability estimates.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Non-negative class probabilities; each row sums to 1.0.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return cumproba_to_proba(self._cumproba(X), repair=True)
+
+    def predict(self, X):
+        """Predict ordinal class labels for patterns in X.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels drawn from ``self.classes_``.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        proba = cumproba_to_proba(self._cumproba(X), repair=True)
+        return self.classes_[proba.argmax(axis=1)]
+
+    def _init_params(self, n_features, n_classes):
+        """Build the initial packed parameter vector ``[w; t]``."""
+        w = np.zeros(n_features)
+
+        quantiles = np.arange(1, n_classes) / n_classes
+        b_init = np.log(quantiles / (1.0 - quantiles))
+
+        t = thresholds_to_params(b_init)
+
+        return np.concatenate([w, t])
+
+    def _objective(
+        self,
+        params,
+        X,
+        y_enc,
+        sample_weight,
+        n_features,
+        n_classes,
+    ):
+        """Return the Immediate-Threshold loss + L2 objective and gradient."""
+        w = params[:n_features]
+        t = params[n_features:]
+        thresholds = params_to_thresholds(t)
+
+        n = X.shape[0]
+        K = n_classes
+        f = X @ w
+
+        # Per-sample adjacent-threshold lookups. The -inf/+inf sentinels
+        # make each boundary margin +inf, so softplus(-inf)=0 drops that term
+        b_left = np.where(
+            y_enc > 0,
+            thresholds[np.clip(y_enc - 1, 0, K - 2)],
+            -np.inf,
+        )
+        b_right = np.where(
+            y_enc < K - 1,
+            thresholds[np.clip(y_enc, 0, K - 2)],
+            np.inf,
+        )
+        m_left = f - b_left
+        m_right = b_right - f
+
+        J = (
+            (sample_weight * np.logaddexp(0.0, -m_left)).sum() / n
+            + (sample_weight * np.logaddexp(0.0, -m_right)).sum() / n
+            + (self.alpha / (2 * n)) * (w @ w)
+        )
+
+        s_left = -scipy.special.expit(-m_left)
+        s_right = -scipy.special.expit(-m_right)
+        grad_f = sample_weight * (s_left - s_right) / n
+        grad_w = X.T @ grad_f + (self.alpha / n) * w
+
+        # Sparse scatter: each sample touches only its adjacent threshold bins
+        grad_b = np.zeros(K - 1)
+        mask_l = y_enc > 0
+        mask_r = y_enc < K - 1
+        np.add.at(grad_b, y_enc[mask_l] - 1, -s_left[mask_l] * sample_weight[mask_l])
+        np.add.at(grad_b, y_enc[mask_r], s_right[mask_r] * sample_weight[mask_r])
+        grad_b /= n
+
+        grad_t = thresholds_grad(t, grad_b)
+
+        return float(J), np.concatenate([grad_w, grad_t])

--- a/skordinal/classifiers/tests/test_logistic_at.py
+++ b/skordinal/classifiers/tests/test_logistic_at.py
@@ -1,0 +1,344 @@
+"""Tests for the LogisticAT classifier."""
+
+import inspect
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.optimize
+from sklearn.exceptions import NotFittedError
+from sklearn.utils.class_weight import compute_class_weight
+
+from skordinal.classifiers import LogisticAT
+from skordinal.datasets import make_ordinal_classification
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [-0.1, 0.2],
+            [2.0, 2.0],
+            [2.1, 1.9],
+            [1.9, 2.1],
+            [4.0, 4.0],
+            [4.1, 3.9],
+            [3.9, 4.1],
+        ]
+    )
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+
+
+@pytest.fixture
+def ordinal_data():
+    """Create a synthetic 3-class ordinal dataset for behavioural tests."""
+    return make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        noise=0.1,
+        random_state=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("alpha", -1),
+        ("max_iter", 0),
+        ("tol", 0),
+        ("class_weight", "unknown"),
+    ],
+)
+def test_logistic_at_hyperparameter_value_validation(X, y, param_name, invalid_value):
+    """Invalid hyperparameter values raise ValueError."""
+    classifier = LogisticAT(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("alpha", "strong"),
+        ("max_iter", 1.5),
+        ("tol", "eps"),
+        ("class_weight", 1.0),
+    ],
+)
+def test_logistic_at_hyperparameter_type_validation(X, y, param_name, invalid_value):
+    """Invalid hyperparameter types raise ValueError."""
+    classifier = LogisticAT(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_logistic_at_fit_returns_self(X, y):
+    """fit returns self (sklearn contract)."""
+    classifier = LogisticAT()
+    model = classifier.fit(X, y)
+    assert model is classifier
+
+
+def test_logistic_at_fit_input_validation(X, y):
+    """fit rejects mismatched or empty X and y."""
+    X_invalid = X[:-1, :-1]
+    y_invalid = y[:-1]
+
+    classifier = LogisticAT()
+    with pytest.raises(ValueError):
+        classifier.fit(X, y_invalid)
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+    with pytest.raises(ValueError):
+        classifier.fit(X_invalid, y)
+
+
+def test_logistic_at_sets_fitted_attributes_after_fit(X, y):
+    """fit sets the sklearn fitted attributes."""
+    clf = LogisticAT().fit(X, y)
+
+    for attr in [
+        "classes_",
+        "n_features_in_",
+        "coef_",
+        "thresholds_",
+        "n_iter_",
+        "loss_",
+    ]:
+        assert hasattr(clf, attr), f"Missing fitted attribute: {attr}"
+
+    assert isinstance(clf.classes_, np.ndarray) and np.array_equal(
+        clf.classes_, np.unique(y)
+    )
+    assert isinstance(clf.n_features_in_, int) and clf.n_features_in_ == X.shape[1]
+    assert clf.coef_.shape == (X.shape[1],)
+    assert clf.thresholds_.shape == (len(np.unique(y)) - 1,)
+    assert type(clf.n_iter_) is int
+    assert type(clf.loss_) is float
+    assert np.isfinite(clf.loss_)
+    assert clf.loss_ >= 0.0
+
+
+def test_logistic_at_predict_invalid_input_raises_error(X, y):
+    """predict rejects invalid input."""
+    classifier = LogisticAT()
+    classifier.fit(X, y)
+
+    with pytest.raises(ValueError):
+        classifier.predict([])
+
+
+def test_logistic_at_predict_raises_if_not_fitted(X):
+    """predict raises NotFittedError before fit."""
+    classifier = LogisticAT()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_logistic_at_feature_names_in_when_dataframe(X, y):
+    """feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = LogisticAT().fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_logistic_at_parameter_constraints_match_init_params():
+    """_parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(LogisticAT.__init__).parameters) - {"self"}
+    assert set(LogisticAT._parameter_constraints) == init_params
+
+
+def test_logistic_at_predict_rejects_wrong_n_features(X, y):
+    """predict rejects a mismatched n_features."""
+    classifier = LogisticAT().fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_logistic_at_label_roundtrip(labels):
+    """fit preserves arbitrary ordinal labels in classes_."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = LogisticAT()
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_logistic_at_deterministic_two_fits(X, y):
+    """Two fits on the same data give bit-identical coef_ and thresholds_."""
+    clf_a = LogisticAT().fit(X, y)
+    clf_b = LogisticAT().fit(X, y)
+
+    np.testing.assert_array_equal(clf_a.coef_, clf_b.coef_)
+    np.testing.assert_array_equal(clf_a.thresholds_, clf_b.thresholds_)
+
+
+def test_logistic_at_thresholds_non_decreasing(ordinal_data):
+    """thresholds_ are non-decreasing after fit."""
+    X, y = ordinal_data
+    clf = LogisticAT().fit(X, y)
+
+    assert np.all(np.diff(clf.thresholds_) >= 0)
+    assert set(clf.predict(X)).issubset(set(clf.classes_))
+
+
+def test_logistic_at_proba_and_cumproba_well_formed(ordinal_data):
+    """predict_proba/predict_cumproba are well-formed and match predict."""
+    X, y = ordinal_data
+    clf = LogisticAT().fit(X, y)
+    n_classes = len(clf.classes_)
+
+    proba = clf.predict_proba(X)
+    assert proba.shape == (X.shape[0], n_classes)
+    assert np.all(proba >= 0.0) and np.all(proba <= 1.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+    cumproba = clf.predict_cumproba(X)
+    assert cumproba.shape == (X.shape[0], n_classes - 1)
+    assert np.all(cumproba >= 0.0) and np.all(cumproba <= 1.0)
+    assert np.all(np.diff(cumproba, axis=1) >= 0)
+
+    expected_pred = clf.classes_[(cumproba < 0.5).sum(axis=1)]
+    np.testing.assert_array_equal(clf.predict(X), expected_pred)
+
+
+def test_logistic_at_alpha_regularisation_reduces_coef_norm(ordinal_data):
+    """Higher alpha yields a coef_ with a smaller L2 norm than alpha=0."""
+    X, y = ordinal_data
+    clf_noreg = LogisticAT(alpha=0.0).fit(X, y)
+    clf_reg = LogisticAT(alpha=10.0).fit(X, y)
+
+    assert np.linalg.norm(clf_reg.coef_) < np.linalg.norm(clf_noreg.coef_)
+
+
+def test_logistic_at_class_weight_balanced_differs_from_none_and_matches_dict():
+    """class_weight='balanced' differs from None and matches a dict."""
+    X, y = make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        weights=[0.1, 0.3, 0.6],
+        random_state=1,
+    )
+
+    clf_none = LogisticAT(alpha=1.0).fit(X, y)
+    clf_bal = LogisticAT(alpha=1.0, class_weight="balanced").fit(X, y)
+    assert not (
+        np.allclose(clf_bal.coef_, clf_none.coef_)
+        and np.allclose(clf_bal.thresholds_, clf_none.thresholds_)
+    )
+
+    weights = compute_class_weight("balanced", classes=clf_bal.classes_, y=y)
+    cw_dict = dict(zip(clf_bal.classes_, weights))
+    clf_dict = LogisticAT(alpha=1.0, class_weight=cw_dict).fit(X, y)
+
+    np.testing.assert_allclose(clf_dict.coef_, clf_bal.coef_, atol=1e-8)
+    np.testing.assert_allclose(clf_dict.thresholds_, clf_bal.thresholds_, atol=1e-8)
+
+
+def test_logistic_at_binary_ordinal_data():
+    """LogisticAT fits and predicts on a 2-class ordinal dataset."""
+    X, y = make_ordinal_classification(
+        n_samples=60,
+        n_features=3,
+        n_classes=2,
+        n_informative=3,
+        noise=0.1,
+        random_state=2,
+    )
+    clf = LogisticAT().fit(X, y)
+
+    assert clf.thresholds_.shape == (1,)
+    assert set(clf.predict(X)).issubset(set(clf.classes_))
+    proba = clf.predict_proba(X)
+    assert proba.shape == (X.shape[0], 2)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+
+def _build_logistic_at_objective_callables(n, p, K, seed):
+    """Return (fun, jac, params0) for check_grad on LogisticAT._objective."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    y_enc = rng.integers(0, K, size=n)
+
+    clf = LogisticAT(alpha=0.3)
+    w = rng.standard_normal(p) * 0.3
+    t = np.zeros(K - 1)
+    t[0] = -1.0
+    if K > 2:
+        t[1:] = 0.5
+    params = np.concatenate([w, t])
+    sample_weight = np.ones(n)
+
+    def fun(params_):
+        """Return the scalar objective value for params_."""
+        value, _ = clf._objective(params_, X, y_enc, sample_weight, p, K)
+        return value
+
+    def jac(params_):
+        """Return the gradient vector for params_."""
+        _, grad = clf._objective(params_, X, y_enc, sample_weight, p, K)
+        return grad
+
+    return fun, jac, params
+
+
+@pytest.mark.parametrize("K", [3, 5])
+def test_logistic_at_objective_gradient_matches_numerical(K):
+    """Analytic gradient of _objective matches finite differences."""
+    fun, jac, params = _build_logistic_at_objective_callables(n=80, p=3, K=K, seed=42)
+    abs_err = scipy.optimize.check_grad(fun, jac, params)
+    g_num = scipy.optimize.approx_fprime(params, fun, 1e-5)
+    rel_err = abs_err / (1.0 + np.max(np.abs(g_num)))
+    assert rel_err < 1e-5
+
+
+def test_logistic_at_large_magnitude_x_finite_probabilities():
+    """Large-magnitude inputs still yield finite, normalised probabilities."""
+    X, y = make_ordinal_classification(
+        n_samples=60, n_features=4, n_classes=3, n_informative=4, random_state=0
+    )
+    X = X * 1000.0
+
+    classifier = LogisticAT().fit(X, y)
+    proba = classifier.predict_proba(X)
+
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)

--- a/skordinal/classifiers/tests/test_logistic_it.py
+++ b/skordinal/classifiers/tests/test_logistic_it.py
@@ -1,0 +1,344 @@
+"""Tests for the LogisticIT classifier."""
+
+import inspect
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.optimize
+from sklearn.exceptions import NotFittedError
+from sklearn.utils.class_weight import compute_class_weight
+
+from skordinal.classifiers import LogisticIT
+from skordinal.datasets import make_ordinal_classification
+
+
+@pytest.fixture
+def X():
+    """Create sample feature patterns for testing."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [-0.1, 0.2],
+            [2.0, 2.0],
+            [2.1, 1.9],
+            [1.9, 2.1],
+            [4.0, 4.0],
+            [4.1, 3.9],
+            [3.9, 4.1],
+        ]
+    )
+
+
+@pytest.fixture
+def y():
+    """Create sample target variables for testing."""
+    return np.array([0, 0, 0, 1, 1, 1, 2, 2, 2])
+
+
+@pytest.fixture
+def ordinal_data():
+    """Create a synthetic 3-class ordinal dataset for behavioural tests."""
+    return make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        noise=0.1,
+        random_state=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("alpha", -1),
+        ("max_iter", 0),
+        ("tol", 0),
+        ("class_weight", "unknown"),
+    ],
+)
+def test_logistic_it_hyperparameter_value_validation(X, y, param_name, invalid_value):
+    """Invalid hyperparameter values raise ValueError."""
+    classifier = LogisticIT(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "param_name, invalid_value",
+    [
+        ("alpha", "strong"),
+        ("max_iter", 1.5),
+        ("tol", "eps"),
+        ("class_weight", 1.0),
+    ],
+)
+def test_logistic_it_hyperparameter_type_validation(X, y, param_name, invalid_value):
+    """Invalid hyperparameter types raise ValueError."""
+    classifier = LogisticIT(**{param_name: invalid_value})
+
+    with pytest.raises(ValueError, match=rf"The '{param_name}' parameter.*"):
+        classifier.fit(X, y)
+
+
+def test_logistic_it_fit_returns_self(X, y):
+    """fit returns self (sklearn contract)."""
+    classifier = LogisticIT()
+    model = classifier.fit(X, y)
+    assert model is classifier
+
+
+def test_logistic_it_fit_input_validation(X, y):
+    """fit rejects mismatched or empty X and y."""
+    X_invalid = X[:-1, :-1]
+    y_invalid = y[:-1]
+
+    classifier = LogisticIT()
+    with pytest.raises(ValueError):
+        classifier.fit(X, y_invalid)
+
+    with pytest.raises(ValueError):
+        classifier.fit([], y)
+
+    with pytest.raises(ValueError):
+        classifier.fit(X, [])
+
+    with pytest.raises(ValueError):
+        classifier.fit(X_invalid, y)
+
+
+def test_logistic_it_sets_fitted_attributes_after_fit(X, y):
+    """fit sets the sklearn fitted attributes."""
+    clf = LogisticIT().fit(X, y)
+
+    for attr in [
+        "classes_",
+        "n_features_in_",
+        "coef_",
+        "thresholds_",
+        "n_iter_",
+        "loss_",
+    ]:
+        assert hasattr(clf, attr), f"Missing fitted attribute: {attr}"
+
+    assert isinstance(clf.classes_, np.ndarray) and np.array_equal(
+        clf.classes_, np.unique(y)
+    )
+    assert isinstance(clf.n_features_in_, int) and clf.n_features_in_ == X.shape[1]
+    assert clf.coef_.shape == (X.shape[1],)
+    assert clf.thresholds_.shape == (len(np.unique(y)) - 1,)
+    assert type(clf.n_iter_) is int
+    assert type(clf.loss_) is float
+    assert np.isfinite(clf.loss_)
+    assert clf.loss_ >= 0.0
+
+
+def test_logistic_it_predict_invalid_input_raises_error(X, y):
+    """predict rejects invalid input."""
+    classifier = LogisticIT()
+    classifier.fit(X, y)
+
+    with pytest.raises(ValueError):
+        classifier.predict([])
+
+
+def test_logistic_it_predict_raises_if_not_fitted(X):
+    """predict raises NotFittedError before fit."""
+    classifier = LogisticIT()
+    with pytest.raises(NotFittedError):
+        classifier.predict(X)
+
+
+def test_logistic_it_feature_names_in_when_dataframe(X, y):
+    """feature_names_in_ is set when X is a DataFrame."""
+    df = pd.DataFrame(X, columns=["f0", "f1"])
+    classifier = LogisticIT().fit(df, y)
+
+    assert hasattr(classifier, "feature_names_in_")
+    np.testing.assert_array_equal(
+        classifier.feature_names_in_, np.array(["f0", "f1"], dtype=object)
+    )
+
+
+def test_logistic_it_parameter_constraints_match_init_params():
+    """_parameter_constraints keys match __init__ parameters."""
+    init_params = set(inspect.signature(LogisticIT.__init__).parameters) - {"self"}
+    assert set(LogisticIT._parameter_constraints) == init_params
+
+
+def test_logistic_it_predict_rejects_wrong_n_features(X, y):
+    """predict rejects a mismatched n_features."""
+    classifier = LogisticIT().fit(X, y)
+    with pytest.raises(ValueError):
+        classifier.predict(X[:, :-1])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        [1, 2, 3],  # standard 1-indexed
+        [0, 1, 2],  # 0-indexed
+        [-1, 0, 1],  # negative labels
+        [3, 5, 7],  # non-contiguous with gaps
+    ],
+)
+def test_logistic_it_label_roundtrip(labels):
+    """fit preserves arbitrary ordinal labels in classes_."""
+    labels_array = np.array(labels)
+    X = np.array(
+        [[i, i] for i, _ in enumerate(np.repeat(labels_array, 3))], dtype=float
+    )
+    y = np.repeat(labels_array, 3)
+
+    classifier = LogisticIT()
+    classifier.fit(X, y)
+
+    assert np.array_equal(classifier.classes_, np.unique(labels_array))
+    assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_logistic_it_deterministic_two_fits(X, y):
+    """Two fits on the same data give bit-identical coef_ and thresholds_."""
+    clf_a = LogisticIT().fit(X, y)
+    clf_b = LogisticIT().fit(X, y)
+
+    np.testing.assert_array_equal(clf_a.coef_, clf_b.coef_)
+    np.testing.assert_array_equal(clf_a.thresholds_, clf_b.thresholds_)
+
+
+def test_logistic_it_thresholds_non_decreasing(ordinal_data):
+    """thresholds_ are non-decreasing after fit."""
+    X, y = ordinal_data
+    clf = LogisticIT().fit(X, y)
+
+    assert np.all(np.diff(clf.thresholds_) >= 0)
+    assert set(clf.predict(X)).issubset(set(clf.classes_))
+
+
+def test_logistic_it_proba_and_cumproba_well_formed(ordinal_data):
+    """predict_proba/predict_cumproba are well-formed and match predict."""
+    X, y = ordinal_data
+    clf = LogisticIT().fit(X, y)
+    n_classes = len(clf.classes_)
+
+    proba = clf.predict_proba(X)
+    assert proba.shape == (X.shape[0], n_classes)
+    assert np.all(proba >= 0.0) and np.all(proba <= 1.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+    cumproba = clf.predict_cumproba(X)
+    assert cumproba.shape == (X.shape[0], n_classes - 1)
+    assert np.all(cumproba >= 0.0) and np.all(cumproba <= 1.0)
+    assert np.all(np.diff(cumproba, axis=1) >= 0)
+
+    expected_pred = clf.classes_[proba.argmax(axis=1)]
+    np.testing.assert_array_equal(clf.predict(X), expected_pred)
+
+
+def test_logistic_it_alpha_regularisation_reduces_coef_norm(ordinal_data):
+    """Higher alpha yields a coef_ with a smaller L2 norm than alpha=0."""
+    X, y = ordinal_data
+    clf_noreg = LogisticIT(alpha=0.0).fit(X, y)
+    clf_reg = LogisticIT(alpha=10.0).fit(X, y)
+
+    assert np.linalg.norm(clf_reg.coef_) < np.linalg.norm(clf_noreg.coef_)
+
+
+def test_logistic_it_class_weight_balanced_differs_from_none_and_matches_dict():
+    """class_weight='balanced' differs from None and matches a dict."""
+    X, y = make_ordinal_classification(
+        n_samples=90,
+        n_features=4,
+        n_classes=3,
+        n_informative=4,
+        weights=[0.1, 0.3, 0.6],
+        random_state=1,
+    )
+
+    clf_none = LogisticIT(alpha=1.0).fit(X, y)
+    clf_bal = LogisticIT(alpha=1.0, class_weight="balanced").fit(X, y)
+    assert not (
+        np.allclose(clf_bal.coef_, clf_none.coef_)
+        and np.allclose(clf_bal.thresholds_, clf_none.thresholds_)
+    )
+
+    weights = compute_class_weight("balanced", classes=clf_bal.classes_, y=y)
+    cw_dict = dict(zip(clf_bal.classes_, weights))
+    clf_dict = LogisticIT(alpha=1.0, class_weight=cw_dict).fit(X, y)
+
+    np.testing.assert_allclose(clf_dict.coef_, clf_bal.coef_, atol=1e-8)
+    np.testing.assert_allclose(clf_dict.thresholds_, clf_bal.thresholds_, atol=1e-8)
+
+
+def test_logistic_it_binary_ordinal_data():
+    """LogisticIT fits and predicts on a 2-class ordinal dataset."""
+    X, y = make_ordinal_classification(
+        n_samples=60,
+        n_features=3,
+        n_classes=2,
+        n_informative=3,
+        noise=0.1,
+        random_state=2,
+    )
+    clf = LogisticIT().fit(X, y)
+
+    assert clf.thresholds_.shape == (1,)
+    assert set(clf.predict(X)).issubset(set(clf.classes_))
+    proba = clf.predict_proba(X)
+    assert proba.shape == (X.shape[0], 2)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+
+def _build_logistic_it_objective_callables(n, p, K, seed):
+    """Return (fun, jac, params0) for check_grad on LogisticIT._objective."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    y_enc = rng.integers(0, K, size=n)
+
+    clf = LogisticIT(alpha=0.3)
+    w = rng.standard_normal(p) * 0.3
+    t = np.zeros(K - 1)
+    t[0] = -1.0
+    if K > 2:
+        t[1:] = 0.5
+    params = np.concatenate([w, t])
+    sample_weight = np.ones(n)
+
+    def fun(params_):
+        """Return the scalar objective value for params_."""
+        value, _ = clf._objective(params_, X, y_enc, sample_weight, p, K)
+        return value
+
+    def jac(params_):
+        """Return the gradient vector for params_."""
+        _, grad = clf._objective(params_, X, y_enc, sample_weight, p, K)
+        return grad
+
+    return fun, jac, params
+
+
+@pytest.mark.parametrize("K", [3, 5])
+def test_logistic_it_objective_gradient_matches_numerical(K):
+    """Analytic gradient of _objective matches finite differences."""
+    fun, jac, params = _build_logistic_it_objective_callables(n=80, p=3, K=K, seed=42)
+    abs_err = scipy.optimize.check_grad(fun, jac, params)
+    g_num = scipy.optimize.approx_fprime(params, fun, 1e-5)
+    rel_err = abs_err / (1.0 + np.max(np.abs(g_num)))
+    assert rel_err < 1e-5
+
+
+def test_logistic_it_large_magnitude_x_finite_probabilities():
+    """Large-magnitude inputs still yield finite, normalised probabilities."""
+    X, y = make_ordinal_classification(
+        n_samples=60, n_features=4, n_classes=3, n_informative=4, random_state=0
+    )
+    X = X * 1000.0
+
+    classifier = LogisticIT().fit(X, y)
+    proba = classifier.predict_proba(X)
+
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds two ordinal threshold classifiers: `LogisticIT` (immediate-threshold) and `LogisticAT` (all-threshold), both fit via logistic loss with ordered decision thresholds and following the scikit-learn estimator API. Includes unit tests for each.