### PR TITLE
FIX: Collapse single-column metric targets by ravel, not argmax

### DIFF
--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -11,7 +11,8 @@ def _check_metric_inputs(y_true, y_pred):
     """Coerce metric inputs to 1-D arrays and validate length consistency.
 
     Two-dimensional inputs are interpreted as one-hot encoded labels and
-    collapsed via ``argmax`` along the last axis. Centralises the input
+    collapsed via ``argmax`` along the last axis, except a single-column
+    input, which is raveled to its original values. Centralises the input
     coercion that every public ordinal metric needs.
 
     Parameters
@@ -33,11 +34,19 @@ def _check_metric_inputs(y_true, y_pred):
         If ``y_true`` and ``y_pred`` have different lengths.
     """
     y_true_arr = np.asarray(y_true)
-    y_pred_arr = np.asarray(y_pred)
     if y_true_arr.ndim > 1:
-        y_true_arr = y_true_arr.argmax(axis=-1)
+        y_true_arr = (
+            y_true_arr.argmax(axis=-1)
+            if y_true_arr.shape[1] > 1
+            else y_true_arr.ravel()
+        )
+    y_pred_arr = np.asarray(y_pred)
     if y_pred_arr.ndim > 1:
-        y_pred_arr = y_pred_arr.argmax(axis=-1)
+        y_pred_arr = (
+            y_pred_arr.argmax(axis=-1)
+            if y_pred_arr.shape[1] > 1
+            else y_pred_arr.ravel()
+        )
     check_consistent_length(y_true_arr, y_pred_arr)
     return y_true_arr, y_pred_arr
 
@@ -45,9 +54,10 @@ def _check_metric_inputs(y_true, y_pred):
 def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
     """Validate inputs for probabilistic ordinal metrics.
 
-    ``y_true`` may be 1-D class labels or a 2-D one-hot matrix.
-    ``y_proba`` must be a 2-D matrix coercible to ``float64`` whose rows
-    sum to approximately one.
+    ``y_true`` may be 1-D class labels or a 2-D one-hot matrix; a
+    single-column ``y_true`` is raveled instead of argmaxed. ``y_proba``
+    must be a 2-D matrix coercible to ``float64`` whose rows sum to
+    approximately one.
 
     Parameters
     ----------
@@ -73,7 +83,11 @@ def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
     """
     y_true_arr = np.asarray(y_true)
     if y_true_arr.ndim > 1:
-        y_true_arr = y_true_arr.argmax(axis=-1)
+        y_true_arr = (
+            y_true_arr.argmax(axis=-1)
+            if y_true_arr.shape[1] > 1
+            else y_true_arr.ravel()
+        )
     y_proba_arr = check_array(
         y_proba, ensure_2d=True, dtype="float64", input_name="y_proba"
     )

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -70,6 +70,15 @@ def test_check_metric_inputs_one_hot_argmax():
     assert np.array_equal(out_p, np.array([1, 0, 2]))
 
 
+def test_check_metric_inputs_column_vector_ravel():
+    """(n, 1) column vectors are raveled, not argmaxed to all-zeros."""
+    y_t_col = np.array([[0], [1], [2]])
+    y_p_col = np.array([[0], [2], [2]])
+    out_t, out_p = _check_metric_inputs(y_t_col, y_p_col)
+    assert np.array_equal(out_t, np.array([0, 1, 2]))
+    assert np.array_equal(out_p, np.array([0, 2, 2]))
+
+
 def test_check_metric_inputs_length_mismatch_raises():
     """Mismatched lengths raise ValueError."""
     with pytest.raises(ValueError):
@@ -89,6 +98,15 @@ def test_check_proba_inputs_requires_2d_proba():
 
     out_t_oh, _ = _check_proba_inputs(np.eye(3), y_p)
     assert np.array_equal(out_t_oh, y_t)
+
+
+def test_check_proba_inputs_column_vector_ravel():
+    """(n, 1) column vector y_true is raveled, not argmaxed to all-zeros."""
+    y_t_col = np.array([[0], [1], [2]])
+    y_p = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
+    out_t, out_p = _check_proba_inputs(y_t_col, y_p)
+    assert np.array_equal(out_t, np.array([0, 1, 2]))
+    npt.assert_allclose(out_p, y_p)
 
 
 def test_check_proba_inputs_rejects_unnormalised_rows():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`_check_metric_inputs` and `_check_proba_inputs` argmaxed column vectors of shape `(n, 1)` to all-zeros instead of ravelling them, silently corrupting every metric that routes through them.