### PR TITLE
FIX: Guard kendalls_tau against constant input

### DIFF
--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -514,7 +514,8 @@ def kendalls_tau(y_true, y_pred):
 
     Measures the ordinal association between ``y_true`` and ``y_pred``
     using the number of concordant minus discordant pairs. Computed via
-    :func:`scipy.stats.kendalltau`.
+    :func:`scipy.stats.kendalltau`. Returns ``0.0`` when one of the
+    inputs is constant.
 
     Parameters
     ----------
@@ -545,6 +546,8 @@ def kendalls_tau(y_true, y_pred):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    if np.unique(y_true).size < 2 or np.unique(y_pred).size < 2:
+        return 0.0
     corr, _ = scipy.stats.kendalltau(y_true, y_pred)
     return float(corr)
 

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -272,11 +272,20 @@ def test_ranked_probability_score_out_of_range():
     )
 
 
-def test_kendalls_tau():
-    """kendalls_tau returns the correct rank correlation for a known sequence."""
-    y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
-    y_pred = np.array([1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3])
-    npt.assert_almost_equal(kendalls_tau(y_true, y_pred), 0.6240, decimal=4)
+@pytest.mark.parametrize(
+    "y_true, y_pred, expected",
+    [
+        (
+            [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3],
+            [1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3],
+            0.6240,
+        ),
+        ([1, 1, 1, 1], [0, 1, 2, 3], 0.0),
+    ],
+)
+def test_kendalls_tau(y_true, y_pred, expected):
+    """kendalls_tau returns the correct rank correlation for known sequences."""
+    npt.assert_almost_equal(kendalls_tau(y_true, y_pred), expected, decimal=4)
 
 
 def test_weighted_kappa():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`kendalls_tau` returns `nan` for constant input, since Kendall's tau is undefined when either vector has zero variance. This PR adds a guard that returns `0.0` instead, matching `spearmans_rho`'s existing convention and sklearn's own degenerate-correlation metrics (`matthews_corrcoef`, `r2_score`).