### PR TITLE
FIX: Treat empty SKORDINAL_DATA as unset

### DIFF
--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -208,6 +208,7 @@ def get_data_home(data_home=None) -> str:
     Mirrors ``sklearn.datasets.get_data_home``. Resolution order:
     ``data_home`` argument → ``$SKORDINAL_DATA`` environment variable →
     ``~/skordinal_data``. The directory is created if it does not exist.
+    An empty ``$SKORDINAL_DATA`` value is treated as unset.
 
     Parameters
     ----------
@@ -228,7 +229,8 @@ def get_data_home(data_home=None) -> str:
     True
     """
     if data_home is None:
-        data_home = os.environ.get("SKORDINAL_DATA", Path.home() / "skordinal_data")
+        # Empty SKORDINAL_DATA would otherwise resolve to the cwd
+        data_home = os.environ.get("SKORDINAL_DATA") or (Path.home() / "skordinal_data")
     data_home = Path(data_home).expanduser()
     data_home.mkdir(parents=True, exist_ok=True)
     return str(data_home)

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -104,6 +104,15 @@ def test_clear_data_home_removes_directory(tmp_path):
     assert not target.exists()
 
 
+def test_get_data_home_empty_env_var_treated_as_unset(tmp_path, monkeypatch):
+    """``SKORDINAL_DATA=""`` falls back to the default home, not the cwd."""
+    monkeypatch.setenv("SKORDINAL_DATA", "")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = get_data_home(data_home=None)
+    assert Path(result) == tmp_path / "skordinal_data"
+    assert Path(result) != Path.cwd()
+
+
 def test_load_dataset_named_csv_bunch_contract(named_csv):
     """Named-header CSV yields a Bunch with correct shape, names, dtype."""
     bunch = load_dataset(named_csv)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`get_data_home` resolved `SKORDINAL_DATA=""` to `Path("")`, the current working directory, so `clear_data_home()` would delete the caller's cwd instead of the skordinal cache. An empty environment value is now treated as unset, falling  back to `~/skordinal_data`.