### PR TITLE
ENH: Warn on non-convergence in NNOP and NNPOM

### DIFF
--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math as math
+import warnings
 from numbers import Integral, Real
 
 import numpy as np
@@ -10,6 +11,7 @@ import scipy
 from numpy.typing import ArrayLike
 from scipy.special import expit
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted, validate_data
@@ -85,6 +87,9 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
     Notes
     -----
+    If the L-BFGS-B solver stops before converging, a ``ConvergenceWarning``
+    is raised and ``n_iter_`` reports the iterations actually run.
+
     This file is part of ORCA: https://github.com/ayrna/orca
 
     References
@@ -210,6 +215,19 @@ class NNOP(ClassifierMixin, BaseEstimator):
         nn_params = results_optimization[0]
         self.loss_ = float(results_optimization[1])
         self.n_iter_ = int(results_optimization[2].get("nit", 0))
+
+        if results_optimization[2].get("warnflag", 0) != 0:
+            task = results_optimization[2].get("task", "")
+            if isinstance(task, bytes):
+                task = task.decode()
+            warnings.warn(
+                f"NNOP did not converge (stopped after {self.n_iter_} "
+                f"iterations: {task}). Consider increasing max_iter, "
+                "adjusting the regularization strength alpha, or "
+                "standardizing X.",
+                ConvergenceWarning,
+                stacklevel=2,
+            )
 
         # Unpack the parameters
         theta1, theta2 = self._unpack_parameters(

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from numbers import Integral, Real
 
 import numpy as np
@@ -9,6 +10,7 @@ import scipy
 from numpy.typing import ArrayLike
 from scipy.special import expit
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_random_state
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted, validate_data
@@ -88,6 +90,11 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
     thresholds_ : ndarray of shape (1, n_classes - 1)
         Class thresholds parameters
+
+    Notes
+    -----
+    If the L-BFGS-B solver stops before converging, a ``ConvergenceWarning``
+    is raised and ``n_iter_`` reports the iterations actually run.
 
     References
     ----------
@@ -218,6 +225,19 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         nn_params = results_optimization[0]
         self.loss_ = float(results_optimization[1])
         self.n_iter_ = int(results_optimization[2].get("nit", 0))
+
+        if results_optimization[2].get("warnflag", 0) != 0:
+            task = results_optimization[2].get("task", "")
+            if isinstance(task, bytes):
+                task = task.decode()
+            warnings.warn(
+                f"NNPOM did not converge (stopped after {self.n_iter_} "
+                f"iterations: {task}). Consider increasing max_iter, "
+                "adjusting the regularization strength alpha, or "
+                "standardizing X.",
+                ConvergenceWarning,
+                stacklevel=2,
+            )
 
         # Unpack the parameters
         theta1, theta2, thresholds_param = self._unpack_parameters(

--- a/skordinal/classifiers/tests/test_nnop.py
+++ b/skordinal/classifiers/tests/test_nnop.py
@@ -1,11 +1,13 @@
 """Tests for the NNOP classifier."""
 
 import inspect
+import re
+import warnings
 
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.exceptions import NotFittedError
+from sklearn.exceptions import ConvergenceWarning, NotFittedError
 
 from skordinal.classifiers import NNOP
 from skordinal.datasets import make_ordinal_classification
@@ -288,3 +290,17 @@ def test_nnop_predict_cumproba_repairs_non_monotone_raw_row():
     proba = clf.predict_proba(probe)
     assert np.all(proba >= 0.0)
     np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
+
+
+def test_nnop_convergence_warning_only_at_insufficient_max_iter(ordinal_data):
+    """ConvergenceWarning fires at max_iter=1, not with the default budget."""
+    X, y = ordinal_data
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
+        NNOP(random_state=0).fit(X, y)
+
+    with pytest.warns(ConvergenceWarning, match="did not converge") as record:
+        clf = NNOP(max_iter=1, random_state=0).fit(X, y)
+
+    message = str(record[0].message)
+    assert re.search(rf"stopped after {clf.n_iter_} iterations?\b", message), message

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -1,12 +1,14 @@
 """Tests for the NNPOM classifier."""
 
 import inspect
+import re
+import warnings
 
 import numpy as np
 import pandas as pd
 import pytest
 from scipy.optimize import check_grad
-from sklearn.exceptions import NotFittedError
+from sklearn.exceptions import ConvergenceWarning, NotFittedError
 
 from skordinal.classifiers import NNPOM
 from skordinal.datasets import make_ordinal_classification
@@ -282,3 +284,17 @@ def test_nnpom_proba_and_cumproba_well_formed(ordinal_data):
 
     expected_pred = clf.classes_[proba.argmax(axis=1)]
     np.testing.assert_array_equal(clf.predict(X), expected_pred)
+
+
+def test_nnpom_convergence_warning_only_at_insufficient_max_iter(ordinal_data):
+    """ConvergenceWarning fires at max_iter=1, not with the default budget."""
+    X, y = ordinal_data
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
+        NNPOM(random_state=0).fit(X, y)
+
+    with pytest.warns(ConvergenceWarning, match="did not converge") as record:
+        clf = NNPOM(max_iter=1, random_state=0).fit(X, y)
+
+    message = str(record[0].message)
+    assert re.search(rf"stopped after {clf.n_iter_} iterations?\b", message), message


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

NNOP and NNPOM ran L-BFGS-B without inspecting its exit status, so a fit that stopped before converging returned silently. This checks the solver's `warnflag` and raises a `ConvergenceWarning` naming the iterations run and the solver's diagnostic message, the same format POM already uses. KDLOR and POM were the only classifiers in this module already warning on non-convergence.