### PR TITLE
FIX: Harden the CSV reader and DESCR resolution

### DIFF
--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -71,15 +71,19 @@ def _read_csv_any(path):
             return False
         return int(r0[1]) == len(r1) - 1
 
+    n_samples_declared = None
     if len(rows) < 2:
         # With only one row there is no header, so treat it as data
         r0 = rows[0]
+        if any(not _is_float(tok) for tok in r0):
+            raise ValueError(f"CSV file {path} has a header but no data rows.")
         data_rows = rows
         feature_names = [f"x{i}" for i in range(len(r0) - 1)]
     else:
         r0, r1 = rows[0], rows[1]
         if _is_metadata_header(r0, r1):
             # Metadata header holds n_samples, n_features then the class names
+            n_samples_declared = int(r0[0])
             n_features = int(r0[1])
             feature_names = [f"x{i}" for i in range(n_features)]
             # Only trust class-name tokens when at least one is present;
@@ -95,7 +99,24 @@ def _read_csv_any(path):
             feature_names = [f"x{i}" for i in range(len(r0) - 1)]
             data_rows = rows
 
+    if n_samples_declared is not None and len(data_rows) != n_samples_declared:
+        raise ValueError(
+            f"Metadata header of {path} declares {n_samples_declared} "
+            f"sample(s), but the file has {len(data_rows)} data row(s)."
+        )
+
     n_features = len(feature_names)
+    row_lengths = {len(row) for row in data_rows}
+    if len(row_lengths) > 1:
+        raise ValueError(
+            f"Rows of {path} have inconsistent lengths {sorted(row_lengths)}."
+        )
+    row_width = row_lengths.pop()
+    if row_width != n_features + 1:
+        raise ValueError(
+            f"Expected {n_features} feature column(s) plus 1 target column "
+            f"({n_features + 1} total) in {path}, but found {row_width}."
+        )
     # Parse every data row in one vectorised pass, the first n_features
     # columns are the features and the last column is the target
     table = np.asarray(data_rows, dtype=np.float64)

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -39,7 +39,9 @@ def _cast_target_column(y_raw, path):
 
 def _read_csv_any(path):
     """Read an ordinal-classification CSV, auto-detecting the header style."""
-    with open(path, "r", encoding="utf-8", newline="") as fh:
+    # utf-8-sig strips a leading BOM instead of folding it into the first
+    # token, which would otherwise break header and integer detection
+    with open(path, "r", encoding="utf-8-sig", newline="") as fh:
         rows = list(csv.reader(fh))
 
     if not rows:
@@ -80,7 +82,9 @@ def _read_csv_any(path):
             # Metadata header holds n_samples, n_features then the class names
             n_features = int(r0[1])
             feature_names = [f"x{i}" for i in range(n_features)]
-            header_class_names = np.array(r0[2:])
+            # Only trust class-name tokens when at least one is present;
+            # otherwise fall back to the unique targets downstream
+            header_class_names = np.array(r0[2:]) if len(r0) > 2 else None
             data_rows = rows[1:]
         elif any(not _is_float(tok) for tok in r0):
             # Named header, with at least one non-numeric token

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -113,11 +113,15 @@ def _resolve_csv_path(name, data_home=None):
     return bundled_dir / f"{stem}.csv", DATA_MODULE
 
 
-def _load_descr(csv_path):
+def _load_descr(csv_path, data_module):
     """Return the ``.rst`` description for a CSV path, or None."""
     sidecar = csv_path.with_suffix(".rst")
     if sidecar.exists():
         return sidecar.read_text(encoding="utf-8")
+    if data_module is None:
+        # A path not resolved from the bundled directory must not inherit
+        # a bundled dataset's description just because the stem matches
+        return None
     bundled = Path(str(resources.files(DESCR_MODULE))) / f"{csv_path.stem}.rst"
     if bundled.exists():
         return bundled.read_text(encoding="utf-8")
@@ -383,7 +387,7 @@ def load_dataset(name, *, data_home=None, return_X_y=False, as_frame=False):
     target_names = _resolve_target_names(header_class_names, target)
     n_classes = len(target_names)
 
-    descr = _load_descr(path)
+    descr = _load_descr(path, data_module_value)
     if descr is None:
         descr = (
             f"Dataset '{path.stem}': {data.shape[0]} samples, "

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -178,6 +178,13 @@ def test_load_dataset_bundled_era():
     assert len(bunch.DESCR) > 10
 
 
+def test_load_dataset_data_home_does_not_inherit_bundled_descr(tmp_path):
+    """A user's own ``era.csv`` must not inherit the bundled ERA DESCR."""
+    _write_csv(tmp_path, "era")
+    bunch = load_dataset("era", data_home=tmp_path)
+    assert bunch.DESCR.startswith("Dataset 'era'")
+
+
 @pytest.mark.parametrize(
     "csv_text, expected_feature_names, expected_shape",
     [

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -153,8 +153,18 @@ def test_load_dataset_named_csv_bunch_contract(named_csv):
             ["x0", "x1"],
             ["0", "1", "2"],
         ),
+        (
+            "3,2\n1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n",
+            ["x0", "x1"],
+            ["0", "1", "2"],
+        ),
     ],
-    ids=["metadata-header", "named-header", "no-header"],
+    ids=[
+        "metadata-header",
+        "named-header",
+        "no-header",
+        "metadata-header-no-class-names",
+    ],
 )
 def test_load_dataset_header_styles(
     tmp_path, csv_text, expected_feature_names, expected_target_names
@@ -165,6 +175,23 @@ def test_load_dataset_header_styles(
     bunch = load_dataset(path)
     assert bunch.feature_names == expected_feature_names
     assert list(bunch.target_names) == expected_target_names
+    assert bunch.data.shape == (3, 2)
+
+
+@pytest.mark.parametrize(
+    "csv_text, expected_feature_names",
+    [
+        ("3,2\n1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n", ["x0", "x1"]),
+        ("x_0,x_1,y\n1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n", ["x_0", "x_1"]),
+    ],
+    ids=["metadata-header", "named-header"],
+)
+def test_load_dataset_strips_bom(tmp_path, csv_text, expected_feature_names):
+    """A leading UTF-8 BOM is stripped, not folded into the first token."""
+    path = tmp_path / "bom.csv"
+    path.write_text(csv_text, encoding="utf-8-sig")
+    bunch = load_dataset(path)
+    assert bunch.feature_names == expected_feature_names
     assert bunch.data.shape == (3, 2)
 
 

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -306,6 +306,32 @@ def test_load_dataset_invalid_target_raises(tmp_path, bad_target):
         load_dataset(path)
 
 
+@pytest.mark.parametrize(
+    "csv_text, match",
+    [
+        ("3,2\n1.0,2.0,0\n3.0,4.0,1\n", "declares 3 sample.*file has 2 data row"),
+        ("1.0,2.0,0\n3.0,4.0\n5.0,6.0,2\n", "inconsistent lengths"),
+        (
+            "x_0,x_1,x_2,y\n1.0,2.0,0\n3.0,4.0,1\n5.0,6.0,2\n",
+            "Expected 3 feature column",
+        ),
+        ("x_0,x_1,y\n", "header but no data rows"),
+    ],
+    ids=[
+        "declared-count-mismatch",
+        "ragged-rows",
+        "wrong-column-count",
+        "header-only",
+    ],
+)
+def test_load_dataset_malformed_csv_raises(tmp_path, csv_text, match):
+    """A structurally malformed CSV raises ``ValueError`` naming the file."""
+    path = tmp_path / "malformed.csv"
+    path.write_text(csv_text, encoding="utf-8")
+    with pytest.raises(ValueError, match=match):
+        load_dataset(path)
+
+
 def test_cv_fallback_era():
     """CV fallback on ``era`` yields 3 folds (ids, counts, classes)."""
     bunches = list(load_partitions("era", resamples=3))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Three related fixes to CSV dataset loading:

- The bundled `.rst` description no longer leaks into an external CSV that happens to share a bundled dataset's filename.
- A leading UTF-8 BOM no longer breaks header-style detection, and a metadata header with no class names now falls back to the unique target values.
- A malformed CSV now raises a clear, file-specific error instead of an opaque NumPy one.