### PR TITLE
FIX: Seed nested random_state in ModelConfig.build

### DIFF
--- a/skordinal/experiments/_model_config.py
+++ b/skordinal/experiments/_model_config.py
@@ -107,12 +107,10 @@ class ModelConfig:
 
         Creates a clone via ``sklearn.base.clone`` so ``self.estimator``
         is never mutated.  When ``random_state`` is not ``None``, the
-        seed is forwarded to the clone, using the first match:
-
-        1. If the clone exposes ``random_state`` directly, it is set.
-        2. Else if the clone exposes ``clf__random_state`` (Pipeline
-           with a ``clf`` step), that is set.
-        3. Otherwise the seed is silently ignored.
+        seed is forwarded to every parameter named ``random_state`` or
+        ending in ``__random_state``, including those of nested
+        estimators and Pipeline steps.  When the estimator exposes no
+        such parameter, the seed is ignored.
 
         Parameters
         ----------
@@ -127,9 +125,11 @@ class ModelConfig:
         """
         est = clone(self.estimator)
         if random_state is not None:
-            params = est.get_params(deep=True)
-            if "random_state" in params:
-                est.set_params(random_state=random_state)
-            elif "clf__random_state" in params:
-                est.set_params(clf__random_state=random_state)
+            est.set_params(
+                **{
+                    key: random_state
+                    for key in est.get_params(deep=True)
+                    if key == "random_state" or key.endswith("__random_state")
+                }
+            )
         return est

--- a/skordinal/experiments/tests/test_model_config.py
+++ b/skordinal/experiments/tests/test_model_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from sklearn.ensemble import BaggingClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
@@ -99,6 +100,12 @@ def test_build_returns_distinct_clone_without_mutating_source():
     assert built is not cfg.estimator
     assert cfg.estimator.random_state == 0
 
+    nested = ModelConfig(
+        BaggingClassifier(estimator=DecisionTreeClassifier(random_state=0))
+    )
+    nested.build(7)
+    assert nested.estimator.estimator.random_state == 0
+
 
 @pytest.mark.parametrize(
     "estimator, check",
@@ -111,36 +118,35 @@ def test_build_returns_distinct_clone_without_mutating_source():
             Pipeline([("scaler", StandardScaler()), ("clf", DecisionTreeClassifier())]),
             lambda built: built.named_steps["clf"].random_state == 7,
         ),
-    ],
-    ids=["direct_estimator", "pipeline_clf_step"],
-)
-def test_build_forwards_random_state(estimator, check):
-    """``build(7)`` sets the seed on the clone (direct or Pipeline)."""
-    cfg = ModelConfig(estimator)
-    built = cfg.build(7)
-    assert check(built)
-
-
-@pytest.mark.parametrize(
-    "estimator, check",
-    [
-        (
-            StandardScaler(),
-            lambda built: "random_state" not in built.get_params(),
-        ),
         (
             Pipeline([("scaler", StandardScaler()), ("model", LogisticRegression())]),
-            lambda built: built.named_steps["model"].random_state is None,
+            lambda built: built.named_steps["model"].random_state == 7,
+        ),
+        (
+            BaggingClassifier(estimator=DecisionTreeClassifier()),
+            lambda built: built.random_state == 7 and built.estimator.random_state == 7,
         ),
     ],
-    ids=["no_random_state", "pipeline_step_not_clf"],
+    ids=[
+        "direct_estimator",
+        "pipeline_clf_step",
+        "pipeline_step_not_clf",
+        "own_and_nested_random_state",
+    ],
 )
-def test_build_ignores_random_state_when_absent(estimator, check):
-    """``build(7)`` returns a clone and injects no seed when none applies."""
+def test_build_forwards_random_state(estimator, check):
+    """``build(7)`` seeds every matching parameter on the clone."""
     cfg = ModelConfig(estimator)
     built = cfg.build(7)
-    assert built is not cfg.estimator
     assert check(built)
+
+
+def test_build_ignores_random_state_when_absent():
+    """``build(7)`` returns a clone and injects no seed when none applies."""
+    cfg = ModelConfig(StandardScaler())
+    built = cfg.build(7)
+    assert built is not cfg.estimator
+    assert "random_state" not in built.get_params()
 
 
 def test_build_none_seed_preserves_defaults():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`ModelConfig.build()` seeded only the `random_state` and `clf__random_state` parameters, so a seed exposed under any other key was ignored. `CostSensitiveWrapper`, `RegressorWrapper` and Pipelines with a step not named `clf` ran unseeded, making their results irreproducible.

`build()` now seeds every parameter named `random_state` or ending in `__random_state`, at any nesting depth.