### PR TITLE
ENH: Add predict_projection to the ordinal classifiers

### DIFF
--- a/skordinal/classifiers/_kdlor.py
+++ b/skordinal/classifiers/_kdlor.py
@@ -394,6 +394,32 @@ class KDLOR(ClassifierMixin, BaseEstimator):
         labels_enc = (wx > 0).sum(axis=1)  # (m,) in [0, K-1]
         return self.classes_[labels_enc]
 
+    def predict_projection(self, X):
+        """Return the raw latent projection for each sample.
+
+        The kernel projection ``f(x)`` is the raw latent projection
+        (ordinal-axis score) that ``thresholds_`` partitions into class
+        regions.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw kernel projection for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return self._project(X)
+
     def _cumproba(self, X):
         """Compute raw cumulative probabilities on pre-validated X."""
         projection = self._project(X)

--- a/skordinal/classifiers/_logistic_at.py
+++ b/skordinal/classifiers/_logistic_at.py
@@ -291,6 +291,32 @@ class LogisticAT(ClassifierMixin, BaseEstimator):
         labels_enc = (f[:, np.newaxis] > self.thresholds_[np.newaxis, :]).sum(axis=1)
         return self.classes_[labels_enc]
 
+    def predict_projection(self, X):
+        """Return the raw latent projection for each sample.
+
+        The linear projection ``f(x) = w^T x`` is the raw latent
+        projection (ordinal-axis score) that ``thresholds_`` partitions
+        into class regions.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw linear projection for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return self._project(X)
+
     def _init_params(self, n_features, n_classes):
         """Build the initial packed parameter vector ``[w; t]``."""
         w = np.zeros(n_features)

--- a/skordinal/classifiers/_logistic_it.py
+++ b/skordinal/classifiers/_logistic_it.py
@@ -286,6 +286,32 @@ class LogisticIT(ClassifierMixin, BaseEstimator):
         proba = cumproba_to_proba(self._cumproba(X), repair=True)
         return self.classes_[proba.argmax(axis=1)]
 
+    def predict_projection(self, X):
+        """Return the raw latent projection for each sample.
+
+        The linear projection ``f(x) = w^T x`` is the raw latent
+        projection (ordinal-axis score) that ``thresholds_`` partitions
+        into class regions.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw linear projection for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return self._project(X)
+
     def _init_params(self, n_features, n_classes):
         """Build the initial packed parameter vector ``[w; t]``."""
         w = np.zeros(n_features)

--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -500,9 +500,9 @@ class NNOP(ClassifierMixin, BaseEstimator):
         # Neural Network model
         a1 = np.append(np.ones((n_samples, 1)), X, axis=1)
         z2 = np.matmul(a1, theta1.T)
-        a2 = np.append(np.ones((n_samples, 1)), 1.0 / (1.0 + np.exp(-z2)), axis=1)
+        a2 = np.append(np.ones((n_samples, 1)), expit(z2), axis=1)
         z3 = np.matmul(a2, theta2.T)
-        h = np.append(1.0 / (1.0 + np.exp(-z3)), np.ones((n_samples, 1)), axis=1)
+        h = np.append(expit(z3), np.ones((n_samples, 1)), axis=1)
 
         # Final output
         out = h

--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -197,7 +197,7 @@ class NNOP(ClassifierMixin, BaseEstimator):
         )[:, np.newaxis]
 
         results_optimization = scipy.optimize.fmin_l_bfgs_b(
-            func=self._nnop_cost_function,
+            func=self._objective,
             x0=initial_nn_params.ravel(),
             args=(
                 self.n_features_in_,
@@ -443,7 +443,7 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         return W
 
-    def _nnop_cost_function(
+    def _objective(
         self,
         nn_params: np.ndarray,
         n_features: int,

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -210,7 +210,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         )[:, np.newaxis]
 
         results_optimization = scipy.optimize.fmin_l_bfgs_b(
-            func=self._nnpom_cost_function,
+            func=self._objective,
             x0=initial_nn_params.ravel(),
             args=(
                 self.n_features_in_,
@@ -444,7 +444,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         return W
 
-    def _nnpom_cost_function(
+    def _objective(
         self,
         nn_params: np.ndarray,
         n_features: int,

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -346,6 +346,32 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, reset=False)
         return cumproba_to_proba(self._cumproba(X), repair=True)
 
+    def predict_projection(self, X: ArrayLike) -> np.ndarray:
+        """Return the raw latent projection for each sample.
+
+        The network's scalar output ``f(x)`` is the raw latent
+        projection (ordinal-axis score) that ``thresholds_`` partitions
+        into class regions.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw network output for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        return self._project(X)
+
     def _project(self, X: np.ndarray) -> np.ndarray:
         """Compute the raw latent projection for pre-validated X."""
         a1 = np.append(np.ones((X.shape[0], 1)), X, axis=1)

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -284,23 +284,8 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
-        n_samples = X.shape[0]
-        n_classes = len(self.classes_)
-
-        a1 = np.append(np.ones((n_samples, 1)), X, axis=1)
-        z2 = np.matmul(a1, self.theta1_.T)
-        a2 = expit(z2)
-        projected = np.matmul(a2, self.theta2_.T)
-
-        z3 = np.tile(self.thresholds_, (n_samples, 1)) - np.tile(
-            projected, (1, n_classes - 1)
-        )
-        a3T = expit(z3)
-        a3 = np.append(a3T, np.ones((n_samples, 1)), axis=1)
-        a3[:, 1:] = a3[:, 1:] - a3[:, 0:-1]
-        y_pred = self.classes_[a3.argmax(1)]
-
-        return y_pred
+        proba = cumproba_to_proba(self._cumproba(X), repair=True)
+        return self.classes_[proba.argmax(axis=1)]
 
     def predict_cumproba(self, X: ArrayLike) -> np.ndarray:
         """Cumulative class probabilities for each sample.
@@ -363,12 +348,16 @@ class NNPOM(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, reset=False)
         return cumproba_to_proba(self._cumproba(X), repair=True)
 
-    def _cumproba(self, X: np.ndarray) -> np.ndarray:
-        """Compute raw cumulative probabilities on pre-validated X."""
+    def _project(self, X: np.ndarray) -> np.ndarray:
+        """Compute the raw latent projection for pre-validated X."""
         a1 = np.append(np.ones((X.shape[0], 1)), X, axis=1)
         a2 = expit(np.matmul(a1, self.theta1_.T))
-        projected = np.matmul(a2, self.theta2_.T)
-        return expit(self.thresholds_ - projected)
+        return np.matmul(a2, self.theta2_.T).ravel()
+
+    def _cumproba(self, X: np.ndarray) -> np.ndarray:
+        """Compute raw cumulative probabilities on pre-validated X."""
+        projected = self._project(X)  # (n,)
+        return expit(self.thresholds_ - projected[:, np.newaxis])
 
     def _unpack_parameters(
         self,

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -91,7 +91,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
     theta2_ : ndarray of shape (1, n_hidden)
         Output layer weights (without bias, the biases will be the thresholds)
 
-    thresholds_ : ndarray of shape (1, n_classes - 1)
+    thresholds_ : ndarray of shape (n_classes - 1,)
         Class thresholds parameters
 
     Notes
@@ -249,9 +249,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
 
         self.theta1_ = theta1
         self.theta2_ = theta2
-        self.thresholds_ = params_to_thresholds(thresholds_param.ravel()).reshape(
-            1, n_classes - 1
-        )
+        self.thresholds_ = params_to_thresholds(thresholds_param.ravel())
 
         # Scikit-learn compatibility
         self.n_layers_ = 3
@@ -357,7 +355,7 @@ class NNPOM(ClassifierMixin, BaseEstimator):
     def _cumproba(self, X: np.ndarray) -> np.ndarray:
         """Compute raw cumulative probabilities on pre-validated X."""
         projected = self._project(X)  # (n,)
-        return expit(self.thresholds_ - projected[:, np.newaxis])
+        return expit(self.thresholds_[np.newaxis, :] - projected[:, np.newaxis])
 
     def _unpack_parameters(
         self,

--- a/skordinal/classifiers/_orboost.py
+++ b/skordinal/classifiers/_orboost.py
@@ -69,6 +69,11 @@ class ORBoost(ClassifierMixin, BaseEstimator):
         Feature names seen during ``fit``. Defined only when ``X`` is a
         ``pandas.DataFrame``.
 
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Fitted ordered thresholds partitioning the ensemble score into class
+        regions.  ``predict`` assigns
+        ``classes_[(predict_projection(X)[:, None] >= thresholds_).sum(axis=1)]``.
+
     model_ : dict
         Model state returned by the C++ backend after fitting, with
         keys ``'model'`` (learned parameters) and ``'params'``
@@ -172,6 +177,8 @@ class ORBoost(ClassifierMixin, BaseEstimator):
             K,
             self.n_estimators,
         )
+        # reported at the aggregation size predict uses
+        self.thresholds_ = np.asarray(self.model_["thresholds"], dtype=np.float64)
         return self
 
     def predict(self, X):
@@ -194,6 +201,33 @@ class ORBoost(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False, dtype=np.float64)
-        y_pred = _orensemble_lib.predict(X.tolist(), self.model_)
+        y_pred, _ = _orensemble_lib.predict(X.tolist(), self.model_)
         # Map the backend's 1-indexed ranks back to labels in classes_
         return self.classes_[np.array(y_pred, dtype=int) - 1]
+
+    def predict_projection(self, X):
+        """Return the raw latent projection for each sample.
+
+        The aggregated ensemble score ``f(x)`` is the raw latent
+        projection (ordinal-axis score) that ``thresholds_`` partitions
+        into class regions, on the same scale.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input samples.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw ensemble score for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        _, projection = _orensemble_lib.predict(X.tolist(), self.model_)
+        return np.asarray(projection, dtype=np.float64)

--- a/skordinal/classifiers/_pom.py
+++ b/skordinal/classifiers/_pom.py
@@ -339,9 +339,13 @@ class POM(ClassifierMixin, BaseEstimator):
         proba = cumproba_to_proba(self._cumproba(X), repair=True)
         return self.classes_[proba.argmax(axis=1)]
 
+    def _project(self, X):
+        """Compute the raw latent projection for pre-validated X."""
+        return X @ self.coef_
+
     def _cumproba(self, X):
         """Compute raw cumulative probabilities on pre-validated X."""
-        f = X @ self.coef_  # (n,)
+        f = self._project(X)  # (n,)
         eta = self.thresholds_[np.newaxis, :] - f[:, np.newaxis]  # (n, K-1)
         # Predict path only needs the CDF; skip the density computation
         return self._link_cdf_pdf(eta, need_pdf=False)[0]

--- a/skordinal/classifiers/_pom.py
+++ b/skordinal/classifiers/_pom.py
@@ -339,6 +339,32 @@ class POM(ClassifierMixin, BaseEstimator):
         proba = cumproba_to_proba(self._cumproba(X), repair=True)
         return self.classes_[proba.argmax(axis=1)]
 
+    def predict_projection(self, X):
+        """Return the raw latent projection for each sample.
+
+        The linear projection ``f(x) = w^T x`` is the raw latent
+        projection (ordinal-axis score) that ``thresholds_`` partitions
+        into class regions.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input patterns.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw linear projection for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, dtype=np.float64)
+        return self._project(X)
+
     def _project(self, X):
         """Compute the raw latent projection for pre-validated X."""
         return X @ self.coef_

--- a/skordinal/classifiers/_redsvm.py
+++ b/skordinal/classifiers/_redsvm.py
@@ -68,6 +68,11 @@ class REDSVM(ClassifierMixin, BaseEstimator):
     classes_ : ndarray of shape (n_classes,)
         Array that contains all different class labels found in the original dataset.
 
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Fitted ordered thresholds partitioning the latent projection into
+        class regions.  ``predict`` assigns
+        ``classes_[(predict_projection(X)[:, None] >= thresholds_).sum(axis=1)]``.
+
     model_ : object
         Fitted estimator.
 
@@ -196,6 +201,8 @@ class REDSVM(ClassifierMixin, BaseEstimator):
             str(1 if self.shrinking else 0),
         )
         self.model_ = svm.fit((y_encoded + 1).tolist(), X.tolist(), options)
+        # the backend folds rho[0] into the projection; rho[1:] are the cutpoints
+        self.thresholds_ = np.asarray(self.model_["rho"][1:], dtype=np.float64)
 
         return self
 
@@ -224,5 +231,37 @@ class REDSVM(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
-        y_pred = np.array(svm.predict(X.tolist(), self.model_))
-        return self.classes_[y_pred.astype(int) - 1]
+        y_pred, _ = svm.predict(X.tolist(), self.model_)
+        return self.classes_[np.asarray(y_pred).astype(int) - 1]
+
+    def predict_projection(self, X: ArrayLike) -> np.ndarray:
+        """Return the raw latent projection for each sample.
+
+        The projection ``f(x)`` is the raw latent projection (ordinal-axis
+        score) that ``thresholds_`` partitions into class regions, on the
+        same scale.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Test patterns array, where n_samples is the number of samples and
+            n_features is the number of features.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw projection for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+
+        ValueError
+            If input is invalid.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        _, projection = svm.predict(X.tolist(), self.model_)
+        return np.asarray(projection, dtype=np.float64)

--- a/skordinal/classifiers/_regressor_wrapper.py
+++ b/skordinal/classifiers/_regressor_wrapper.py
@@ -38,6 +38,11 @@ class RegressorWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
     classes_ : ndarray of shape (n_classes,)
         Class labels for each output.
 
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Ordered thresholds partitioning the projection into class regions,
+        at the midpoints between consecutive ranks (``0.5, 1.5, ...``).
+        Determined by ``n_classes`` alone, not learned from the data.
+
     estimator_ : regressor instance
         Fitted clone of the base estimator.
 
@@ -110,6 +115,9 @@ class RegressorWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         self.estimator_ = clone(base)
         self.estimator_.fit(X, y_enc)
 
+        # nearest-rank rounding puts the boundaries at the rank midpoints
+        self.thresholds_ = np.arange(self.classes_.size - 1, dtype=np.float64) + 0.5
+
         return self
 
     def predict(self, X: ArrayLike) -> np.ndarray:
@@ -136,13 +144,7 @@ class RegressorWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         check_is_fitted(self)
         X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
 
-        y_cont = self.estimator_.predict(X)
-
-        if np.isnan(y_cont).any():
-            raise ValueError(
-                "The wrapped regressor returned NaN predictions. "
-                "RegressorWrapper cannot map NaN to a rank."
-            )
+        y_cont = self._project(X)
 
         # Clip so unbounded output maps to the nearest extreme class
         max_rank = self.classes_.size - 1
@@ -151,3 +153,47 @@ class RegressorWrapper(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         ranks = np.arange(self.classes_.size, dtype=float)
         idx = np.abs(y_cont[:, None] - ranks[None, :]).argmin(axis=1)
         return self.classes_[idx]
+
+    def _project(self, X: np.ndarray) -> np.ndarray:
+        """Compute the raw regressor output on pre-validated X."""
+        y_cont = self.estimator_.predict(X)
+
+        if np.isnan(y_cont).any():
+            raise ValueError(
+                "The wrapped regressor returned NaN predictions. "
+                "RegressorWrapper cannot map NaN to a rank."
+            )
+
+        return y_cont
+
+    def predict_projection(self, X: ArrayLike) -> np.ndarray:
+        """Return the raw latent projection for each sample.
+
+        The wrapped regressor's continuous output on the zero-based rank
+        scale is the raw latent projection (ordinal-axis score) that
+        ``predict`` discretises by rounding to the nearest rank.  It is
+        returned **unclipped**, so values outside ``[0, n_classes - 1]``
+        are visible here even though ``predict`` folds them into the
+        extreme classes.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw regressor output for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+
+        ValueError
+            If the wrapped regressor returns a NaN prediction.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False, ensure_2d=True, dtype=None)
+        return self._project(X)

--- a/skordinal/classifiers/_svorex.py
+++ b/skordinal/classifiers/_svorex.py
@@ -54,6 +54,11 @@ class SVOREX(ClassifierMixin, BaseEstimator):
     classes_ : ndarray of shape (n_classes,)
         Array that contains all different class labels found in the original dataset.
 
+    thresholds_ : ndarray of shape (n_classes - 1,)
+        Fitted ordered thresholds partitioning the latent projection into
+        class regions.  ``predict`` assigns
+        ``classes_[(predict_projection(X)[:, None] > thresholds_).sum(axis=1)]``.
+
     model_ : object
         Fitted estimator.
 
@@ -143,6 +148,8 @@ class SVOREX(ClassifierMixin, BaseEstimator):
             arg, str(self.tol), str(gamma_value), str(self.C)
         )
         self.model_ = svorex.fit((y_encoded + 1).tolist(), X.tolist(), options)
+        # biasj are the backend's ordered cutpoints
+        self.thresholds_ = np.asarray(self.model_["biasj"], dtype=np.float64)
         return self
 
     def predict(self, X: ArrayLike) -> np.ndarray:
@@ -170,5 +177,37 @@ class SVOREX(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
-        y_pred = np.array(svorex.predict(X.tolist(), self.model_))
-        return self.classes_[y_pred.astype(int) - 1]
+        y_pred, _ = svorex.predict(X.tolist(), self.model_)
+        return self.classes_[np.asarray(y_pred).astype(int) - 1]
+
+    def predict_projection(self, X: ArrayLike) -> np.ndarray:
+        """Return the raw latent projection for each sample.
+
+        The kernel projection ``f(x)`` is the raw latent projection
+        (ordinal-axis score) that ``thresholds_`` partitions into class
+        regions, on the same scale.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Test patterns array, where n_samples is the number of samples and
+            n_features is the number of features.
+
+        Returns
+        -------
+        projection : ndarray of shape (n_samples,)
+            Raw kernel projection for each sample.
+
+        Raises
+        ------
+        NotFittedError
+            If the model is not fitted yet.
+
+        ValueError
+            If the input is invalid.
+
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        _, projection = svorex.predict(X.tolist(), self.model_)
+        return np.asarray(projection, dtype=np.float64)

--- a/skordinal/classifiers/src/libsvmrank/python/svm-predict.cpp
+++ b/skordinal/classifiers/src/libsvmrank/python/svm-predict.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits>
 
 #include "svm-module-functions.hpp"
 #include "svm.h"
@@ -14,6 +15,8 @@
 PyObject* predictLabels(PyObject* features, struct svm_model *model)
 {
 	PyObject* predicted_labels = Py_BuildValue("[]"), *list_el = NULL;
+	PyObject* projections = Py_BuildValue("[]"), *proj_el = NULL;
+	double projection;
 	int feature_number, testing_instance_number;
 	int instance_index;
 	double **ptr_instance;
@@ -56,6 +59,8 @@ PyObject* predictLabels(PyObject* features, struct svm_model *model)
 		{
 			double res;
 			svm_predict_values(model, x, &res);
+			/* svm_predict_values already subtracted rho[0] */
+			projection = res;
 			if(svm_type == ONE_CLASS)
 				predict_label =  (res>0)?1:-1;
 			else if (svm_type == C_RNK || svm_type == SVORIM){
@@ -75,6 +80,8 @@ PyObject* predictLabels(PyObject* features, struct svm_model *model)
 		{
 			double *dec_values = (double *) malloc(sizeof(double) * nr_class*(nr_class-1)/2);
 			svm_predict_values(model, x, dec_values);
+			/* one-vs-one voting has no single latent axis */
+			projection = std::numeric_limits<double>::quiet_NaN();
 
 			int i;
 			int *vote = (int *) malloc(sizeof(int)* nr_class);
@@ -102,6 +109,10 @@ PyObject* predictLabels(PyObject* features, struct svm_model *model)
 			free(dec_values);
 		}
 
+		proj_el = Py_BuildValue("d", projection);
+		PyList_Append(projections, proj_el);
+		Py_DECREF(proj_el);
+
 		list_el = Py_BuildValue("d", predict_label);
 		PyList_Append(predicted_labels, list_el);
 		//PyList_Append increment the passed in PyObjects references so is necesary
@@ -116,7 +127,7 @@ PyObject* predictLabels(PyObject* features, struct svm_model *model)
 		free(ptr_instance[i]);
 	free(ptr_instance);
 
-	return predicted_labels;
+	return Py_BuildValue("(NN)", predicted_labels, projections);
 }
 
 /* Interface function of Python*/

--- a/skordinal/classifiers/src/orensemble/python/boostrank-predict.cpp
+++ b/skordinal/classifiers/src/orensemble/python/boostrank-predict.cpp
@@ -84,17 +84,24 @@ PyObject *predict(PyObject *self, PyObject *args)
     // std::cout << "Raw Ranking Loss: " << rl << std::endl;
     // std::cout << "Thresholded Ranking Loss: " << tl << std::endl;
 
+    /* out[i][0] is the rank, out[i][1] the ensemble score behind it */
     PyObject *predictedLabels = Py_BuildValue("[]"), *list_el = NULL;
+    PyObject *projections = Py_BuildValue("[]"), *proj_el = NULL;
     for (UINT i = 0; i < out.size(); ++i)
     {
         list_el = Py_BuildValue("i", (int)out[i][0]);
         PyList_Append(predictedLabels, list_el);
 
         Py_DECREF(list_el);
+
+        proj_el = Py_BuildValue("d", (double)out[i][1]);
+        PyList_Append(projections, proj_el);
+
+        Py_DECREF(proj_el);
     }
 
     delete pbag;
-    return predictedLabels;
+    return Py_BuildValue("(NN)", predictedLabels, projections);
 }
 
 int parseArgumentsPred(PyObject *args, PyObject **features, lemga::AggRank **model, boostrankParams &params)

--- a/skordinal/classifiers/src/orensemble/python/orensemble-model-python.cpp
+++ b/skordinal/classifiers/src/orensemble/python/orensemble-model-python.cpp
@@ -52,6 +52,24 @@ boostrankParams *pythonToParams(PyObject *paramsPyton)
     return ret;
 }
 
+/* AggRank keeps one set of n_rank-1 thresholds per iteration; take the set
+   at the aggregation size prediction will use */
+static PyObject *thresholdsToPython(const lemga::AggRank *model, const boostrankParams &params)
+{
+    UINT iter = params.n_iter;
+    if (iter > model->aggregation_size())
+        iter = model->aggregation_size();
+
+    PyObject *thresholds = Py_BuildValue("[]"), *el = NULL;
+    for (UINT k = 1; k < model->get_n_rank(); ++k)
+    {
+        el = Py_BuildValue("d", (double)model->threshold(iter, k));
+        PyList_Append(thresholds, el);
+        Py_DECREF(el);
+    }
+    return thresholds;
+}
+
 PyObject *modelAndParamsToPython(const lemga::AggRank *model, const boostrankParams &params)
 {
 
@@ -59,14 +77,18 @@ PyObject *modelAndParamsToPython(const lemga::AggRank *model, const boostrankPar
 
     PyObject *paramsPython = paramsToPython(params);
 
+    PyObject *thresholdsPython = thresholdsToPython(model, params);
+
     PyObject *ret = Py_BuildValue(
-        "{s:O, s:O}",
+        "{s:O, s:O, s:O}",
         "model", modelPython,
-        "params", paramsPython
+        "params", paramsPython,
+        "thresholds", thresholdsPython
     );
 
     Py_DECREF(modelPython);
     Py_DECREF(paramsPython);
+    Py_DECREF(thresholdsPython);
 
     return ret;
 }

--- a/skordinal/classifiers/src/svorex/svorex_predict.c
+++ b/skordinal/classifiers/src/svorex/svorex_predict.c
@@ -24,6 +24,7 @@ PyObject* predict(PyObject* self, PyObject* args)
 	Data_Node* testnode = NULL;
 	int feature_number, testing_instance_number, i, j;
 	PyObject* predicted_labels = NULL, *list_el = NULL;
+	PyObject* projections = NULL, *proj_el = NULL;
    	//Python parameters
    	PyObject* features = NULL;
 	PyObject* py_model = NULL;
@@ -97,6 +98,7 @@ PyObject* predict(PyObject* self, PyObject* args)
 	svm_predict_Python (testdata, model);
 
 	predicted_labels = Py_BuildValue("[]");
+	projections = Py_BuildValue("[]");
 	testnode = testdata->front ;
 	while (testnode!=NULL){
 		list_el = Py_BuildValue("d", testnode->guess);
@@ -105,6 +107,10 @@ PyObject* predict(PyObject* self, PyObject* args)
 		//to decrement them in order to let python free memory when the model 
 		//is not longer needed
 		Py_DECREF(list_el);
+		/* guess holds the rank, not the score: rebuild it from fx */
+		proj_el = Py_BuildValue("d", testnode->fx + model->bias);
+		PyList_Append(projections, proj_el);
+		Py_DECREF(proj_el);
 		testnode = testnode->next ;
 	}
 	
@@ -141,6 +147,6 @@ PyObject* predict(PyObject* self, PyObject* args)
 		return NULL;
 	}
 
-	return predicted_labels;
+	return Py_BuildValue("(NN)", predicted_labels, projections);
 }
 //end of svorex_predict.c 

--- a/skordinal/classifiers/tests/test_kdlor.py
+++ b/skordinal/classifiers/tests/test_kdlor.py
@@ -141,10 +141,12 @@ def test_kdlor_predict_invalid_input_raises_error(X, y):
 
 
 def test_kdlor_predict_raises_if_not_fitted(X):
-    """Test that predict raises NotFittedError if called before fit."""
+    """predict and predict_projection raise NotFittedError before fit."""
     classifier = KDLOR()
     with pytest.raises(NotFittedError):
         classifier.predict(X)
+    with pytest.raises(NotFittedError):
+        classifier.predict_projection(X)
 
 
 def test_kdlor_feature_names_in_when_dataframe(X, y):
@@ -165,10 +167,12 @@ def test_kdlor_parameter_constraints_match_init_params():
 
 
 def test_kdlor_predict_rejects_wrong_n_features(X, y):
-    """Test that predict rejects input with mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = KDLOR().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -362,3 +366,34 @@ def test_kdlor_large_magnitude_x_finite_probabilities():
 
     assert np.isfinite(proba).all()
     np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)
+
+
+def test_kdlor_projection_well_formed(X, y):
+    """predict_projection is well-formed and consistent with predict."""
+    clf = KDLOR().fit(X, y)
+
+    projection = clf.predict_projection(X)
+    assert projection.shape == (len(X),)
+    assert np.isfinite(projection).all()
+
+    order = np.argsort(projection)
+    assert np.all(np.diff(clf.predict(X)[order]) >= 0)
+
+    # stronger than monotonicity: catches a rescaled or shifted projection
+    n_exceeded = (projection[:, np.newaxis] > clf.thresholds_[np.newaxis, :]).sum(
+        axis=1
+    )
+    np.testing.assert_array_equal(clf.predict(X), clf.classes_[n_exceeded])
+
+
+def test_kdlor_projection_linear_in_convex_combination(X, y):
+    """With a linear kernel, projection(a*x1+(1-a)*x2) == a*proj(x1)+(1-a)*proj(x2)."""
+    clf = KDLOR(kernel="linear").fit(X, y)
+    alpha = 0.3
+    a, b = X[[0]], X[[1]]
+    combo = alpha * a + (1 - alpha) * b
+    np.testing.assert_allclose(
+        clf.predict_projection(combo),
+        alpha * clf.predict_projection(a) + (1 - alpha) * clf.predict_projection(b),
+        atol=1e-8,
+    )

--- a/skordinal/classifiers/tests/test_logistic_at.py
+++ b/skordinal/classifiers/tests/test_logistic_at.py
@@ -146,10 +146,12 @@ def test_logistic_at_predict_invalid_input_raises_error(X, y):
 
 
 def test_logistic_at_predict_raises_if_not_fitted(X):
-    """predict raises NotFittedError before fit."""
+    """predict and predict_projection raise NotFittedError before fit."""
     classifier = LogisticAT()
     with pytest.raises(NotFittedError):
         classifier.predict(X)
+    with pytest.raises(NotFittedError):
+        classifier.predict_projection(X)
 
 
 def test_logistic_at_feature_names_in_when_dataframe(X, y):
@@ -170,10 +172,12 @@ def test_logistic_at_parameter_constraints_match_init_params():
 
 
 def test_logistic_at_predict_rejects_wrong_n_features(X, y):
-    """predict rejects a mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = LogisticAT().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -342,3 +346,36 @@ def test_logistic_at_large_magnitude_x_finite_probabilities():
 
     assert np.isfinite(proba).all()
     np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)
+
+
+def test_logistic_at_projection_well_formed(ordinal_data):
+    """predict_projection is well-formed and consistent with predict."""
+    X, y = ordinal_data
+    clf = LogisticAT().fit(X, y)
+
+    projection = clf.predict_projection(X)
+    assert projection.shape == (len(X),)
+    assert np.isfinite(projection).all()
+
+    order = np.argsort(projection)
+    assert np.all(np.diff(clf.predict(X)[order]) >= 0)
+
+    # stronger than monotonicity: catches a rescaled or shifted projection
+    n_exceeded = (projection[:, np.newaxis] > clf.thresholds_[np.newaxis, :]).sum(
+        axis=1
+    )
+    np.testing.assert_array_equal(clf.predict(X), clf.classes_[n_exceeded])
+
+
+def test_logistic_at_projection_linear_in_convex_combination(ordinal_data):
+    """predict_projection(a*x1+(1-a)*x2) == a*proj(x1)+(1-a)*proj(x2)."""
+    X, y = ordinal_data
+    clf = LogisticAT().fit(X, y)
+    alpha = 0.3
+    a, b = X[[0]], X[[1]]
+    combo = alpha * a + (1 - alpha) * b
+    np.testing.assert_allclose(
+        clf.predict_projection(combo),
+        alpha * clf.predict_projection(a) + (1 - alpha) * clf.predict_projection(b),
+        atol=1e-8,
+    )

--- a/skordinal/classifiers/tests/test_logistic_it.py
+++ b/skordinal/classifiers/tests/test_logistic_it.py
@@ -146,10 +146,12 @@ def test_logistic_it_predict_invalid_input_raises_error(X, y):
 
 
 def test_logistic_it_predict_raises_if_not_fitted(X):
-    """predict raises NotFittedError before fit."""
+    """predict and predict_projection raise NotFittedError before fit."""
     classifier = LogisticIT()
     with pytest.raises(NotFittedError):
         classifier.predict(X)
+    with pytest.raises(NotFittedError):
+        classifier.predict_projection(X)
 
 
 def test_logistic_it_feature_names_in_when_dataframe(X, y):
@@ -170,10 +172,12 @@ def test_logistic_it_parameter_constraints_match_init_params():
 
 
 def test_logistic_it_predict_rejects_wrong_n_features(X, y):
-    """predict rejects a mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = LogisticIT().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -342,3 +346,30 @@ def test_logistic_it_large_magnitude_x_finite_probabilities():
 
     assert np.isfinite(proba).all()
     np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)
+
+
+def test_logistic_it_projection_well_formed(ordinal_data):
+    """predict_projection is well-formed and consistent with predict."""
+    X, y = ordinal_data
+    clf = LogisticIT().fit(X, y)
+
+    projection = clf.predict_projection(X)
+    assert projection.shape == (len(X),)
+    assert np.isfinite(projection).all()
+
+    order = np.argsort(projection)
+    assert np.all(np.diff(clf.predict(X)[order]) >= 0)
+
+
+def test_logistic_it_projection_linear_in_convex_combination(ordinal_data):
+    """predict_projection(a*x1+(1-a)*x2) == a*proj(x1)+(1-a)*proj(x2)."""
+    X, y = ordinal_data
+    clf = LogisticIT().fit(X, y)
+    alpha = 0.3
+    a, b = X[[0]], X[[1]]
+    combo = alpha * a + (1 - alpha) * b
+    np.testing.assert_allclose(
+        clf.predict_projection(combo),
+        alpha * clf.predict_projection(a) + (1 - alpha) * clf.predict_projection(b),
+        atol=1e-8,
+    )

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -141,10 +141,12 @@ def test_nnpom_predict_invalid_input_raises_error(X, y):
 
 
 def test_nnpom_predict_raises_if_not_fitted(X):
-    """Test that predict raises NotFittedError if called before fit."""
+    """predict and predict_projection raise NotFittedError before fit."""
     classifier = NNPOM()
     with pytest.raises(NotFittedError):
         classifier.predict(X)
+    with pytest.raises(NotFittedError):
+        classifier.predict_projection(X)
 
 
 def test_nnpom_feature_names_in_when_dataframe(X, y):
@@ -165,10 +167,12 @@ def test_nnpom_parameter_constraints_match_init_params():
 
 
 def test_nnpom_predict_rejects_wrong_n_features(X, y):
-    """Test that predict rejects input with mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = NNPOM(n_hidden=4, max_iter=5).fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -320,3 +324,16 @@ def test_nnpom_convergence_warning_only_at_insufficient_max_iter(ordinal_data):
 
     message = str(record[0].message)
     assert re.search(rf"stopped after {clf.n_iter_} iterations?\b", message), message
+
+
+def test_nnpom_projection_well_formed(ordinal_data):
+    """predict_projection is well-formed and consistent with predict."""
+    X, y = ordinal_data
+    clf = NNPOM(n_hidden=4, max_iter=50, random_state=0).fit(X, y)
+
+    projection = clf.predict_projection(X)
+    assert projection.shape == (len(X),)
+    assert np.isfinite(projection).all()
+
+    order = np.argsort(projection)
+    assert np.all(np.diff(clf.predict(X)[order]) >= 0)

--- a/skordinal/classifiers/tests/test_nnpom.py
+++ b/skordinal/classifiers/tests/test_nnpom.py
@@ -235,8 +235,8 @@ def test_fit_no_nan_with_near_zero_probabilities():
     assert set(clf.predict(X_reg)).issubset(set(clf.classes_))
 
 
-def test_nnpom_cost_function_gradient_matches_finite_difference():
-    """The analytic cost gradient matches a finite-difference approximation."""
+def test_nnpom_objective_gradient_matches_finite_difference():
+    """The analytic objective gradient matches a finite-difference approximation."""
     rng = np.random.default_rng(0)
     n_samples, n_features, n_hidden, n_classes = 30, 4, 3, 3
     X_data = rng.standard_normal((n_samples, n_features))
@@ -251,13 +251,13 @@ def test_nnpom_cost_function_gradient_matches_finite_difference():
     clf = NNPOM()
 
     def cost(nn_params):
-        J, _ = clf._nnpom_cost_function(
+        J, _ = clf._objective(
             nn_params, n_features, n_hidden, n_classes, X_data, Y, 0.01
         )
         return J
 
     def grad(nn_params):
-        _, g = clf._nnpom_cost_function(
+        _, g = clf._objective(
             nn_params, n_features, n_hidden, n_classes, X_data, Y, 0.01
         )
         return g
@@ -266,7 +266,7 @@ def test_nnpom_cost_function_gradient_matches_finite_difference():
     assert err < 1e-4
 
 
-def test_nnpom_cost_function_gradient_is_zero_in_clamped_region():
+def test_nnpom_objective_gradient_is_zero_in_clamped_region():
     """A fully clamped objective is flat, so its gradient must vanish."""
     n_samples, n_features, n_hidden, n_classes = 30, 4, 3, 3
     rng = np.random.default_rng(0)
@@ -282,9 +282,7 @@ def test_nnpom_cost_function_gradient_is_zero_in_clamped_region():
     )
 
     clf = NNPOM()
-    cost, grad = clf._nnpom_cost_function(
-        x0, n_features, n_hidden, n_classes, X_data, Y, 0.0
-    )
+    cost, grad = clf._objective(x0, n_features, n_hidden, n_classes, X_data, Y, 0.0)
 
     np.testing.assert_allclose(cost, -np.log(1e-15))
     np.testing.assert_array_equal(grad, np.zeros_like(grad))

--- a/skordinal/classifiers/tests/test_orboost.py
+++ b/skordinal/classifiers/tests/test_orboost.py
@@ -124,10 +124,12 @@ def test_orboost_model_dict_present_after_fit(X, y):
 
 
 def test_orboost_predict_raises_if_not_fitted(X):
-    """Test that predict raises NotFittedError if called before fit."""
+    """predict and predict_projection raise NotFittedError before fit."""
     classifier = ORBoost()
     with pytest.raises(NotFittedError):
         classifier.predict(X)
+    with pytest.raises(NotFittedError):
+        classifier.predict_projection(X)
 
 
 def test_orboost_feature_names_in_when_dataframe(X, y):
@@ -142,10 +144,12 @@ def test_orboost_feature_names_in_when_dataframe(X, y):
 
 
 def test_orboost_predict_rejects_wrong_n_features(X, y):
-    """Test that predict rejects input with mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = ORBoost(n_estimators=5).fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -245,3 +249,22 @@ def test_orboost_fits_on_era_dataset():
     preds = classifier.predict(X)
     assert preds.shape == (len(X),)
     assert set(preds).issubset(set(classifier.classes_))
+
+
+def test_orboost_projection_well_formed(ordinal_dataset):
+    """predict_projection is well-formed and reproduces predict via thresholds_."""
+    X, y = ordinal_dataset
+    clf = ORBoost(n_estimators=20).fit(X, y)
+
+    projection = clf.predict_projection(X)
+    assert projection.shape == (len(X),)
+    assert np.isfinite(projection).all()
+
+    assert clf.thresholds_.shape == (clf.classes_.size - 1,)
+    assert np.all(np.diff(clf.thresholds_) >= 0)
+
+    # recomputing predict cross-checks what the C++ actually returned
+    n_reached = (projection[:, np.newaxis] >= clf.thresholds_[np.newaxis, :]).sum(
+        axis=1
+    )
+    np.testing.assert_array_equal(clf.predict(X), clf.classes_[n_reached])

--- a/skordinal/classifiers/tests/test_pom.py
+++ b/skordinal/classifiers/tests/test_pom.py
@@ -154,10 +154,12 @@ def test_pom_predict_invalid_input_raises_error(X, y):
 
 
 def test_pom_predict_raises_if_not_fitted(X):
-    """Test that predict raises NotFittedError if called before fit."""
+    """predict and predict_projection raise NotFittedError before fit."""
     classifier = POM()
     with pytest.raises(NotFittedError):
         classifier.predict(X)
+    with pytest.raises(NotFittedError):
+        classifier.predict_projection(X)
 
 
 def test_pom_feature_names_in_when_dataframe(X, y):
@@ -178,10 +180,12 @@ def test_pom_parameter_constraints_match_init_params():
 
 
 def test_pom_predict_rejects_wrong_n_features(X, y):
-    """Test that predict rejects input with mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = POM().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -424,3 +428,30 @@ def test_pom_large_magnitude_x_finite_probabilities():
 
     assert np.isfinite(proba).all()
     np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-12)
+
+
+def test_pom_projection_well_formed(ordinal_data):
+    """predict_projection is well-formed and consistent with predict."""
+    X, y = ordinal_data
+    clf = POM().fit(X, y)
+
+    projection = clf.predict_projection(X)
+    assert projection.shape == (len(X),)
+    assert np.isfinite(projection).all()
+
+    order = np.argsort(projection)
+    assert np.all(np.diff(clf.predict(X)[order]) >= 0)
+
+
+def test_pom_projection_linear_in_convex_combination(ordinal_data):
+    """predict_projection(a*x1+(1-a)*x2) == a*proj(x1)+(1-a)*proj(x2)."""
+    X, y = ordinal_data
+    clf = POM().fit(X, y)
+    alpha = 0.3
+    a, b = X[[0]], X[[1]]
+    combo = alpha * a + (1 - alpha) * b
+    np.testing.assert_allclose(
+        clf.predict_projection(combo),
+        alpha * clf.predict_projection(a) + (1 - alpha) * clf.predict_projection(b),
+        atol=1e-8,
+    )

--- a/skordinal/classifiers/tests/test_redsvm.py
+++ b/skordinal/classifiers/tests/test_redsvm.py
@@ -176,10 +176,12 @@ def test_redsvm_parameter_constraints_match_init_params():
 
 
 def test_redsvm_predict_rejects_wrong_n_features(X, y):
-    """Test that predict rejects input with mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = REDSVM().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -232,3 +234,23 @@ def test_redsvm_gamma_string_resolves_like_numeric(gamma, expected_gamma):
     explicit = REDSVM(gamma=expected_gamma(X_train)).fit(X_train, y_train)
 
     np.testing.assert_array_equal(resolved.predict(X_test), explicit.predict(X_test))
+
+
+@pytest.mark.parametrize("kernel", ["linear", "rbf", "poly"])
+def test_redsvm_projection_well_formed(kernel):
+    """predict_projection is well-formed and reproduces predict via thresholds_."""
+    X_train, X_test, y_train, _ = make_balance_scale_split()
+    clf = REDSVM(kernel=kernel).fit(X_train, y_train)
+
+    projection = clf.predict_projection(X_test)
+    assert projection.shape == (len(X_test),)
+    assert np.isfinite(projection).all()
+
+    assert clf.thresholds_.shape == (clf.classes_.size - 1,)
+    assert np.all(np.diff(clf.thresholds_) >= 0)
+
+    # recomputing predict cross-checks what the C++ actually returned
+    n_reached = (projection[:, np.newaxis] >= clf.thresholds_[np.newaxis, :]).sum(
+        axis=1
+    )
+    npt.assert_array_equal(clf.predict(X_test), clf.classes_[n_reached])

--- a/skordinal/classifiers/tests/test_regressor_wrapper.py
+++ b/skordinal/classifiers/tests/test_regressor_wrapper.py
@@ -110,10 +110,12 @@ def test_regressor_wrapper_parameter_constraints_match_init_params():
 
 
 def test_regressor_wrapper_predict_rejects_wrong_n_features(X, y):
-    """Test that predict rejects input with mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = RegressorWrapper().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -175,3 +177,21 @@ def test_regressor_wrapper_predict_clips_infinite_output_to_extreme_class(
     npt.assert_array_equal(
         predictions, np.full(len(X), expected_class_fn(classifier.classes_))
     )
+
+
+def test_regressor_wrapper_projection_is_the_wrapped_regressor_output(X, y):
+    """predict_projection returns the wrapped regressor's own output."""
+    clf = RegressorWrapper(LinearRegression()).fit(X, y)
+
+    projection = clf.predict_projection(X)
+    assert projection.shape == (len(X),)
+    assert np.isfinite(projection).all()
+
+    # the projection is the regressor output on the rank scale, unclipped
+    npt.assert_allclose(projection, clf.estimator_.predict(X))
+
+    # predict clips then rounds to nearest rank; ties fall to the lower class
+    max_rank = clf.classes_.size - 1
+    clipped = np.clip(projection, 0.0, max_rank)
+    n_exceeded = (clipped[:, np.newaxis] > clf.thresholds_[np.newaxis, :]).sum(axis=1)
+    npt.assert_array_equal(clf.predict(X), clf.classes_[n_exceeded])

--- a/skordinal/classifiers/tests/test_svorex.py
+++ b/skordinal/classifiers/tests/test_svorex.py
@@ -158,10 +158,12 @@ def test_svorex_parameter_constraints_match_init_params():
 
 
 def test_svorex_predict_rejects_wrong_n_features(X, y):
-    """Test that predict rejects input with mismatched n_features."""
+    """predict and predict_projection reject a mismatched n_features."""
     classifier = SVOREX().fit(X, y)
     with pytest.raises(ValueError):
         classifier.predict(X[:, :-1])
+    with pytest.raises(ValueError):
+        classifier.predict_projection(X[:, :-1])
 
 
 @pytest.mark.parametrize(
@@ -214,3 +216,23 @@ def test_svorex_gamma_scale_zero_variance(X, y):
         classifier = SVOREX(gamma="scale", kernel="rbf").fit(X_constant, y)
 
     assert set(classifier.predict(X_constant)).issubset(set(classifier.classes_))
+
+
+@pytest.mark.parametrize("kernel", ["linear", "rbf", "poly"])
+def test_svorex_projection_well_formed(kernel):
+    """predict_projection is well-formed and reproduces predict via thresholds_."""
+    X_train, X_test, y_train, _ = make_balance_scale_split()
+    clf = SVOREX(kernel=kernel).fit(X_train, y_train)
+
+    projection = clf.predict_projection(X_test)
+    assert projection.shape == (len(X_test),)
+    assert np.isfinite(projection).all()
+
+    assert clf.thresholds_.shape == (clf.classes_.size - 1,)
+    assert np.all(np.diff(clf.thresholds_) >= 0)
+
+    # recomputing predict cross-checks what the C actually returned
+    n_exceeded = (projection[:, np.newaxis] > clf.thresholds_[np.newaxis, :]).sum(
+        axis=1
+    )
+    npt.assert_array_equal(clf.predict(X_test), clf.classes_[n_exceeded])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds `predict_projection(X)`, returning each classifier's raw latent score before it is discretised into a class, plus a `thresholds_` attribute giving the cutpoints on the same scale. Covers all nine classifiers with a single scalar projection: `POM`, `KDLOR`, `NNPOM`, `LogisticAT`, `LogisticIT`, `SVOREX`, `REDSVM`, `ORBoost`, and `RegressorWrapper`. For the three C/C++ backends, the projection was already computed internally and just wasn't returned to Python.

Also renames the NNOP/NNPOM cost functions to `_objective`, matching the other classifiers, and replaces NNOP's remaining manual sigmoid with `scipy.special.expit`, removing spurious overflow warnings.

#### Any other comments?

`decision_function` was intentionally left out: for `n_classes > 2` it would violate scikit-learn's multiclass contract and silently break tools like `CalibratedClassifierCV`.