### PR TITLE
BUG: Zero the NNPOM gradient in the clamped probability region

### DIFF
--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -23,6 +23,9 @@ from skordinal.utils.extmath import (
 )
 from skordinal.utils.validation import check_ordinal_targets
 
+# Per-class probability floor used in the objective
+_PROBA_FLOOR = 1e-15
+
 
 class NNPOM(ClassifierMixin, BaseEstimator):
     """Neural Network based on Proportional Odd Model (NNPOM).
@@ -522,9 +525,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         z2 = np.matmul(a1, theta1.T)
         a2 = expit(z2)
 
-        z3 = np.tile(thresholds, (n_samples, 1)) - np.tile(
-            np.matmul(a2, theta2.T), (1, n_classes - 1)
-        )
+        z3 = thresholds - np.matmul(a2, theta2.T)
         a3T = expit(z3)
         a3 = np.append(a3T, np.ones((n_samples, 1)), axis=1)
         h = np.concatenate(
@@ -532,21 +533,19 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         )
 
         # Guard against zero probabilities: log(0) and -1/0 would produce NaN.
-        out = np.maximum(h, 1e-15)
+        out = np.maximum(h, _PROBA_FLOOR)
 
         # Calculate penalty (L2 regularization)
-        p = np.sum((theta1[:, 1:] ** 2).sum() + (theta2[:, 0:] ** 2).sum())
+        p = (theta1[:, 1:] ** 2).sum() + (theta2**2).sum()
 
         # Cross entropy
         J = np.sum(-np.log(out[np.where(Y == 1)]), axis=0) / n_samples + alpha * p / (
             2 * n_samples
         )
 
-        # Error derivative
-        error_der = np.zeros(Y.shape)
-        error_der[np.where(Y != 0)] = np.divide(
-            -Y[np.where(Y != 0)], out[np.where(Y != 0)]
-        )
+        # Error derivative, zeroed where the floor flattens the objective
+        error_der = -Y / out
+        error_der[h <= _PROBA_FLOOR] = 0.0
 
         # Calculate sigmas
         f_gradients = np.multiply(a3T, (1 - a3T))

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -266,6 +266,30 @@ def test_nnpom_cost_function_gradient_matches_finite_difference():
     assert err < 1e-4
 
 
+def test_nnpom_cost_function_gradient_is_zero_in_clamped_region():
+    """A fully clamped objective is flat, so its gradient must vanish."""
+    n_samples, n_features, n_hidden, n_classes = 30, 4, 3, 3
+    rng = np.random.default_rng(0)
+    X_data = rng.standard_normal((n_samples, n_features))
+    Y = np.zeros((n_samples, n_classes))
+    Y[:, 0] = 1.0
+
+    saturating_projection = 75.0
+    theta1 = rng.standard_normal((n_hidden, n_features + 1)) * 0.01
+    theta2 = np.full((1, n_hidden), saturating_projection / n_hidden)
+    x0 = np.concatenate(
+        [theta1.flatten(order="F"), theta2.flatten(order="F"), [0.0, 1.0]]
+    )
+
+    clf = NNPOM()
+    cost, grad = clf._nnpom_cost_function(
+        x0, n_features, n_hidden, n_classes, X_data, Y, 0.0
+    )
+
+    np.testing.assert_allclose(cost, -np.log(1e-15))
+    np.testing.assert_array_equal(grad, np.zeros_like(grad))
+
+
 def test_nnpom_proba_and_cumproba_well_formed(ordinal_data):
     """predict_proba/predict_cumproba are well-formed and match predict."""
     X, y = ordinal_data


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`_nnpom_cost_function` floors the predicted class probabilities before taking their log, but the gradient still divided by that floor where it was active. The floor makes the cross-entropy term locally constant there, so the error derivative is now zeroed wherever the floor applies. A new test pins the gradient to exactly zero where every true-class probability sits on the floor. The cost is unchanged, so the existing tests fit identical parameters.