### PR TITLE
FIX: Default Benchmark random_state and resolve it once

### DIFF
--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from numbers import Integral
 from pathlib import Path
+
+from sklearn.utils import check_random_state
 
 from skordinal.datasets import load_partitions
 
@@ -71,12 +74,14 @@ class Benchmark:
         only, then applied to both train and test splits. ``None`` means no
         preprocessing.
 
-    random_state : int or None, default=None
+    random_state : int or None, default=0
         Seed used for two sources of randomness: the base estimator and the
         cross-validation splitter (``StratifiedKFold``) used during
         hyper-parameter search. Also forwarded to ``load_partitions`` when a
-        fallback split is generated. When ``None``, both use their own default
-        random behaviour.
+        fallback split is generated. A non-integer value (including ``None``)
+        is resolved to one concrete integer at construction, so every
+        ``load_partitions`` call in ``run`` shares the same partitioning
+        scheme.
 
     verbose : bool, default=True
         If ``True``, progress messages are printed to stdout.
@@ -116,7 +121,7 @@ class Benchmark:
         cv: int = 3,
         n_jobs: int = 1,
         input_preprocessing: str | None = None,
-        random_state: int | None = None,
+        random_state: int | None = 0,
         verbose: bool = True,
     ) -> None:
         if not models:
@@ -158,6 +163,9 @@ class Benchmark:
         self.cv = cv
         self.n_jobs = n_jobs
         self.input_preprocessing = input_preprocessing
+        # Collapse to one concrete int shared by every load_partitions call in run()
+        if not isinstance(random_state, Integral):
+            random_state = int(check_random_state(random_state).randint(2**31 - 1))
         self.random_state = random_state
         self.verbose = verbose
 

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -167,6 +167,55 @@ def test_protocol_attrs_stored(tmp_path):
     assert b.verbose is False
 
 
+def test_run_default_seed_reproducible_across_constructions(tmp_path):
+    """Two separately-constructed runs with the default random_state match."""
+
+    def _run(results_dir):
+        b = Benchmark(
+            _SVC_CONF,
+            datasets=[_BUNDLED_DS],
+            eval_metrics=["mean_absolute_error"],
+            results_path=results_dir,
+            resamples=3,
+            cv=2,
+            verbose=False,
+        )
+        b.run()
+        df = pd.read_csv(results_dir / "SVM" / _BUNDLED_DS / "report.csv", index_col=0)
+        return df.drop(columns=[c for c in df.columns if c.startswith("time_")])
+
+    df_a = _run(tmp_path / "a")
+    df_b = _run(tmp_path / "b")
+    pd.testing.assert_frame_equal(df_a, df_b)
+
+
+def test_run_all_models_see_identical_partitions_with_random_state_none(tmp_path):
+    """random_state=None resolves once, so every model sees identical partitions."""
+    configs = {
+        "SVM1": ModelConfig(SVC(), param_grid={"C": [1]}),
+        "SVM2": ModelConfig(SVC(), param_grid={"C": [1]}),
+    }
+    results_dir = tmp_path / "out"
+    b = Benchmark(
+        configs,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=results_dir,
+        resamples=3,
+        cv=2,
+        verbose=False,
+        random_state=None,
+    )
+    assert isinstance(b.random_state, int)
+    b.run()
+
+    def _pattern_ids(label):
+        seed_dir = results_dir / label / _BUNDLED_DS / "predictions_by_seed" / "seed_0"
+        return pd.read_csv(seed_dir / "test_predictions.csv")["Pattern ID"].values
+
+    np.testing.assert_array_equal(_pattern_ids("SVM1"), _pattern_ids("SVM2"))
+
+
 def test_run_and_summarize_bundled_dataset(tmp_path):
     """run() + summarize() over a bundled dataset write the expected on-disk layout."""
     results_dir = tmp_path / "runs"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`Benchmark.random_state` defaulted to `None`, so `load_partitions` fell back to an unseeded `StratifiedKFold` shuffle on every call. Since `run()` calls `load_partitions` separately per model, each model saw different train/test partitions within the same benchmark, and results were not reproducible across runs.

`random_state` now defaults to `0`, and any non-integer value (including `None`) is resolved to one integer once at construction, so every `load_partitions` call in `run()` shares the same partitioning scheme.

#### Any other comments?

Default `random_state` changed from `None` to `0`. Runs using the default now produce different, but reproducible and consistent, results.