### PR TITLE
REF: Extract experiments persistence helpers into _io

### DIFF
--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from ._results import _atomic_write
+from ._io import _atomic_write
 
 
 def _check_split(split, *, allow_both):

--- a/skordinal/experiments/_io.py
+++ b/skordinal/experiments/_io.py
@@ -1,0 +1,76 @@
+"""File-persistence primitives for the experiments results tree."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import joblib
+import numpy as np
+
+_TEMP_PREFIX = ".skordinal-tmp-"
+
+
+def _check_path_component(name: Any, what: str) -> None:
+    """Reject a path component that is empty, dotted or holds a separator."""
+    if not isinstance(name, str):
+        raise TypeError(f"{what} must be a str; got {type(name).__name__}.")
+    if name in ("", ".", ".."):
+        raise ValueError(f"{what} must not be empty or a dot segment; got {name!r}.")
+    if any(sep in name for sep in (os.sep, "/", os.altsep) if sep):
+        raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write text to path atomically via a temp file, fsync and replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def _atomic_dump(path: Path, obj: Any) -> None:
+    """Serialise obj to path atomically via a temp file, fsync and replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
+    try:
+        # Close the mkstemp descriptor; joblib opens its own handle by path
+        os.close(fd)
+        joblib.dump(obj, tmp)
+        with open(tmp, "rb") as fh:
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def _sweep_orphaned_temp_files(base_dir: Path) -> None:
+    """Unlink stray temp files a prior crash left under base_dir."""
+    if not base_dir.is_dir():
+        return
+    for path in base_dir.rglob(f"{_TEMP_PREFIX}*"):
+        if path.is_file():
+            path.unlink(missing_ok=True)
+
+
+def _format_proba_column(proba: np.ndarray) -> list[str]:
+    """Render probability rows as single-line ``"[p0, p1, ...]"`` cells."""
+    return [
+        "[" + ", ".join(repr(float(p)) for p in row) + "]" for row in np.asarray(proba)
+    ]
+
+
+def _parse_proba_column(series: Iterable[str]) -> np.ndarray:
+    """Expand stringified ``"[p0, p1, ...]"`` cells into an (n, q) array."""
+    return np.vstack([np.fromstring(x.strip("[]"), sep=",") for x in series])

--- a/skordinal/experiments/_io.py
+++ b/skordinal/experiments/_io.py
@@ -24,9 +24,19 @@ def _check_path_component(name: Any, what: str) -> None:
         raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
 
 
+def _ensure_parent(path: Path) -> None:
+    """Create path's parent directory, wrapping OSError with the failing path."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise OSError(
+            f"Could not create folder {path.parent} to store results."
+        ) from exc
+
+
 def _atomic_write(path: Path, content: str) -> None:
     """Write text to path atomically via a temp file, fsync and replace."""
-    path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_parent(path)
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
@@ -41,7 +51,7 @@ def _atomic_write(path: Path, content: str) -> None:
 
 def _atomic_dump(path: Path, obj: Any) -> None:
     """Serialise obj to path atomically via a temp file, fsync and replace."""
-    path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_parent(path)
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
     try:
         # Close the mkstemp descriptor; joblib opens its own handle by path

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -2,59 +2,23 @@
 
 from __future__ import annotations
 
-import os
 import sys
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import joblib
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.metrics import confusion_matrix
 
-_TEMP_PREFIX = ".skordinal-tmp-"
-
-
-def _atomic_write(path: Path, content: str) -> None:
-    """Write text to path atomically via a temp file, fsync and replace."""
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
-            fh.write(content)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.replace(tmp, path)
-    except BaseException:
-        Path(tmp).unlink(missing_ok=True)
-        raise
-
-
-def _atomic_dump(path: Path, obj: Any) -> None:
-    """Serialise obj to path atomically via a temp file, fsync and replace."""
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=_TEMP_PREFIX, suffix=".tmp")
-    try:
-        # Close the mkstemp descriptor; joblib opens its own handle by path
-        os.close(fd)
-        joblib.dump(obj, tmp)
-        with open(tmp, "rb") as fh:
-            os.fsync(fh.fileno())
-        os.replace(tmp, path)
-    except BaseException:
-        Path(tmp).unlink(missing_ok=True)
-        raise
-
-
-def _check_path_component(name: Any, what: str) -> None:
-    """Reject a path component that is empty, dotted or holds a separator."""
-    if not isinstance(name, str):
-        raise TypeError(f"{what} must be a str; got {type(name).__name__}.")
-    if name in ("", ".", ".."):
-        raise ValueError(f"{what} must not be empty or a dot segment; got {name!r}.")
-    if any(sep in name for sep in (os.sep, "/", os.altsep) if sep):
-        raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
+from ._io import (
+    _atomic_dump,
+    _atomic_write,
+    _check_path_component,
+    _format_proba_column,
+    _sweep_orphaned_temp_files,
+)
 
 
 @dataclass(frozen=True)
@@ -139,13 +103,6 @@ class ExperimentResult:
     train_index: np.ndarray | None = None
     test_index: np.ndarray | None = None
     train_y_proba: np.ndarray | None = None
-
-
-def _format_proba_column(proba: np.ndarray) -> list[str]:
-    """Render probability rows as single-line ``"[p0, p1, ...]"`` cells."""
-    return [
-        "[" + ", ".join(repr(float(p)) for p in row) + "]" for row in np.asarray(proba)
-    ]
 
 
 def _write_split_files(
@@ -320,9 +277,7 @@ class Results:
             save_model=save_model,
         )
         # Clear any temp file left by a prior crash before writing new ones
-        for stray in base_dir.rglob(f"{_TEMP_PREFIX}*"):
-            if stray.is_file():
-                stray.unlink(missing_ok=True)
+        _sweep_orphaned_temp_files(base_dir)
         # Drop this resample's committed row so a crash mid-write cannot
         # leave a report row describing predictions no longer on disk
         self._uncommit_report_row(base_dir, result.resample_id)

--- a/skordinal/experiments/tests/test_io.py
+++ b/skordinal/experiments/tests/test_io.py
@@ -13,6 +13,7 @@ from skordinal.experiments._io import (
     _atomic_dump,
     _atomic_write,
     _check_path_component,
+    _ensure_parent,
     _format_proba_column,
     _parse_proba_column,
     _sweep_orphaned_temp_files,
@@ -52,6 +53,16 @@ def test_atomic_write_creates_missing_parent(tmp_path):
     target = tmp_path / "nested" / "f.csv"
     _atomic_write(target, "a,b\n1,2\n")
     assert target.read_text() == "a,b\n1,2\n"
+
+
+def test_ensure_parent_wraps_mkdir_failure(tmp_path, monkeypatch):
+    """A failing parent mkdir raises a clear, wrapped OSError."""
+    monkeypatch.setattr(
+        "skordinal.experiments._io.Path.mkdir",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("denied")),
+    )
+    with pytest.raises(OSError, match="Could not create folder"):
+        _ensure_parent(tmp_path / "nested" / "f.csv")
 
 
 def test_atomic_write_cleans_up_on_failure(tmp_path, monkeypatch):

--- a/skordinal/experiments/tests/test_io.py
+++ b/skordinal/experiments/tests/test_io.py
@@ -1,0 +1,117 @@
+"""Tests for the experiments file-persistence primitives."""
+
+import os
+
+import joblib
+import numpy as np
+import numpy.testing as npt
+import pandas as pd
+import pytest
+
+from skordinal.experiments._io import (
+    _TEMP_PREFIX,
+    _atomic_dump,
+    _atomic_write,
+    _check_path_component,
+    _format_proba_column,
+    _parse_proba_column,
+    _sweep_orphaned_temp_files,
+)
+
+
+def test_format_proba_column_cells_round_trip():
+    """Wide probability cells stay single-line and parse back exactly."""
+    rng = np.random.default_rng(0)
+    raw = rng.random((3, 20))
+    proba = raw / raw.sum(axis=1, keepdims=True)
+
+    for cell, row in zip(_format_proba_column(proba), proba):
+        assert "\n" not in cell
+        npt.assert_array_equal(np.fromstring(cell.strip("[]"), sep=","), row)
+
+
+def test_parse_proba_column_round_trips_formatted_cells():
+    """_parse_proba_column reconstructs the matrix _format_proba_column wrote."""
+    rng = np.random.default_rng(0)
+    raw = rng.random((3, 5))
+    proba = raw / raw.sum(axis=1, keepdims=True)
+    parsed = _parse_proba_column(pd.Series(_format_proba_column(proba)))
+    npt.assert_array_equal(parsed, proba)
+
+
+def test_atomic_write_success_leaves_no_temp(tmp_path):
+    """_atomic_write writes full content and leaves no temp file."""
+    target = tmp_path / "f.csv"
+    _atomic_write(target, "a,b\n1,2\n")
+    assert target.read_text() == "a,b\n1,2\n"
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+def test_atomic_write_creates_missing_parent(tmp_path):
+    """_atomic_write creates the target's parent directory if absent."""
+    target = tmp_path / "nested" / "f.csv"
+    _atomic_write(target, "a,b\n1,2\n")
+    assert target.read_text() == "a,b\n1,2\n"
+
+
+def test_atomic_write_cleans_up_on_failure(tmp_path, monkeypatch):
+    """A failing os.replace unlinks the temp file and re-raises."""
+    monkeypatch.setattr(
+        "skordinal.experiments._io.os.replace",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
+    )
+    with pytest.raises(OSError, match="boom"):
+        _atomic_write(tmp_path / "f.csv", "data")
+    assert not (tmp_path / "f.csv").exists()
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+def test_atomic_write_fsyncs(tmp_path, monkeypatch):
+    """_atomic_write calls os.fsync on the temp file descriptor."""
+    calls = []
+    real_fsync = os.fsync
+    monkeypatch.setattr(
+        "skordinal.experiments._io.os.fsync",
+        lambda fd: calls.append(fd) or real_fsync(fd),
+    )
+    _atomic_write(tmp_path / "f.txt", "x")
+    assert len(calls) == 1
+
+
+def test_atomic_dump_cleans_up_on_failure(tmp_path, monkeypatch):
+    """A failing os.replace unlinks the dump's temp file and re-raises."""
+    monkeypatch.setattr(
+        "skordinal.experiments._io.os.replace",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
+    )
+    with pytest.raises(OSError, match="boom"):
+        _atomic_dump(tmp_path / "m.joblib", {"k": 1})
+    assert not (tmp_path / "m.joblib").exists()
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+def test_atomic_dump_round_trips_no_temp(tmp_path):
+    """_atomic_dump serialises an object recoverable by joblib.load."""
+    target = tmp_path / "m.joblib"
+    _atomic_dump(target, {"k": [1, 2, 3]})
+    assert joblib.load(target) == {"k": [1, 2, 3]}
+    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
+
+
+@pytest.mark.parametrize("bad", ["", ".", "..", "a/b", f"a{os.sep}b"])
+def test_check_path_component_rejects_bad_strings(bad):
+    """_check_path_component rejects empty, dotted or separator names."""
+    with pytest.raises(ValueError):
+        _check_path_component(bad, "classifier_name")
+
+
+@pytest.mark.parametrize("bad", [3, None, ("x",)])
+def test_check_path_component_rejects_non_str(bad):
+    """_check_path_component rejects a non-string component."""
+    with pytest.raises(TypeError):
+        _check_path_component(bad, "classifier_name")
+
+
+def test_sweep_orphaned_temp_files_ignores_missing_dir(tmp_path):
+    """The sweep is a no-op when the base directory does not exist."""
+    _sweep_orphaned_temp_files(tmp_path / "absent")

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -1,7 +1,5 @@
 """Tests for the Results class."""
 
-import os
-
 import joblib
 import numpy as np
 import numpy.testing as npt
@@ -11,14 +9,8 @@ from sklearn.metrics import confusion_matrix
 from sklearn.svm import SVC
 
 from skordinal.experiments import ExperimentResult, Results
-from skordinal.experiments._results import (
-    _TEMP_PREFIX,
-    _atomic_dump,
-    _atomic_write,
-    _check_path_component,
-    _format_proba_column,
-    _write_split_files,
-)
+from skordinal.experiments._io import _TEMP_PREFIX
+from skordinal.experiments._results import _write_split_files
 
 
 def _fitted_svc(classes=(1, 2, 3), probability=False):
@@ -310,17 +302,6 @@ def test_save_rejects_misshaped_proba(tmp_path):
         Results(tmp_path).save(result, save_model=False)
 
 
-def test_format_proba_column_cells_round_trip():
-    """Wide probability cells stay single-line and parse back exactly."""
-    rng = np.random.default_rng(0)
-    raw = rng.random((3, 20))
-    proba = raw / raw.sum(axis=1, keepdims=True)
-
-    for cell, row in zip(_format_proba_column(proba), proba):
-        assert "\n" not in cell
-        npt.assert_array_equal(np.fromstring(cell.strip("[]"), sep=","), row)
-
-
 def test_save_no_test_partition(tmp_path):
     """When test_predicted_y is None, no test files are written."""
     result = _make_result(
@@ -595,72 +576,6 @@ def test_exists(tmp_path):
     )
     assert r.exists("SVC", "toy", "0") is True
     assert r.exists("SVC", "toy", "1") is False
-
-
-def test_atomic_write_success_leaves_no_temp(tmp_path):
-    """_atomic_write writes full content and leaves no temp file."""
-    target = tmp_path / "f.csv"
-    _atomic_write(target, "a,b\n1,2\n")
-    assert target.read_text() == "a,b\n1,2\n"
-    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
-
-
-def test_atomic_write_cleans_up_on_failure(tmp_path, monkeypatch):
-    """A failing os.replace unlinks the temp file and re-raises."""
-    monkeypatch.setattr(
-        "skordinal.experiments._results.os.replace",
-        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
-    )
-    with pytest.raises(OSError, match="boom"):
-        _atomic_write(tmp_path / "f.csv", "data")
-    assert not (tmp_path / "f.csv").exists()
-    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
-
-
-def test_atomic_write_fsyncs(tmp_path, monkeypatch):
-    """_atomic_write calls os.fsync on the temp file descriptor."""
-    calls = []
-    real_fsync = os.fsync
-    monkeypatch.setattr(
-        "skordinal.experiments._results.os.fsync",
-        lambda fd: calls.append(fd) or real_fsync(fd),
-    )
-    _atomic_write(tmp_path / "f.txt", "x")
-    assert len(calls) == 1
-
-
-def test_atomic_dump_cleans_up_on_failure(tmp_path, monkeypatch):
-    """A failing os.replace unlinks the dump's temp file and re-raises."""
-    monkeypatch.setattr(
-        "skordinal.experiments._results.os.replace",
-        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
-    )
-    with pytest.raises(OSError, match="boom"):
-        _atomic_dump(tmp_path / "m.joblib", {"k": 1})
-    assert not (tmp_path / "m.joblib").exists()
-    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
-
-
-def test_atomic_dump_round_trips_no_temp(tmp_path):
-    """_atomic_dump serialises an object recoverable by joblib.load."""
-    target = tmp_path / "m.joblib"
-    _atomic_dump(target, {"k": [1, 2, 3]})
-    assert joblib.load(target) == {"k": [1, 2, 3]}
-    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
-
-
-@pytest.mark.parametrize("bad", ["", ".", "..", "a/b", f"a{os.sep}b"])
-def test_check_path_component_rejects_bad_strings(bad):
-    """_check_path_component rejects empty, dotted or separator names."""
-    with pytest.raises(ValueError):
-        _check_path_component(bad, "classifier_name")
-
-
-@pytest.mark.parametrize("bad", [3, None, ("x",)])
-def test_check_path_component_rejects_non_str(bad):
-    """_check_path_component rejects a non-string component."""
-    with pytest.raises(TypeError):
-        _check_path_component(bad, "classifier_name")
 
 
 def test_save_rejects_traversal_before_writing(tmp_path):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Extracts the experiments module's file-persistence helpers from `_results.py` into a new `_io.py`. `_atomic_write` and `_atomic_dump` now create the target's parent directory if missing, wrapping any resulting `OSError` in a clear error message, and a new `_parse_proba_column` inverts `_format_proba_column` with no caller yet.