### PR TITLE
ENH: Add scale/auto gamma to SVOREX, align REDSVM

### DIFF
--- a/skordinal/classifiers/_redsvm.py
+++ b/skordinal/classifiers/_redsvm.py
@@ -42,11 +42,14 @@ class REDSVM(ClassifierMixin, BaseEstimator):
     degree : int, default=3
         Set degree in kernel function.
 
-    gamma : {'scale', 'auto'} or float, default='auto'
-        Kernel coefficient determining the influence of individual training samples:
-        - 'scale': 1 / (n_features * X.var())
-        - 'auto': 1 / n_features
-        - float: Must be non-negative.
+    gamma : {'scale', 'auto'} or float, default='scale'
+        Kernel coefficient for the RBF, polynomial, sigmoid, laplacian and
+        exponential kernels.
+
+        - ``'scale'``: ``1 / (n_features * X.var())``. Falls back to
+          ``1.0`` when ``X.var() == 0``.
+        - ``'auto'``: ``1 / n_features``.
+        - float: used as-is. Must be strictly positive.
 
     coef0 : float, default=0
         Set coef0 in kernel function.
@@ -115,7 +118,7 @@ class REDSVM(ClassifierMixin, BaseEstimator):
         C: float = 1,
         kernel: str = "rbf",
         degree: int = 3,
-        gamma: float | str = "auto",
+        gamma: float | str = "scale",
         coef0: float = 0,
         shrinking: bool = True,
         tol: float = 0.001,
@@ -157,13 +160,15 @@ class REDSVM(ClassifierMixin, BaseEstimator):
         X, y = validate_data(self, X, y)
         self.classes_, y_encoded = check_ordinal_targets(y)
 
-        # Set default gamma value if not specified
-        gamma_value = self.gamma
-        if self.gamma == "auto":
-            gamma_value = 1.0 / X.shape[1]
-        elif self.gamma == "scale":
+        # Resolve gamma to a scalar before passing it to the C++ backend
+        n_features = X.shape[1]
+        if self.gamma == "scale":
             x_var = X.var()
-            gamma_value = 1.0 / (X.shape[1] * x_var) if x_var != 0.0 else 1.0
+            gamma_value = 1.0 / (n_features * x_var) if x_var != 0.0 else 1.0
+        elif self.gamma == "auto":
+            gamma_value = 1.0 / n_features
+        else:
+            gamma_value = float(self.gamma)
 
         # Map kernel type
         kernel_type_mapping = {

--- a/skordinal/classifiers/_svorex.py
+++ b/skordinal/classifiers/_svorex.py
@@ -40,8 +40,14 @@ class SVOREX(ClassifierMixin, BaseEstimator):
     tol : float, default=0.001
         Set tolerance of termination criterion.
 
-    gamma : float, default=1
-        Kernel coefficient for the RBF and polynomial kernels.
+    gamma : {'scale', 'auto'} or float, default='scale'
+        Kernel coefficient for the RBF kernel. Ignored by the linear
+        and polynomial kernels.
+
+        - ``'scale'``: ``1 / (n_features * X.var())``. Falls back to
+          ``1.0`` when ``X.var() == 0``.
+        - ``'auto'``: ``1 / n_features``.
+        - float: used as-is. Must be strictly positive.
 
     Attributes
     ----------
@@ -69,7 +75,10 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         "kernel": [StrOptions({"rbf", "linear", "poly"})],
         "degree": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0.0, None, closed="neither")],
-        "gamma": [Interval(Real, 0.0, None, closed="neither")],
+        "gamma": [
+            StrOptions({"scale", "auto"}),
+            Interval(Real, 0.0, None, closed="neither"),
+        ],
     }
 
     def __init__(
@@ -78,7 +87,7 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         kernel: str = "rbf",
         degree: int = 2,
         tol: float = 0.001,
-        gamma: float = 1,
+        gamma: float | str = "scale",
     ) -> None:
         self.C = C
         self.kernel = kernel
@@ -120,8 +129,18 @@ class SVOREX(ClassifierMixin, BaseEstimator):
             arg = "-P {}".format(self.degree)
         # kernel == "rbf" maps to the C core's default (gaussian); no flag emitted.
 
+        # Resolve gamma to a scalar before passing it to the C backend
+        n_features = X.shape[1]
+        if self.gamma == "scale":
+            x_var = X.var()
+            gamma_value = 1.0 / (n_features * x_var) if x_var != 0.0 else 1.0
+        elif self.gamma == "auto":
+            gamma_value = 1.0 / n_features
+        else:
+            gamma_value = float(self.gamma)
+
         options = "svorex {} -T {} -K {} -C {}".format(
-            arg, str(self.tol), str(self.gamma), str(self.C)
+            arg, str(self.tol), str(gamma_value), str(self.C)
         )
         self.model_ = svorex.fit((y_encoded + 1).tolist(), X.tolist(), options)
         return self

--- a/skordinal/classifiers/tests/test_redsvm.py
+++ b/skordinal/classifiers/tests/test_redsvm.py
@@ -214,3 +214,21 @@ def test_redsvm_gamma_scale_zero_variance(X, y):
         classifier = REDSVM(gamma="scale", kernel="rbf").fit(X_constant, y)
 
     assert set(classifier.predict(X_constant)).issubset(set(classifier.classes_))
+
+
+@pytest.mark.parametrize(
+    "gamma, expected_gamma",
+    [
+        ("auto", lambda X: 1.0 / X.shape[1]),
+        ("scale", lambda X: 1.0 / (X.shape[1] * X.var())),
+    ],
+    ids=["auto", "scale"],
+)
+def test_redsvm_gamma_string_resolves_like_numeric(gamma, expected_gamma):
+    """A string gamma predicts the same as the numeric value it resolves to."""
+    X_train, X_test, y_train, _ = make_balance_scale_split()
+
+    resolved = REDSVM(gamma=gamma).fit(X_train, y_train)
+    explicit = REDSVM(gamma=expected_gamma(X_train)).fit(X_train, y_train)
+
+    np.testing.assert_array_equal(resolved.predict(X_test), explicit.predict(X_test))

--- a/skordinal/classifiers/tests/test_svorex.py
+++ b/skordinal/classifiers/tests/test_svorex.py
@@ -1,6 +1,7 @@
 """Tests for the SVOREX classifier."""
 
 import inspect
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -59,6 +60,7 @@ def test_svorex_predict_matches_expected(kernel):
         ("tol", -1e-5),
         ("kernel", "unknown"),
         ("gamma", -1),
+        ("gamma", "low"),
     ],
 )
 def test_svorex_hyperparameter_value_validation(X, y, param_name, invalid_value):
@@ -76,7 +78,6 @@ def test_svorex_hyperparameter_value_validation(X, y, param_name, invalid_value)
         ("kernel", 5),
         ("degree", 2.5),
         ("tol", "tight"),
-        ("gamma", "low"),
     ],
 )
 def test_svorex_hyperparameter_type_validation(X, y, param_name, invalid_value):
@@ -185,3 +186,31 @@ def test_svorex_label_roundtrip(labels):
 
     assert np.array_equal(classifier.classes_, np.unique(labels_array))
     assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+@pytest.mark.parametrize(
+    "gamma, expected_gamma",
+    [
+        ("auto", lambda X: 1.0 / X.shape[1]),
+        ("scale", lambda X: 1.0 / (X.shape[1] * X.var())),
+    ],
+    ids=["auto", "scale"],
+)
+def test_svorex_gamma_string_resolves_like_numeric(gamma, expected_gamma):
+    """A string gamma predicts the same as the numeric value it resolves to."""
+    X_train, X_test, y_train, _ = make_balance_scale_split()
+
+    resolved = SVOREX(gamma=gamma).fit(X_train, y_train)
+    explicit = SVOREX(gamma=expected_gamma(X_train)).fit(X_train, y_train)
+
+    np.testing.assert_array_equal(resolved.predict(X_test), explicit.predict(X_test))
+
+
+def test_svorex_gamma_scale_zero_variance(X, y):
+    """Test that gamma='scale' handles zero-variance input without dividing by zero."""
+    X_constant = np.ones_like(X)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        classifier = SVOREX(gamma="scale", kernel="rbf").fit(X_constant, y)
+
+    assert set(classifier.predict(X_constant)).issubset(set(classifier.classes_))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`SVOREX` now accepts `gamma='scale'` and `'auto'` in addition to a float, matching the gamma contract already used by `KDLOR` and `REDSVM`. It also gains the zero-variance guard those two classifiers already had, avoiding a division by zero when `X` is constant. Both `SVOREX` and `REDSVM` now default to `gamma='scale'`.

#### Any other comments?

Breaking default change. `SVOREX`'s previous default was `1`. `REDSVM`'s was `'auto'`. Code that left `gamma` unset will now fit a different model.