### PR TITLE
ENH: Accept n_classes=2 in build_coding_matrix

### DIFF
--- a/skordinal/preprocessing/_coding.py
+++ b/skordinal/preprocessing/_coding.py
@@ -128,7 +128,7 @@ def binary_cumulative_to_ordinal(binary_preds, classes):
 
 @validate_params(
     {
-        "n_classes": [Interval(Integral, 3, None, closed="left")],
+        "n_classes": [Interval(Integral, 2, None, closed="left")],
         "decomposition": [StrOptions(set(_VALID_DECOMPOSITIONS))],
     },
     prefer_skip_nested_validation=True,
@@ -144,13 +144,13 @@ def build_coding_matrix(n_classes, decomposition):
     Parameters
     ----------
     n_classes : int
-        Number of ordinal classes (must be ``>= 3``).
+        Number of ordinal classes (must be ``>= 2``).
 
     decomposition : {'ordered_partitions', 'one_vs_next', 'one_vs_followers', 'one_vs_previous'}
         Decomposition strategy.
 
         - ``'ordered_partitions'``: subproblem ``k`` is
-          ``{0, ..., k} vs {k+1, ..., K-1}``. See [1]_.
+          ``{k+1, ..., K-1} vs {0, ..., k}``. See [1]_.
         - ``'one_vs_next'``: subproblem ``k`` is class ``k`` vs class
           ``k+1`` (other classes excluded).
         - ``'one_vs_followers'``: subproblem ``k`` is class ``k`` vs
@@ -166,12 +166,15 @@ def build_coding_matrix(n_classes, decomposition):
     Raises
     ------
     ValueError
-        If ``n_classes < 3`` or ``decomposition`` is not one of the
+        If ``n_classes < 2`` or ``decomposition`` is not one of the
         recognised strategies.
 
     Examples
     --------
     >>> from skordinal.preprocessing import build_coding_matrix
+    >>> build_coding_matrix(2, "ordered_partitions")
+    array([[-1],
+           [ 1]])
     >>> build_coding_matrix(4, "ordered_partitions")
     array([[-1, -1, -1],
            [ 1, -1, -1],

--- a/skordinal/preprocessing/tests/test_coding.py
+++ b/skordinal/preprocessing/tests/test_coding.py
@@ -232,11 +232,25 @@ def test_coding_matrix_one_vs_previous_structural_property(K):
         npt.assert_array_equal(col[k + 2 :], 0)
 
 
-@pytest.mark.parametrize("invalid", [-1, 0, 2])
-def test_coding_matrix_raises_on_n_classes_below_three(invalid):
-    """n_classes < 3 raises ValueError."""
+@pytest.mark.parametrize("invalid", [-1, 0, 1])
+def test_coding_matrix_raises_on_n_classes_below_two(invalid):
+    """n_classes < 2 raises ValueError."""
     with pytest.raises(ValueError, match=r"n_classes"):
         build_coding_matrix(invalid, "ordered_partitions")
+
+
+@pytest.mark.parametrize(
+    "strategy, expected",
+    [
+        ("ordered_partitions", np.array([[-1], [1]])),
+        ("one_vs_next", np.array([[1], [-1]])),
+        ("one_vs_followers", np.array([[1], [-1]])),
+        ("one_vs_previous", np.array([[-1], [1]])),
+    ],
+)
+def test_coding_matrix_k2_reference(strategy, expected):
+    """K=2 yields a single well-formed binary subproblem for every strategy."""
+    npt.assert_array_equal(build_coding_matrix(2, strategy), expected)
 
 
 def test_coding_matrix_raises_on_unknown_decomposition():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`build_coding_matrix` now accepts `n_classes=2` (previously required `>= 3`), and the `ordered_partitions` docstring is corrected. It had the two sides of the subproblem swapped. No change to the function body or to `n_classes >= 3` output.