### PR TITLE
FIX: Reject a feature column named "target" under as_frame

### DIFF
--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -122,6 +122,12 @@ def _convert_data_dataframe(caller_name, data, target, feature_names, target_col
         ImportError
     ) as exc:  # pragma: no cover - exercised in environments without pandas
         raise ImportError(f"{caller_name} with as_frame=True requires pandas.") from exc
+    collision = set(feature_names) & set(target_columns)
+    if collision:
+        raise ValueError(
+            f"{caller_name}: feature column {collision.pop()!r} collides with the "
+            "target column name."
+        )
     data_df = pd.DataFrame(data, columns=feature_names, copy=False)
     target_df = pd.DataFrame(target, columns=target_columns)
     combined_df = pd.concat([data_df, target_df], axis=1)

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -227,6 +227,15 @@ def test_load_dataset_as_frame(named_csv):
     assert bunch.frame is not None
 
 
+def test_load_dataset_as_frame_feature_named_target_raises(tmp_path):
+    """A feature column literally named ``target`` collides and raises."""
+    pytest.importorskip("pandas")
+    path = tmp_path / "collide.csv"
+    path.write_text("x_0,target,y\n1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="target"):
+        load_dataset(path, as_frame=True)
+
+
 @pytest.mark.parametrize("name", ["ds_home", "ds_home.csv"], ids=["stem", "filename"])
 def test_load_dataset_data_home(tmp_path, name):
     """Stem or filename resolves against an explicit ``data_home`` directory."""


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`load_dataset(..., as_frame=True)` silently corrupted its output when a CSV feature column was literally named `target`: `X` gained a spurious duplicated column and `y` stayed a 2-column `DataFrame` instead of a `Series`. `_convert_data_dataframe` now raises a `ValueError` naming the colliding column instead of building the frame.