### PR TITLE
FIX: Freeze OrdinalDecomposition decision_method at fit time

### DIFF
--- a/skordinal/classifiers/_ordinal_decomposition.py
+++ b/skordinal/classifiers/_ordinal_decomposition.py
@@ -161,6 +161,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
                 "When using Frank and Hall decision method, "
                 "ordered_partitions must be used"
             )
+        self._decision_method_ = decision
 
         # Give each train input its corresponding output label
         # for each binary classifier
@@ -206,9 +207,6 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         ValueError
             If input is invalid.
 
-        AttributeError
-            If the specified loss method is not implemented.
-
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
@@ -216,7 +214,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         # Getting predicted labels for dataset from each classifier
         predictions = self._get_predictions(X)
 
-        decision_method = self.decision_method.lower()
+        decision_method = self._decision_method_
         if decision_method == "exponential_loss":
             # Scaling predictions from [0,1] range to [-1,1]
             predictions = predictions * 2 - 1
@@ -241,15 +239,10 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
             losses = self._logarithmic_loss(predictions)
             y_pred = self.classes_[np.argmin(losses, axis=1)]
 
-        elif decision_method == "frank_hall":
+        else:  # frank_hall
             # Transforming from binary problems to the original problem
             y_proba = self._frank_hall_method(predictions)
             y_pred = self.classes_[np.argmax(y_proba, axis=1)]
-
-        else:
-            raise AttributeError(
-                'The specified loss method "%s" is not implemented' % decision_method
-            )
 
         return y_pred
 
@@ -277,9 +270,6 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         ValueError
             If input is invalid.
 
-        AttributeError
-            If the specified loss method is not implemented.
-
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
@@ -287,7 +277,7 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
         # Getting predicted labels for dataset from each classifier
         predictions = self._get_predictions(X)
 
-        decision_method = self.decision_method.lower()
+        decision_method = self._decision_method_
         if decision_method == "exponential_loss":
             # Scaling predictions from [0,1] range to [-1,1]
             predictions = predictions * 2 - 1
@@ -312,14 +302,9 @@ class OrdinalDecomposition(ClassifierMixin, BaseEstimator):
             losses = self._logarithmic_loss(predictions).astype(float)
             y_proba = losses_to_proba(losses)
 
-        elif decision_method == "frank_hall":
+        else:  # frank_hall
             # Transforming from binary problems to the original problem
             y_proba = self._frank_hall_method(predictions)
-
-        else:
-            raise AttributeError(
-                'The specified loss method "%s" is not implemented' % decision_method
-            )
 
         return y_proba
 

--- a/skordinal/classifiers/tests/test_ordinal_decomposition.py
+++ b/skordinal/classifiers/tests/test_ordinal_decomposition.py
@@ -431,3 +431,31 @@ def test_ordinal_decomposition_label_roundtrip(labels):
 
     np.testing.assert_array_equal(classifier.classes_, np.unique(labels_array))
     assert set(classifier.predict(X)).issubset(set(np.unique(labels_array)))
+
+
+def test_ordinal_decomposition_decision_method_frozen_after_fit(X, y):
+    """Test that decision_method is frozen at fit time, not read live by predict."""
+    classifier = OrdinalDecomposition(decision_method="frank_hall").fit(X, y)
+    y_proba_before = classifier.predict_proba(X)
+
+    classifier.set_params(decision_method="hinge_loss")
+    npt.assert_allclose(classifier.predict_proba(X), y_proba_before)
+
+    # Refitting picks up the new decision_method
+    classifier.fit(X, y)
+    reference = OrdinalDecomposition(decision_method="hinge_loss").fit(X, y)
+    npt.assert_allclose(classifier.predict_proba(X), reference.predict_proba(X))
+
+
+def test_ordinal_decomposition_frank_hall_unreachable_by_set_params(X, y):
+    """Test that set_params cannot reach frank_hall over a one_vs_next coding matrix."""
+    classifier = OrdinalDecomposition(
+        dtype="one_vs_next", decision_method="hinge_loss"
+    ).fit(X, y)
+    y_proba_before = classifier.predict_proba(X)
+
+    classifier.set_params(decision_method="frank_hall")
+    npt.assert_allclose(classifier.predict_proba(X), y_proba_before)
+
+    with pytest.raises(ValueError, match="ordered_partitions must be used"):
+        classifier.fit(X, y)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

OrdinalDecomposition now captures decision_method at fit time instead of re-reading it live in predict and predict_proba, so set_params(decision_method=...) on a fitted estimator has no effect until fit is called again. Previously this let predictions change silently after fit, and even let frank_hall decoding run on a coding matrix built for another decomposition type, a combination fit otherwise rejects at construction.