### PR TITLE
FIX: Reject y=None in check_ordinal_targets

### DIFF
--- a/skordinal/utils/tests/test_validation.py
+++ b/skordinal/utils/tests/test_validation.py
@@ -71,13 +71,15 @@ def test_cot_non_contiguous_labels():
 @pytest.mark.parametrize(
     "y, match",
     [
+        (None, r"requires y to be passed"),
         ([], None),
         (np.array([[1, 2], [3, 4]]), r"y must be a 1D array"),
-        ([1, 1, 1], r"y must contain at least 2 unique classes"),
+        # "1 class" singular, not "1 classes"
+        ([1, 1, 1], r"y must contain at least 2 unique classes, got 1 class$"),
         (np.array(["a", "b"], dtype=object), None),
         ([np.nan, 1.0, 2.0], None),
     ],
-    ids=["empty", "2d", "single-class", "object-dtype", "nan"],
+    ids=["none", "empty", "2d", "single-class", "object-dtype", "nan"],
 )
 def test_cot_invalid_input_raises(y, match):
     """Each invalid-input shape / dtype / cardinality raises ValueError."""

--- a/skordinal/utils/validation.py
+++ b/skordinal/utils/validation.py
@@ -48,11 +48,11 @@ def check_ordinal_targets(
     Raises
     ------
     ValueError
-        If ``y`` is empty, multi-dimensional, has a non-numeric dtype,
-        or contains fewer than 2 unique classes. Upstream ``ValueError``
-        from ``check_array`` (e.g. NaN inputs, object arrays) and from
-        ``check_classification_targets`` (e.g. continuous targets) are
-        propagated unchanged.
+        If ``y`` is ``None``, empty, multi-dimensional, has a
+        non-numeric dtype, or contains fewer than 2 unique classes.
+        Upstream ``ValueError`` from ``check_array`` (e.g. NaN inputs,
+        object arrays) and from ``check_classification_targets`` (e.g.
+        continuous targets) are propagated unchanged.
 
     Examples
     --------
@@ -64,6 +64,9 @@ def check_ordinal_targets(
     >>> y_enc
     array([2, 0, 1, 0, 2])
     """
+    if y is None:
+        raise ValueError("requires y to be passed, but the target y is None.")
+
     y = check_array(
         y, ensure_2d=False, dtype="numeric", ensure_min_samples=1, input_name="y"
     )
@@ -76,9 +79,7 @@ def check_ordinal_targets(
     classes, y_encoded = np.unique(y, return_inverse=True)
 
     if classes.size < 2:
-        raise ValueError(
-            f"y must contain at least 2 unique classes, got {classes.size}"
-        )
+        raise ValueError("y must contain at least 2 unique classes, got 1 class")
 
     return classes, y_encoded.astype(np.intp)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`check_ordinal_targets` is called from every classifier's `fit`, but passing `y=None` fell through into `check_array` and raised an obscure, misleading error. This adds an explicit guard that raises a clear `ValueError` when `y` is `None`.

Also fixes a pluralization bug in the adjacent "must contain at least 2 unique classes" message, which previously read "got 1 classes" instead of "got 1 class".