### PR TITLE
FIX: Correct the scorer registry contract

### DIFF
--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -43,8 +43,9 @@ class Benchmark:
 
     eval_metrics : list of str
         Metric names to compute for every resample (e.g.
-        ``["mean_absolute_error", "average_mean_absolute_error"]``).
-        Names must be recognised by ``skordinal.metrics.get_ordinal_scorer``.
+        ``["mean_absolute_error", "average_mean_absolute_error"]``). Names
+        must match a ``skordinal.metrics`` metric that scores predicted
+        labels, which excludes ``ranked_probability_score``.
 
     results_path : str or Path
         Directory where result files are written. Expanded and resolved to

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -229,11 +229,7 @@ class Experiment:
         # locals so nothing is ever injected onto the estimator itself
         base = self.model.build(self.random_state)
         if self.model.needs_search:
-            scorer = (
-                get_ordinal_scorer(self.tuning_metric)
-                if isinstance(self.tuning_metric, str)
-                else self.tuning_metric
-            )
+            scorer = get_ordinal_scorer(self.tuning_metric)
             splitter = StratifiedKFold(
                 n_splits=self.cv, shuffle=True, random_state=self.random_state
             )

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import warnings
 from collections import OrderedDict
 from time import perf_counter
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 from sklearn import preprocessing
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import get_ordinal_scorer
+from skordinal.metrics._metrics import _LABEL_METRICS
 
 from ._model_config import ModelConfig
 from ._results import ExperimentResult
@@ -19,8 +20,12 @@ from ._results import ExperimentResult
 
 def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
     """Compute a single ordinal metric by name."""
-    scorer = cast(Any, get_ordinal_scorer(metric_name.strip()))
-    return scorer._score_func(y_true, y_pred, **scorer._kwargs)
+    key = metric_name.strip()
+    if key not in _LABEL_METRICS:
+        raise ValueError(
+            f"Unknown metric name: {metric_name!r}. Available: {sorted(_LABEL_METRICS)}."
+        )
+    return _LABEL_METRICS[key](y_true, y_pred)
 
 
 def _predict_proba_or_none(estimator: Any, inputs: np.ndarray) -> np.ndarray | None:
@@ -59,7 +64,8 @@ class Experiment:
     eval_metrics : list of str
         Metric names to compute for every partition (e.g.
         ``["mean_absolute_error", "average_mean_absolute_error"]``). Names
-        must be recognised by ``skordinal.metrics.get_ordinal_scorer``.
+        must match a ``skordinal.metrics`` metric that scores predicted
+        labels, which excludes ``ranked_probability_score``.
 
     tuning_metric : str, default="neg_mean_absolute_error"
         Metric used as the cross-validation scoring criterion when selecting

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -12,7 +12,7 @@ from sklearn import preprocessing
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import get_ordinal_scorer
-from skordinal.metrics._metrics import _LABEL_METRICS
+from skordinal.metrics._metrics import _resolve_label_metric
 
 from ._model_config import ModelConfig
 from ._results import ExperimentResult
@@ -20,12 +20,7 @@ from ._results import ExperimentResult
 
 def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
     """Compute a single ordinal metric by name."""
-    key = metric_name.strip()
-    if key not in _LABEL_METRICS:
-        raise ValueError(
-            f"Unknown metric name: {metric_name!r}. Available: {sorted(_LABEL_METRICS)}."
-        )
-    return _LABEL_METRICS[key](y_true, y_pred)
+    return _resolve_label_metric(metric_name.strip())(y_true, y_pred)
 
 
 def _predict_proba_or_none(estimator: Any, inputs: np.ndarray) -> np.ndarray | None:

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -228,14 +228,23 @@ def test_run_preprocessing_does_not_mutate_inputs(split_with_test):
 
 
 def test_run_metric_keys_for_each_eval_metric(split_with_test):
-    """Each eval metric yields a _train and a _test key in the result."""
+    """Each eval metric yields a _train and a _test key, reported unnegated."""
     X_train, y_train, X_test, y_test = split_with_test
     exp = _make_experiment(eval_metrics=["mean_absolute_error", "accuracy_score"])
     result = _call_run(exp, X_train, y_train, X_test, y_test)
 
     for name in ("mean_absolute_error", "accuracy_score"):
-        assert name + "_train" in result.train_metrics
-        assert name + "_test" in result.test_metrics
+        # mean_absolute_error is a loss, but reporting must not negate it
+        assert result.train_metrics[name + "_train"] >= 0
+        assert result.test_metrics[name + "_test"] >= 0
+
+
+def test_run_rejects_unknown_eval_metric(split_with_test):
+    """An unknown eval_metric name raises ValueError naming the metric."""
+    X_train, y_train, X_test, y_test = split_with_test
+    exp = _make_experiment(eval_metrics=["ranked_probability_score"])
+    with pytest.raises(ValueError, match="ranked_probability_score"):
+        _call_run(exp, X_train, y_train, X_test, y_test)
 
 
 def test_run_proba_absent_without_predict_proba(split_with_test):

--- a/skordinal/metrics/__init__.py
+++ b/skordinal/metrics/__init__.py
@@ -16,7 +16,7 @@ from ._metrics import (
     spearmans_rho,
     weighted_kappa,
 )
-from ._scorers import get_ordinal_scorer, list_ordinal_scorers
+from ._scorers import get_ordinal_scorer, get_ordinal_scorer_names
 
 __all__ = [
     "accuracy_off1_score",
@@ -24,9 +24,9 @@ __all__ = [
     "average_mean_absolute_error",
     "geometric_mean",
     "get_ordinal_scorer",
+    "get_ordinal_scorer_names",
     "gmsec",
     "kendalls_tau",
-    "list_ordinal_scorers",
     "maximum_mean_absolute_error",
     "mean_absolute_error",
     "mean_extreme_sensitivity",

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -2,7 +2,12 @@
 
 import numpy as np
 import scipy.stats
-from sklearn.metrics import confusion_matrix, recall_score
+from sklearn.metrics import (
+    accuracy_score,
+    confusion_matrix,
+    mean_absolute_error,
+    recall_score,
+)
 from sklearn.utils import check_array, check_consistent_length
 from sklearn.utils._param_validation import validate_params
 
@@ -811,3 +816,20 @@ def accuracy_off1_score(y_true, y_pred, *, labels=None, sample_weight=None):
     correct = mask * conf_mat
 
     return float(np.sum(correct) / np.sum(conf_mat))
+
+
+_LABEL_METRICS = {
+    "accuracy_off1_score": accuracy_off1_score,
+    "accuracy_score": accuracy_score,
+    "average_mean_absolute_error": average_mean_absolute_error,
+    "geometric_mean": geometric_mean,
+    "gmsec": gmsec,
+    "kendalls_tau": kendalls_tau,
+    "maximum_mean_absolute_error": maximum_mean_absolute_error,
+    "mean_absolute_error": mean_absolute_error,
+    "mean_extreme_sensitivity": mean_extreme_sensitivity,
+    "mean_zero_one_error": mean_zero_one_error,
+    "minimum_sensitivity": minimum_sensitivity,
+    "spearmans_rho": spearmans_rho,
+    "weighted_kappa": weighted_kappa,
+}

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -833,3 +833,12 @@ _LABEL_METRICS = {
     "spearmans_rho": spearmans_rho,
     "weighted_kappa": weighted_kappa,
 }
+
+
+def _resolve_label_metric(name):
+    """Return the label metric registered under name, or raise ValueError."""
+    if name not in _LABEL_METRICS:
+        raise ValueError(
+            f"Unknown metric name: {name!r}. Available: {sorted(_LABEL_METRICS)}."
+        )
+    return _LABEL_METRICS[name]

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -13,7 +13,6 @@ from ._metrics import (
     mean_extreme_sensitivity,
     mean_zero_one_error,
     minimum_sensitivity,
-    ranked_probability_score,
     spearmans_rho,
     weighted_kappa,
 )
@@ -31,17 +30,6 @@ _SCORERS = {
     "neg_mean_zero_one_error": make_scorer(
         mean_zero_one_error, greater_is_better=False
     ),
-    "neg_ranked_probability_score": make_scorer(
-        ranked_probability_score, greater_is_better=False
-    ),
-    "average_mean_absolute_error": make_scorer(
-        average_mean_absolute_error, greater_is_better=False
-    ),
-    "mean_absolute_error": make_scorer(mean_absolute_error, greater_is_better=False),
-    "maximum_mean_absolute_error": make_scorer(
-        maximum_mean_absolute_error, greater_is_better=False
-    ),
-    "mean_zero_one_error": make_scorer(mean_zero_one_error, greater_is_better=False),
     "accuracy_score": make_scorer(accuracy_score),
     "accuracy_off1_score": make_scorer(accuracy_off1_score),
     "geometric_mean": make_scorer(geometric_mean),
@@ -88,6 +76,11 @@ def get_ordinal_scorer(name):
     key = name.strip()
     if key in _SCORERS:
         return _SCORERS[key]
+    if f"neg_{key}" in _SCORERS:
+        raise ValueError(
+            f"Unknown scorer name: {name!r}. A scorer must be "
+            f"greater-is-better, so a loss is only registered as 'neg_{key}'."
+        )
     raise ValueError(
         f"Unknown scorer name: {name!r}. Available: {list_ordinal_scorers()}."
     )

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -44,26 +44,32 @@ _SCORERS = {
 }
 
 
-@validate_params({"name": [str]}, prefer_skip_nested_validation=True)
-def get_ordinal_scorer(name):
-    """Return a scikit-learn-compatible scorer by name.
+@validate_params({"scoring": [str, callable, None]}, prefer_skip_nested_validation=True)
+def get_ordinal_scorer(scoring):
+    """Return a scikit-learn-compatible scorer.
+
+    Every registered scorer is greater-is-better, matching the
+    scikit-learn convention: a metric where a lower value is better is
+    registered only under its ``neg_``-prefixed name.
 
     Parameters
     ----------
-    name : str
-        Scorer name. Use :func:`get_ordinal_scorer_names` for the full list.
-        Leading and trailing whitespace is stripped before lookup.
+    scoring : str, callable or None
+        Scorer name. Use :func:`get_ordinal_scorer_names` for the full
+        list. Leading and trailing whitespace is stripped before lookup.
+        A callable is returned as is, and ``None`` returns ``None``,
+        matching :func:`sklearn.metrics.get_scorer`.
 
     Returns
     -------
-    scorer : callable
+    scorer : callable or None
         A scorer compatible with :class:`~sklearn.model_selection.GridSearchCV`
         and :func:`~sklearn.model_selection.cross_val_score`.
 
     Raises
     ------
     ValueError
-        If ``name`` is not a registered scorer name.
+        If ``scoring`` is a string that is not a registered scorer name.
 
     Notes
     -----
@@ -78,16 +84,18 @@ def get_ordinal_scorer(name):
     True
 
     """
-    key = name.strip()
+    if not isinstance(scoring, str):
+        return scoring
+    key = scoring.strip()
     if key in _SCORERS:
         return copy.deepcopy(_SCORERS[key])
     if f"neg_{key}" in _SCORERS:
         raise ValueError(
-            f"Unknown scorer name: {name!r}. A scorer must be "
+            f"Unknown scorer name: {scoring!r}. A scorer must be "
             f"greater-is-better, so a loss is only registered as 'neg_{key}'."
         )
     raise ValueError(
-        f"Unknown scorer name: {name!r}. Available: {get_ordinal_scorer_names()}."
+        f"Unknown scorer name: {scoring!r}. Available: {get_ordinal_scorer_names()}."
     )
 
 

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -1,5 +1,7 @@
 """Scorer registry for ordinal classification metrics."""
 
+import copy
+
 from sklearn.metrics import accuracy_score, make_scorer, mean_absolute_error
 from sklearn.utils._param_validation import validate_params
 
@@ -65,6 +67,11 @@ def get_ordinal_scorer(name):
     ValueError
         If ``name`` is not a registered scorer name.
 
+    Notes
+    -----
+    Returns a fresh copy of the registered scorer on every call, so
+    mutating the result does not affect subsequent lookups.
+
     Examples
     --------
     >>> from skordinal.metrics import get_ordinal_scorer
@@ -75,7 +82,7 @@ def get_ordinal_scorer(name):
     """
     key = name.strip()
     if key in _SCORERS:
-        return _SCORERS[key]
+        return copy.deepcopy(_SCORERS[key])
     if f"neg_{key}" in _SCORERS:
         raise ValueError(
             f"Unknown scorer name: {name!r}. A scorer must be "

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -51,7 +51,7 @@ def get_ordinal_scorer(name):
     Parameters
     ----------
     name : str
-        Scorer name. Use :func:`list_ordinal_scorers` for the full list.
+        Scorer name. Use :func:`get_ordinal_scorer_names` for the full list.
         Leading and trailing whitespace is stripped before lookup.
 
     Returns
@@ -87,11 +87,11 @@ def get_ordinal_scorer(name):
             f"greater-is-better, so a loss is only registered as 'neg_{key}'."
         )
     raise ValueError(
-        f"Unknown scorer name: {name!r}. Available: {list_ordinal_scorers()}."
+        f"Unknown scorer name: {name!r}. Available: {get_ordinal_scorer_names()}."
     )
 
 
-def list_ordinal_scorers():
+def get_ordinal_scorer_names():
     """Return the sorted list of registered ordinal scorer names.
 
     Returns
@@ -101,8 +101,8 @@ def list_ordinal_scorers():
 
     Examples
     --------
-    >>> from skordinal.metrics import list_ordinal_scorers
-    >>> all_scorers = list_ordinal_scorers()
+    >>> from skordinal.metrics import get_ordinal_scorer_names
+    >>> all_scorers = get_ordinal_scorer_names()
     >>> type(all_scorers)
     <class 'list'>
     >>> "neg_mean_absolute_error" in all_scorers

--- a/skordinal/metrics/_scorers.py
+++ b/skordinal/metrics/_scorers.py
@@ -43,8 +43,6 @@ _SCORERS = {
     "weighted_kappa": make_scorer(weighted_kappa),
 }
 
-__all__ = ["get_ordinal_scorer", "list_ordinal_scorers"]
-
 
 @validate_params({"name": [str]}, prefer_skip_nested_validation=True)
 def get_ordinal_scorer(name):

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -1,5 +1,6 @@
 """Tests for the public scorer API."""
 
+import numpy as np
 import pytest
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
@@ -19,22 +20,52 @@ from skordinal.metrics import (
     mean_extreme_sensitivity,
     mean_zero_one_error,
     minimum_sensitivity,
-    ranked_probability_score,
     spearmans_rho,
     weighted_kappa,
 )
 
+_EXPECTED_SCORERS = [
+    ("neg_average_mean_absolute_error", average_mean_absolute_error, -1),
+    ("neg_maximum_mean_absolute_error", maximum_mean_absolute_error, -1),
+    ("neg_mean_absolute_error", mean_absolute_error, -1),
+    ("neg_mean_zero_one_error", mean_zero_one_error, -1),
+    ("accuracy_off1_score", accuracy_off1_score, 1),
+    ("accuracy_score", accuracy_score, 1),
+    ("geometric_mean", geometric_mean, 1),
+    ("gmsec", gmsec, 1),
+    ("kendalls_tau", kendalls_tau, 1),
+    ("mean_extreme_sensitivity", mean_extreme_sensitivity, 1),
+    ("minimum_sensitivity", minimum_sensitivity, 1),
+    ("spearmans_rho", spearmans_rho, 1),
+    ("weighted_kappa", weighted_kappa, 1),
+]
 
-def test_list_ordinal_scorers_is_sorted():
-    """list_ordinal_scorers returns names in sorted order."""
+_LOSS_METRIC_FNS = {
+    average_mean_absolute_error,
+    maximum_mean_absolute_error,
+    mean_absolute_error,
+    mean_zero_one_error,
+}
+
+
+@pytest.mark.parametrize(
+    "name, metric_fn, sign",
+    _EXPECTED_SCORERS,
+    ids=[entry[0] for entry in _EXPECTED_SCORERS],
+)
+def test_registered_scorer_contract(name, metric_fn, sign):
+    """Each scorer wraps its metric, and only a loss is negated."""
+    scorer = get_ordinal_scorer(name)
+    assert scorer._score_func is metric_fn
+    assert scorer._sign == sign
+    assert (metric_fn in _LOSS_METRIC_FNS) == name.startswith("neg_")
+
+
+def test_scorer_names_match_expected():
+    """Names are exactly the pinned contract, sorted, in a fresh list."""
     names = list_ordinal_scorers()
-    assert names == sorted(names)
-
-
-def test_list_ordinal_scorers_returns_new_list():
-    """Two calls return equal but non-identical list objects."""
-    assert list_ordinal_scorers() == list_ordinal_scorers()
-    assert list_ordinal_scorers() is not list_ordinal_scorers()
+    assert names == sorted(entry[0] for entry in _EXPECTED_SCORERS)
+    assert list_ordinal_scorers() is not names
 
 
 def test_scorers_not_in_public_all():
@@ -45,68 +76,30 @@ def test_scorers_not_in_public_all():
 
 
 @pytest.mark.parametrize(
-    "name, metric_fn",
+    "name, labels",
     [
-        ("accuracy_off1_score", accuracy_off1_score),
-        ("accuracy_score", accuracy_score),
-        ("geometric_mean", geometric_mean),
-        ("gmsec", gmsec),
-        ("mean_extreme_sensitivity", mean_extreme_sensitivity),
-        ("minimum_sensitivity", minimum_sensitivity),
-        ("spearmans_rho", spearmans_rho),
-        ("kendalls_tau", kendalls_tau),
-        ("weighted_kappa", weighted_kappa),
+        ("neg_mean_absolute_error", [0, 1, 2]),
+        ("accuracy_score", [0, 1, 2]),
     ],
+    ids=["loss", "utility"],
 )
-def test_utility_scorer_sign(name, metric_fn):
-    """Utility scorers have sign +1 and wrap the expected metric function."""
-    scorer = get_ordinal_scorer(name)
-    assert scorer._score_func is metric_fn
-    assert scorer._sign == 1
-
-
-@pytest.mark.parametrize(
-    "name, metric_fn",
-    [
-        ("neg_average_mean_absolute_error", average_mean_absolute_error),
-        ("neg_mean_absolute_error", mean_absolute_error),
-        ("neg_maximum_mean_absolute_error", maximum_mean_absolute_error),
-        ("neg_mean_zero_one_error", mean_zero_one_error),
-        ("neg_ranked_probability_score", ranked_probability_score),
-        ("average_mean_absolute_error", average_mean_absolute_error),
-        ("mean_absolute_error", mean_absolute_error),
-        ("maximum_mean_absolute_error", maximum_mean_absolute_error),
-        ("mean_zero_one_error", mean_zero_one_error),
-    ],
-)
-def test_loss_scorer_sign(name, metric_fn):
-    """Loss scorers have sign -1 and wrap the expected metric function."""
-    scorer = get_ordinal_scorer(name)
-    assert scorer._score_func is metric_fn
-    assert scorer._sign == -1
-
-
-def test_whitespace_stripped():
-    """Leading and trailing whitespace in the name is ignored."""
-    assert get_ordinal_scorer("  neg_mean_absolute_error  ")._sign == -1
-
-
-def test_gridcv_with_loss_scorer():
-    """Loss scorer integrates with GridSearchCV: best_score_ is non-positive."""
-    import numpy as np
-
+def test_scorer_drives_gridsearchcv(name, labels):
+    """Every scorer shape works in GridSearchCV with the sign its name implies."""
     rng = np.random.default_rng(0)
-    X = rng.standard_normal((30, 3))
-    y = np.repeat([0, 1, 2], 10)
+    X = rng.standard_normal((60, 4))
+    y = np.repeat(np.array(labels), 60 // len(labels))
 
     gs = GridSearchCV(
-        LogisticRegression(max_iter=200),
+        LogisticRegression(max_iter=500),
         param_grid={"C": [0.1, 1.0]},
-        scoring=get_ordinal_scorer("neg_mean_absolute_error"),
-        cv=StratifiedKFold(n_splits=2),
-    )
-    gs.fit(X, y)
-    assert gs.best_score_ <= 0
+        scoring=get_ordinal_scorer(name),
+        cv=StratifiedKFold(n_splits=3),
+    ).fit(X, y)
+
+    if name.startswith("neg_"):
+        assert gs.best_score_ <= 0
+    else:
+        assert gs.best_score_ >= 0
 
 
 def test_get_ordinal_scorer_rejects_non_string():
@@ -121,24 +114,6 @@ def test_get_ordinal_scorer_value_error():
         get_ordinal_scorer("roc_auc")
 
 
-def test_scorer_names_present():
-    """Every expected scorer name appears in list_ordinal_scorers()."""
-    names = list_ordinal_scorers()
-    expected = [
-        "neg_average_mean_absolute_error",
-        "neg_mean_absolute_error",
-        "neg_maximum_mean_absolute_error",
-        "neg_mean_zero_one_error",
-        "neg_ranked_probability_score",
-        "accuracy_score",
-        "accuracy_off1_score",
-        "geometric_mean",
-        "gmsec",
-        "kendalls_tau",
-        "mean_extreme_sensitivity",
-        "minimum_sensitivity",
-        "spearmans_rho",
-        "weighted_kappa",
-    ]
-    for name in expected:
-        assert name in names, f"{name!r} missing from list_ordinal_scorers()"
+def test_whitespace_stripped():
+    """Leading and trailing whitespace in the name is ignored."""
+    assert get_ordinal_scorer("  neg_mean_absolute_error  ")._sign == -1

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -110,16 +110,29 @@ def test_scorer_drives_gridsearchcv(name, labels):
         assert gs.best_score_ >= 0
 
 
-def test_get_ordinal_scorer_rejects_non_string():
-    """A non-string name is rejected at the parameter boundary."""
-    with pytest.raises(InvalidParameterError):
-        get_ordinal_scorer(123)
+def test_get_ordinal_scorer_passes_through_callable_and_none():
+    """A callable is returned as is and None returns None, as in sklearn."""
+
+    def scorer(estimator, X, y):
+        return 0.0
+
+    assert get_ordinal_scorer(scorer) is scorer
+    assert get_ordinal_scorer(None) is None
 
 
-def test_get_ordinal_scorer_value_error():
-    """Unknown name raises ValueError mentioning the requested name."""
-    with pytest.raises(ValueError, match="roc_auc"):
-        get_ordinal_scorer("roc_auc")
+@pytest.mark.parametrize(
+    "name, exception, match",
+    [
+        (123, InvalidParameterError, "must be an instance of"),
+        ("roc_auc", ValueError, "roc_auc"),
+        ("mean_absolute_error", ValueError, "neg_mean_absolute_error"),
+    ],
+    ids=["wrong_type", "unknown_name", "unnegated_loss"],
+)
+def test_get_ordinal_scorer_rejects(name, exception, match):
+    """Bad input raises, and a bare loss name points at its neg_ form."""
+    with pytest.raises(exception, match=match):
+        get_ordinal_scorer(name)
 
 
 def test_whitespace_stripped():

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -1,6 +1,5 @@
 """Tests for the public scorer API."""
 
-import numpy.testing as npt
 import pytest
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
@@ -90,34 +89,6 @@ def test_loss_scorer_sign(name, metric_fn):
 def test_whitespace_stripped():
     """Leading and trailing whitespace in the name is ignored."""
     assert get_ordinal_scorer("  neg_mean_absolute_error  ")._sign == -1
-
-
-@pytest.mark.parametrize(
-    "name, metric_fn",
-    [
-        ("accuracy_score", accuracy_score),
-        ("accuracy_off1_score", accuracy_off1_score),
-        ("geometric_mean", geometric_mean),
-        ("gmsec", gmsec),
-        ("mean_absolute_error", mean_absolute_error),
-        ("mean_extreme_sensitivity", mean_extreme_sensitivity),
-        ("maximum_mean_absolute_error", maximum_mean_absolute_error),
-        ("average_mean_absolute_error", average_mean_absolute_error),
-        ("minimum_sensitivity", minimum_sensitivity),
-        ("mean_zero_one_error", mean_zero_one_error),
-        ("kendalls_tau", kendalls_tau),
-        ("weighted_kappa", weighted_kappa),
-        ("spearmans_rho", spearmans_rho),
-    ],
-)
-def test_scorer_output_matches_metric(name, metric_fn):
-    """Scorer's score function returns the same value as calling the metric directly."""
-    y_true = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3]
-    y_pred = [1, 3, 3, 1, 2, 3, 1, 2, 2, 1, 3, 1, 1, 2, 2, 2, 3, 3, 1, 3]
-    scorer = get_ordinal_scorer(name)
-    npt.assert_almost_equal(
-        scorer._score_func(y_true, y_pred), metric_fn(y_true, y_pred)
-    )
 
 
 def test_gridcv_with_loss_scorer():

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -75,6 +75,14 @@ def test_scorers_not_in_public_all():
     assert "_SCORERS" not in m.__all__
 
 
+def test_get_ordinal_scorer_returns_fresh_copy():
+    """Mutating a returned scorer does not affect subsequent lookups."""
+    first = get_ordinal_scorer("neg_mean_absolute_error")
+    assert get_ordinal_scorer("neg_mean_absolute_error") is not first
+    first._kwargs["sample_weight"] = None
+    assert "sample_weight" not in get_ordinal_scorer("neg_mean_absolute_error")._kwargs
+
+
 @pytest.mark.parametrize(
     "name, labels",
     [

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -12,9 +12,9 @@ from skordinal.metrics import (
     average_mean_absolute_error,
     geometric_mean,
     get_ordinal_scorer,
+    get_ordinal_scorer_names,
     gmsec,
     kendalls_tau,
-    list_ordinal_scorers,
     maximum_mean_absolute_error,
     mean_absolute_error,
     mean_extreme_sensitivity,
@@ -63,9 +63,9 @@ def test_registered_scorer_contract(name, metric_fn, sign):
 
 def test_scorer_names_match_expected():
     """Names are exactly the pinned contract, sorted, in a fresh list."""
-    names = list_ordinal_scorers()
+    names = get_ordinal_scorer_names()
     assert names == sorted(entry[0] for entry in _EXPECTED_SCORERS)
-    assert list_ordinal_scorers() is not names
+    assert get_ordinal_scorer_names() is not names
 
 
 def test_scorers_not_in_public_all():

--- a/skordinal/model_selection/_loaders.py
+++ b/skordinal/model_selection/_loaders.py
@@ -142,9 +142,7 @@ def load_classifier(
     param_grid = prepare_param_grid(classifier_cls, param_grid, random_state)
 
     if is_searchcv(param_grid):
-        scorer = (
-            get_ordinal_scorer(cv_metric) if isinstance(cv_metric, str) else cv_metric
-        )
+        scorer = get_ordinal_scorer(cv_metric)
         cv = StratifiedKFold(
             n_splits=cv_n_folds, shuffle=True, random_state=random_state
         )

--- a/skordinal/model_selection/_loaders.py
+++ b/skordinal/model_selection/_loaders.py
@@ -75,7 +75,7 @@ def load_classifier(
     random_state: int | np.random.RandomState | None = None,
     n_jobs: int = 1,
     cv_n_folds: int = 3,
-    cv_metric: str | Callable[..., Any] = "mae",
+    cv_metric: str | Callable[..., Any] = "neg_mean_absolute_error",
     param_grid: dict[str, Any] | None = None,
 ) -> BaseEstimator | GridSearchCV:
     """Return a fully configured classifier, optionally with cross-validation.
@@ -98,8 +98,10 @@ def load_classifier(
     cv_n_folds : int, optional (default=3)
         Number of folds for cross-validation (only used if applicable).
 
-    cv_metric : str or callable, optional (default="mae")
-        Evaluation metric for cross-validation performance assessment.
+    cv_metric : str or callable, optional (default="neg_mean_absolute_error")
+        Evaluation metric for cross-validation performance assessment. A
+        string name must be recognised by
+        ``skordinal.metrics.get_ordinal_scorer``.
 
     param_grid : dict or None, optional (default=None)
         Hyperparameter grid. If multiple values are given, cross-validation will be applied.

--- a/skordinal/model_selection/tests/test_loaders.py
+++ b/skordinal/model_selection/tests/test_loaders.py
@@ -87,6 +87,12 @@ def test_load_classifier_with_searchcv():
     assert classifier.param_grid == expected_param_grid
 
 
+def test_load_classifier_with_searchcv_default_cv_metric():
+    """load_classifier's default cv_metric resolves to a registered scorer."""
+    classifier = load_classifier("SVC", param_grid={"C": [0.1, 1.0]}, cv_n_folds=2)
+    assert isinstance(classifier, GridSearchCV)
+
+
 def test_load_classifier_with_ensemble_method():
     """Test that load_classifier correctly handles ensemble methods."""
     param_grid = {


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`_SCORERS` registers four loss metrics twice, negated and bare, both with `greater_is_better=False`. The bare names duplicate their `neg_` counterparts and misreport their sign. `get_ordinal_scorer("mean_absolute_error")` returns a negative MAE. They are gone, matching scikit-learn, which never registers a bare loss. `neg_ranked_probability_score` goes too. It feeds hard labels to a probability metric and raises on every call. `get_ordinal_scorer` now copies on lookup and accepts a string, a callable or `None`, mirroring `get_scorer`. `load_classifier`'s `cv_metric` default, `"mae"`, is not a registered name, so grid search crashes unless the caller overrides it.

Breaking changes. Five scorer names are removed, `eval_metrics` no longer accepts `neg_`-prefixed names, and `list_ordinal_scorers` becomes `get_ordinal_scorer_names`. `ranked_probability_score` remains a metric function.