### PR TITLE
FIX: Guard RegressorWrapper against NaN and inf

### DIFF
--- a/skordinal/classifiers/_regressor_wrapper.py
+++ b/skordinal/classifiers/_regressor_wrapper.py
@@ -48,6 +48,12 @@ class RegressorWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         Names of features seen during fit. Defined only when X has feature
         names that are all strings.
 
+    Notes
+    -----
+    The regressor is trained on the rank encoding of the labels, not their
+    raw values, so gaps between label values (e.g. ``[1, 3, 7]``) do not
+    bias it toward larger numeric gaps.
+
     References
     ----------
     .. [1] P. A. Gutiérrez, M. Pérez-Ortiz, J. Sánchez-Monedero,
@@ -124,11 +130,24 @@ class RegressorWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         NotFittedError
             If the estimator has not been fitted yet.
 
+        ValueError
+            If the wrapped regressor returns a NaN prediction.
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
 
         y_cont = self.estimator_.predict(X)
+
+        if np.isnan(y_cont).any():
+            raise ValueError(
+                "The wrapped regressor returned NaN predictions. "
+                "RegressorWrapper cannot map NaN to a rank."
+            )
+
+        # Clip so unbounded output maps to the nearest extreme class
+        max_rank = self.classes_.size - 1
+        y_cont = np.clip(y_cont, 0.0, max_rank)
+
         ranks = np.arange(self.classes_.size, dtype=float)
         idx = np.abs(y_cont[:, None] - ranks[None, :]).argmin(axis=1)
         return self.classes_[idx]

--- a/skordinal/classifiers/tests/test_regressor_wrapper.py
+++ b/skordinal/classifiers/tests/test_regressor_wrapper.py
@@ -137,3 +137,41 @@ def test_regressor_wrapper_label_roundtrip(labels):
 
     assert np.array_equal(classifier.classes_, np.unique(labels_array))
     assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_regressor_wrapper_predict_raises_on_nan_output(X, y, monkeypatch):
+    """Test that a NaN regressor prediction raises a ValueError."""
+
+    def predict_nan(self, X):
+        return np.full(len(X), np.nan)
+
+    monkeypatch.setattr(LinearRegression, "predict", predict_nan)
+    classifier = RegressorWrapper(LinearRegression()).fit(X, y)
+
+    with pytest.raises(ValueError, match="cannot map NaN to a rank"):
+        classifier.predict(X)
+
+
+@pytest.mark.parametrize(
+    "raw_output, expected_class_fn",
+    [
+        (np.inf, lambda classes: classes.max()),
+        (-np.inf, lambda classes: classes.min()),
+    ],
+)
+def test_regressor_wrapper_predict_clips_infinite_output_to_extreme_class(
+    X, y, monkeypatch, raw_output, expected_class_fn
+):
+    """Test that an infinite regressor prediction maps to the nearest extreme class."""
+
+    def predict_constant(self, X):
+        return np.full(len(X), raw_output)
+
+    monkeypatch.setattr(LinearRegression, "predict", predict_constant)
+    classifier = RegressorWrapper(LinearRegression()).fit(X, y)
+
+    predictions = classifier.predict(X)
+
+    npt.assert_array_equal(
+        predictions, np.full(len(X), expected_class_fn(classifier.classes_))
+    )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`RegressorWrapper.predict` rounded the wrapped regressor's continuous output to the nearest class rank without checking for NaN or unbounded values. A NaN prediction silently mapped to the lowest class, and an unbounded `+inf` prediction collapsed to the lowest class too, instead of the highest. `predict` now raises `ValueError` on NaN output, and clips the continuous output to the valid rank range before discretising so unbounded predictions map to the correct extreme class.