### PR TITLE
FIX: Keep Experiment.run refit metadata local

### DIFF
--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -77,8 +77,8 @@ class Experiment:
         Optional feature preprocessing applied to every partition before
         fitting: ``"norm"`` applies min-max normalisation and ``"std"`` applies
         z-score standardisation. Both scalers are fitted on the training split
-        only, then applied to both train and test splits. ``None`` means no
-        preprocessing.
+        only, then applied to the train split and, when present, the test
+        split. ``None`` means no preprocessing.
 
     random_state : int or None, default=None
         Seed used for two sources of randomness: the base estimator and the
@@ -207,14 +207,17 @@ class Experiment:
         train_inputs: np.ndarray = X_train
         test_inputs: np.ndarray | None = X_test
 
-        if self.input_preprocessing == "norm":
-            scaler = preprocessing.MinMaxScaler().fit(train_inputs)
+        if self.input_preprocessing in {"norm", "std"}:
+            scaler_cls = (
+                preprocessing.MinMaxScaler
+                if self.input_preprocessing == "norm"
+                else preprocessing.StandardScaler
+            )
+            scaler = scaler_cls().fit(train_inputs)
             train_inputs = scaler.transform(train_inputs)
-            test_inputs = scaler.transform(cast(np.ndarray, X_test))
-        elif self.input_preprocessing == "std":
-            scaler = preprocessing.StandardScaler().fit(train_inputs)
-            train_inputs = scaler.transform(train_inputs)
-            test_inputs = scaler.transform(cast(np.ndarray, X_test))
+            # A train-only run has no test split to transform
+            if X_test is not None:
+                test_inputs = scaler.transform(X_test)
 
         # Select and fit the best estimator, keeping the refit metadata in
         # locals so nothing is ever injected onto the estimator itself

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections import OrderedDict
-from time import time
+from time import perf_counter
 from typing import Any, cast
 
 import numpy as np
@@ -216,7 +216,8 @@ class Experiment:
             train_inputs = scaler.transform(train_inputs)
             test_inputs = scaler.transform(cast(np.ndarray, X_test))
 
-        # Select and fit the best estimator via GridSearchCV or direct fit.
+        # Select and fit the best estimator, keeping the refit metadata in
+        # locals so nothing is ever injected onto the estimator itself
         base = self.model.build(self.random_state)
         if self.model.needs_search:
             scorer = (
@@ -227,7 +228,7 @@ class Experiment:
             splitter = StratifiedKFold(
                 n_splits=self.cv, shuffle=True, random_state=self.random_state
             )
-            optimal_estimator: Any = GridSearchCV(
+            search = GridSearchCV(
                 base,
                 param_grid=self.model.param_grid,
                 scoring=scorer,
@@ -235,31 +236,34 @@ class Experiment:
                 cv=splitter,
                 error_score="raise",
             )
+            search.fit(train_inputs, y_train)
+            best_estimator = search.best_estimator_
+            best_params = search.best_params_
+            refit_time = search.refit_time_
+            cv_time_train = search.cv_results_["mean_fit_time"].mean()
+            cv_time_test = search.cv_results_["mean_score_time"].mean()
         else:
             if self.model.param_grid:
                 base.set_params(**self.model.fixed_params())
-            optimal_estimator = base
-
-        _fit_start = time()
-        optimal_estimator.fit(train_inputs, y_train)
-        _fit_elapsed = time() - _fit_start
-
-        if not isinstance(optimal_estimator, GridSearchCV):
-            optimal_estimator.refit_time_ = _fit_elapsed
-            optimal_estimator.best_params_ = self.model.fixed_params()
-            optimal_estimator.best_estimator_ = optimal_estimator
+            fit_start = perf_counter()
+            base.fit(train_inputs, y_train)
+            refit_time = perf_counter() - fit_start
+            best_estimator = base
+            best_params = self.model.fixed_params()
+            cv_time_train = np.nan
+            cv_time_test = np.nan
 
         # Predict on the training split.
-        train_predicted_y = optimal_estimator.predict(train_inputs)
+        train_predicted_y = best_estimator.predict(train_inputs)
 
         # Predict on the test split when it is present.
         test_predicted_y = None
         elapsed = np.nan
         if y_test is not None:
             assert test_inputs is not None
-            start = time()
-            test_predicted_y = np.asarray(optimal_estimator.predict(test_inputs))
-            elapsed = time() - start
+            start = perf_counter()
+            test_predicted_y = np.asarray(best_estimator.predict(test_inputs))
+            elapsed = perf_counter() - start
 
         # Compute evaluation metrics for both splits.
         train_metrics: OrderedDict[str, Any] = OrderedDict()
@@ -278,32 +282,18 @@ class Experiment:
                 test_score = _compute_metric(metric_name, y_test, test_predicted_y)
                 test_metrics[metric_name.strip() + "_test"] = test_score
 
-        # Assemble timing keys (GridSearchCV vs direct-fit branches).
-        if isinstance(optimal_estimator, GridSearchCV):
-            train_metrics["cv_time_train"] = optimal_estimator.cv_results_[
-                "mean_fit_time"
-            ].mean()
-            test_metrics["cv_time_test"] = optimal_estimator.cv_results_[
-                "mean_score_time"
-            ].mean()
-            train_metrics["time_train"] = optimal_estimator.refit_time_
-            test_metrics["time_test"] = elapsed
-        else:
-            optimal_estimator.best_params_ = self.model.fixed_params()
-            optimal_estimator.best_estimator_ = optimal_estimator
-
-            train_metrics["cv_time_train"] = np.nan
-            test_metrics["cv_time_test"] = np.nan
-            train_metrics["time_train"] = optimal_estimator.refit_time_
-            test_metrics["time_test"] = elapsed
+        # Assemble timing keys, the cv_* pair stays NaN unless a search ran
+        train_metrics["cv_time_train"] = cv_time_train
+        test_metrics["cv_time_test"] = cv_time_test
+        train_metrics["time_train"] = refit_time
+        test_metrics["time_test"] = elapsed
 
         # Compute class probabilities on each split when supported
-        estimator = optimal_estimator.best_estimator_
-        train_y_proba = _predict_proba_or_none(estimator, train_inputs)
+        train_y_proba = _predict_proba_or_none(best_estimator, train_inputs)
         y_proba = None
         if y_test is not None:
             assert test_inputs is not None
-            y_proba = _predict_proba_or_none(estimator, test_inputs)
+            y_proba = _predict_proba_or_none(best_estimator, test_inputs)
 
         # Build and return the ExperimentResult; no persistence here.
         return ExperimentResult(
@@ -315,8 +305,8 @@ class Experiment:
             y_proba=y_proba,
             train_metrics=train_metrics,
             test_metrics=test_metrics,
-            best_params=optimal_estimator.best_params_,
-            best_model=estimator,
+            best_params=best_params,
+            best_model=best_estimator,
             train_true_y=y_train,
             test_true_y=y_test,
             train_index=train_index,

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -190,13 +190,18 @@ def test_run_timing_with_cv(split_with_test):
     assert result.best_params.get("C") in _CONF_CV.param_grid["C"]
 
 
-@pytest.mark.parametrize("preprocessing", ["std", "norm"])
-def test_run_preprocessing_train_only_raises(split_train_only, preprocessing):
-    """input_preprocessing with X_test=None raises ValueError."""
-    exp = _make_experiment(input_preprocessing=preprocessing)
+@pytest.mark.parametrize("input_preprocessing", ["std", "norm"])
+def test_run_preprocessing_train_only_does_not_raise(
+    split_train_only, input_preprocessing
+):
+    """input_preprocessing with X_test=None runs without transforming None."""
+    exp = _make_experiment(input_preprocessing=input_preprocessing)
     X_train, y_train, X_test, y_test = split_train_only
-    with pytest.raises(ValueError):
-        _call_run(exp, X_train, y_train, X_test, y_test)
+
+    result = _call_run(exp, X_train, y_train, X_test, y_test)
+
+    assert result.test_predicted_y is None
+    assert math.isnan(result.test_metrics["mean_absolute_error_test"])
 
 
 def test_run_best_model_carries_no_refit_metadata(split_with_test):

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -199,6 +199,16 @@ def test_run_preprocessing_train_only_raises(split_train_only, preprocessing):
         _call_run(exp, X_train, y_train, X_test, y_test)
 
 
+def test_run_best_model_carries_no_refit_metadata(split_with_test):
+    """The direct-fit path leaves no GridSearchCV-shaped attributes on best_model."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+
+    assert not hasattr(result.best_model, "best_estimator_")
+    assert not hasattr(result.best_model, "best_params_")
+    assert not hasattr(result.best_model, "refit_time_")
+
+
 def test_run_preprocessing_does_not_mutate_inputs(split_with_test):
     """input_preprocessing='std' operates on copies; caller's arrays are unchanged."""
     exp = _make_experiment(input_preprocessing="std")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`Experiment.run`'s direct-fit path mutated the fitted estimator with `best_estimator_ = self`, creating a self-referential cycle that got pickled into saved models. Metadata now stays in local variables, removing that mutation and a duplicate assignment.

Also fixes a crash: `input_preprocessing` with `X_test=None` called `scaler.transform(None)`. The test split is now only transformed when present.

Timing switches from `time()` to `perf_counter()`.