### PR TITLE
FIX: Compute spearmans_rho with scipy.stats.spearmanr

### DIFF
--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -615,9 +615,10 @@ def weighted_kappa(y_true, y_pred, *, sample_weight=None):
 def spearmans_rho(y_true, y_pred):
     """Spearman's rank correlation coefficient between two ordinal vectors.
 
-    A non-parametric measure of monotonic association computed from
-    label values directly (treated as numerical scores). Returns ``0.0`` when one
-    of the inputs is constant.
+    A non-parametric measure of monotonic association between the ranks of
+    ``y_true`` and ``y_pred``, with average ranks assigned to ties. Computed
+    via :func:`scipy.stats.spearmanr`. Returns ``0.0`` when one of the inputs
+    is constant.
 
     Parameters
     ----------
@@ -645,18 +646,14 @@ def spearmans_rho(y_true, y_pred):
     >>> y_true = np.array([0, 0, 1, 2, 3, 0, 0])
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> spearmans_rho(y_true, y_pred)
-    0.9165444688834581
+    0.8464861424907173
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
-    y_true_centered = y_true - np.mean(y_true)
-    y_pred_centered = y_pred - np.mean(y_pred)
-    num = (y_true_centered * y_pred_centered).sum()
-    div = np.sqrt((y_true_centered**2).sum() * (y_pred_centered**2).sum())
-
-    if num == 0:
+    if np.unique(y_true).size < 2 or np.unique(y_pred).size < 2:
         return 0.0
-    return float(num / div)
+    corr, _ = scipy.stats.spearmanr(y_true, y_pred)
+    return float(corr)
 
 
 @validate_params(

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -286,15 +286,24 @@ def test_weighted_kappa():
     npt.assert_almost_equal(weighted_kappa(y_true, y_pred), 0.6703, decimal=4)
 
 
-def test_spearmans_rho():
-    """spearmans_rho returns the correct rank correlation for a known sequence."""
-    y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
-    y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    npt.assert_almost_equal(spearmans_rho(y_true, y_pred), 0.6429, decimal=4)
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        (
+            [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3],
+            [1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3],
+            0.6429,
+        ),
+        ([0, 0, 1, 2, 3, 0, 0], [0, 1, 1, 2, 3, 0, 1], 0.8465),
+    ],
+)
+def test_spearmans_rho(y_true, y_pred, expected):
+    """spearmans_rho returns the correct rank correlation for known sequences."""
+    npt.assert_almost_equal(spearmans_rho(y_true, y_pred), expected, decimal=4)
 
 
 def test_spearmans_rho_constant_input():
-    """spearmans_rho returns 0.0 when y_true is constant (zero numerator)."""
+    """spearmans_rho returns 0.0 when one of the inputs is constant."""
     npt.assert_equal(spearmans_rho(np.array([1, 1, 1, 1]), np.array([0, 1, 2, 3])), 0.0)
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

The `spearmans_rho` metric computed Pearson's correlation: no ranking, no tie handling, despite its name and docstring. It now calls `scipy.stats.spearmanr`.

Previously published rho values can change. The function's own doctest goes from `0.91654` to `0.84649`, so regenerate any result citing rho. The constant-input case still returns `0.0`, matching sklearn's convention for a degenerate correlation.