### PR TITLE
 ENH: Harden the metric input-validation gateways

### DIFF
--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -12,87 +12,42 @@ from sklearn.utils import check_array, check_consistent_length
 from sklearn.utils._param_validation import validate_params
 
 
-def _check_metric_inputs(y_true, y_pred):
-    """Coerce metric inputs to 1-D arrays and validate length consistency.
+def _check_labels(arr, name):
+    """Validate a label array and collapse a 2-D one to 1-D hard labels.
 
-    Two-dimensional inputs are interpreted as one-hot encoded labels and
-    collapsed via ``argmax`` along the last axis, except a single-column
-    input, which is raveled to its original values. Centralises the input
-    coercion that every public ordinal metric needs.
-
-    Parameters
-    ----------
-    y_true : array-like of shape (n_samples,) or (n_samples, n_classes)
-        Ground truth labels.
-
-    y_pred : array-like of shape (n_samples,) or (n_samples, n_classes)
-        Predicted labels or class scores.
-
-    Returns
-    -------
-    y_true : ndarray of shape (n_samples,)
-    y_pred : ndarray of shape (n_samples,)
-
-    Raises
-    ------
-    ValueError
-        If ``y_true`` and ``y_pred`` have different lengths.
+    ``dtype=None`` keeps string label sets usable. Validation runs before
+    the ``argmax``, which would otherwise mask a NaN behind its own index
+    and quietly turn a 3-D input into a 2-D one.
     """
-    y_true_arr = np.asarray(y_true)
-    if y_true_arr.ndim > 1:
-        y_true_arr = (
-            y_true_arr.argmax(axis=-1)
-            if y_true_arr.shape[1] > 1
-            else y_true_arr.ravel()
-        )
-    y_pred_arr = np.asarray(y_pred)
-    if y_pred_arr.ndim > 1:
-        y_pred_arr = (
-            y_pred_arr.argmax(axis=-1)
-            if y_pred_arr.shape[1] > 1
-            else y_pred_arr.ravel()
-        )
+    arr = check_array(arr, ensure_2d=False, dtype=None, input_name=name)
+    if arr.ndim > 1:
+        return arr.argmax(axis=-1) if arr.shape[1] > 1 else arr.ravel()
+    return arr
+
+
+def _check_metric_inputs(y_true, y_pred):
+    """Coerce a metric's targets to validated 1-D label arrays.
+
+    Either input may be 1-D labels or 2-D: a one-hot matrix is collapsed
+    via ``argmax`` along the last axis, a single column is raveled to its
+    original values. Raises ``ValueError`` if either is empty, more than
+    2-D, complex, holds a non-finite value, or if the two differ in length.
+    """
+    y_true_arr = _check_labels(y_true, "y_true")
+    y_pred_arr = _check_labels(y_pred, "y_pred")
     check_consistent_length(y_true_arr, y_pred_arr)
     return y_true_arr, y_pred_arr
 
 
 def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
-    """Validate inputs for probabilistic ordinal metrics.
+    """Coerce and validate the inputs of a probabilistic ordinal metric.
 
-    ``y_true`` may be 1-D class labels or a 2-D one-hot matrix; a
-    single-column ``y_true`` is raveled instead of argmaxed. ``y_proba``
-    must be a 2-D matrix coercible to ``float64`` whose rows sum to
-    approximately one.
-
-    Parameters
-    ----------
-    y_true : array-like of shape (n_samples,) or (n_samples, n_classes)
-        Ground truth labels.
-
-    y_proba : array-like of shape (n_samples, n_classes)
-        Predicted class probability matrix.
-
-    sum_atol : float, default=1e-6
-        Absolute tolerance for the row-sum check.
-
-    Returns
-    -------
-    y_true : ndarray of shape (n_samples,)
-    y_proba : ndarray of shape (n_samples, n_classes), dtype float64
-
-    Raises
-    ------
-    ValueError
-        If ``y_true`` and ``y_proba`` have inconsistent length, or if any
-        row of ``y_proba`` does not sum to 1 within ``sum_atol``.
+    ``y_true`` is collapsed as in ``_check_metric_inputs``. ``y_proba``
+    must be a 2-D matrix coercible to ``float64`` whose rows sum to 1
+    within ``sum_atol``. Raises ``ValueError`` on a malformed ``y_true``, a
+    length mismatch, or a row that does not sum to 1.
     """
-    y_true_arr = np.asarray(y_true)
-    if y_true_arr.ndim > 1:
-        y_true_arr = (
-            y_true_arr.argmax(axis=-1)
-            if y_true_arr.shape[1] > 1
-            else y_true_arr.ravel()
-        )
+    y_true_arr = _check_labels(y_true, "y_true")
     y_proba_arr = check_array(
         y_proba, ensure_2d=True, dtype="float64", input_name="y_proba"
     )

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -10,6 +10,7 @@ from sklearn.metrics import (
 )
 from sklearn.utils import check_array, check_consistent_length
 from sklearn.utils._param_validation import validate_params
+from sklearn.utils.validation import _check_sample_weight
 
 
 def _check_labels(arr, name):
@@ -23,6 +24,29 @@ def _check_labels(arr, name):
     if arr.ndim > 1:
         return arr.argmax(axis=-1) if arr.shape[1] > 1 else arr.ravel()
     return arr
+
+
+def _check_metric_weight(y_true, sample_weight):
+    """Validate, reshape, and cast a metric's sample weights to float64.
+
+    Every check is scikit-learn's own, so the messages match any other
+    estimator; the all-zero rejection backports, with its exact message,
+    the one ``_check_sample_weight`` itself performs from scikit-learn
+    1.9. A ``(n, 1)`` weight is raveled first, which scikit-learn refuses.
+    """
+    if sample_weight is None:
+        return None
+    weights = np.asarray(sample_weight)
+    if weights.ndim == 2 and weights.shape[1] == 1:
+        weights = weights.ravel()
+    weights = _check_sample_weight(
+        weights, y_true, dtype=np.float64, ensure_non_negative=True
+    )
+    # scikit-learn < 1.9 accepts an all-zero vector and lets the 0/0
+    # surface as nan downstream
+    if not weights.any():
+        raise ValueError("Sample weights must contain at least one non-zero number.")
+    return weights
 
 
 def _check_metric_inputs(y_true, y_pred):
@@ -182,6 +206,7 @@ def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).mean())
 
 
@@ -234,6 +259,7 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     sum_by_class = cm.sum(axis=1)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -289,6 +315,7 @@ def gmsec(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
     return float(np.sqrt(sensitivities[0] * sensitivities[-1]))
 
@@ -335,6 +362,7 @@ def mean_extreme_sensitivity(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
     return float((sensitivities[0] + sensitivities[-1]) / 2.0)
 
@@ -385,6 +413,7 @@ def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).max())
 
 
@@ -430,6 +459,7 @@ def minimum_sensitivity(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
     return float(np.min(sensitivities))
 
@@ -475,6 +505,7 @@ def mean_zero_one_error(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     return float(1 - np.diagonal(cm).sum() / cm.sum())
 
@@ -569,6 +600,7 @@ def weighted_kappa(y_true, y_pred, *, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     n_class = cm.shape[0]
     costs = np.abs(np.arange(n_class)[:, None] - np.arange(n_class)[None, :])
@@ -693,6 +725,7 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     y_true, y_proba = _check_proba_inputs(y_true, y_proba)
     y_true = y_true.astype(np.intp)
     n_samples, n_classes = y_proba.shape
+    sample_weight = _check_metric_weight(y_true, sample_weight)
 
     in_range = (y_true >= 0) & (y_true < n_classes)
     y_oh = np.zeros_like(y_proba)
@@ -705,8 +738,7 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     per_sample = np.power(y_proba_cum - y_oh_cum, 2).sum(axis=1)
     per_sample[~in_range] = 1.0
 
-    weights = None if sample_weight is None else np.asarray(sample_weight, dtype=float)
-    return float(np.average(per_sample, weights=weights))
+    return float(np.average(per_sample, weights=sample_weight))
 
 
 @validate_params(
@@ -760,6 +792,7 @@ def accuracy_off1_score(y_true, y_pred, *, labels=None, sample_weight=None):
 
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    sample_weight = _check_metric_weight(y_true, sample_weight)
     if labels is None:
         labels = np.unique(y_true)
 

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -63,23 +63,38 @@ def _check_metric_inputs(y_true, y_pred):
     return y_true_arr, y_pred_arr
 
 
-def _check_proba_inputs(y_true, y_proba, *, sum_atol=1e-6):
+def _check_proba_inputs(y_true, y_proba):
     """Coerce and validate the inputs of a probabilistic ordinal metric.
 
     ``y_true`` is collapsed as in ``_check_metric_inputs``. ``y_proba``
-    must be a 2-D matrix coercible to ``float64`` whose rows sum to 1
-    within ``sum_atol``. Raises ``ValueError`` on a malformed ``y_true``, a
-    length mismatch, or a row that does not sum to 1.
+    must be coercible to ``float64`` with every entry in ``[0, 1]``; a 1-D
+    or single-column input is the positive-class probability of a binary
+    problem and is expanded to ``[1 - p, p]``, and rows must then sum to 1
+    within ``atol=1e-6, rtol=0``. Raises ``ValueError`` on a malformed
+    ``y_true``, a length mismatch, an out-of-range entry, or a row that
+    does not sum to 1.
     """
     y_true_arr = _check_labels(y_true, "y_true")
     y_proba_arr = check_array(
-        y_proba, ensure_2d=True, dtype="float64", input_name="y_proba"
+        y_proba, ensure_2d=False, dtype="float64", input_name="y_proba"
     )
+    if y_proba_arr.ndim == 1:
+        y_proba_arr = y_proba_arr.reshape(-1, 1)
     check_consistent_length(y_true_arr, y_proba_arr)
-    row_sums = y_proba_arr.sum(axis=1)
-    if not np.allclose(row_sums, 1.0, atol=sum_atol):
+
+    lo, hi = y_proba_arr.min(), y_proba_arr.max()
+    if lo < 0.0 or hi > 1.0:
         raise ValueError(
-            f"y_proba rows must sum to 1 (atol={sum_atol}); got row-sum "
+            f"y_proba entries must lie in [0, 1]; got range [{lo:.6g}, {hi:.6g}]"
+        )
+
+    if y_proba_arr.shape[1] == 1:
+        y_proba_arr = np.hstack([1.0 - y_proba_arr, y_proba_arr])
+
+    row_sums = y_proba_arr.sum(axis=1)
+    if not np.allclose(row_sums, 1.0, atol=1e-6, rtol=0):
+        raise ValueError(
+            "y_proba rows must sum to 1 (atol=1e-6, rtol=0); got row-sum "
             f"range [{row_sums.min():.6g}, {row_sums.max():.6g}]"
         )
     return y_true_arr, y_proba_arr
@@ -686,10 +701,12 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     y_true : array-like of shape (n_samples,)
         Ground truth labels encoded as 0-based integer indices.
 
-    y_proba : array-like of shape (n_samples, n_classes)
-        Predicted class probability distribution. Each row must sum to
-        approximately ``1`` (``atol=1e-6``); otherwise ``ValueError`` is
-        raised.
+    y_proba : array-like of shape (n_samples, n_classes), (n_samples, 1), or (n_samples,)
+        Predicted class probability distribution. A 1-D input, or a
+        single-column 2-D input, is treated as the positive-class
+        probability of a binary problem and expanded to two columns,
+        ``[1 - p, p]``. Every entry must lie in ``[0, 1]`` and each row
+        must sum to approximately ``1`` (``atol=1e-6, rtol=0``).
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights forwarded to :func:`numpy.average`.

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -66,15 +66,25 @@ def _check_metric_inputs(y_true, y_pred):
 def _check_proba_inputs(y_true, y_proba):
     """Coerce and validate the inputs of a probabilistic ordinal metric.
 
-    ``y_true`` is collapsed as in ``_check_metric_inputs``. ``y_proba``
-    must be coercible to ``float64`` with every entry in ``[0, 1]``; a 1-D
-    or single-column input is the positive-class probability of a binary
-    problem and is expanded to ``[1 - p, p]``, and rows must then sum to 1
-    within ``atol=1e-6, rtol=0``. Raises ``ValueError`` on a malformed
-    ``y_true``, a length mismatch, an out-of-range entry, or a row that
-    does not sum to 1.
+    ``y_true`` is collapsed as in ``_check_metric_inputs``, then required
+    to be integer-valued and returned as ``intp`` 0-based class indices.
+    ``y_proba`` must be coercible to ``float64`` with every entry in
+    ``[0, 1]``; a 1-D or single-column input is the positive-class
+    probability of a binary problem and is expanded to ``[1 - p, p]``, and
+    rows must then sum to 1 within ``atol=1e-6, rtol=0``. Raises
+    ``ValueError`` on a malformed or non-integer ``y_true``, a length
+    mismatch, an out-of-range entry, or a row that does not sum to 1.
     """
     y_true_arr = _check_labels(y_true, "y_true")
+    y_true_idx = y_true_arr.astype(np.intp)
+    # the intp cast truncates, so a non-integral float or object value would
+    # land on a different, valid class; a digit string keeps its parsed value
+    if y_true_arr.dtype.kind in "fO" and not np.array_equal(y_true_idx, y_true_arr):
+        raise ValueError(
+            "y_true must be integer-valued (0-based class indices); got "
+            "non-integer values."
+        )
+    y_true_arr = y_true_idx
     y_proba_arr = check_array(
         y_proba, ensure_2d=False, dtype="float64", input_name="y_proba"
     )
@@ -742,7 +752,6 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
 
     """
     y_true, y_proba = _check_proba_inputs(y_true, y_proba)
-    y_true = y_true.astype(np.intp)
     n_samples, n_classes = y_proba.shape
     sample_weight = _check_metric_weight(y_true, sample_weight)
 

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -714,12 +714,14 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     Returns
     -------
     score : float
-        Ranked probability score; lower is better.
+        Ranked probability score, in the range ``[0, n_classes - 1]``.
+        Lower is better.
 
     Notes
     -----
     Samples whose ``y_true`` falls outside ``[0, n_classes)`` are
-    counted with a per-sample contribution of ``1.0``.
+    counted with a per-sample contribution of ``n_classes - 1``, the
+    worst per-sample loss attainable by any in-range label.
 
     References
     ----------
@@ -753,7 +755,8 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     y_proba_cum = y_proba.cumsum(axis=1)
 
     per_sample = np.power(y_proba_cum - y_oh_cum, 2).sum(axis=1)
-    per_sample[~in_range] = 1.0
+    # n_classes - 1 cumulative steps, each contributing 1 squared
+    per_sample[~in_range] = float(n_classes - 1)
 
     return float(np.average(per_sample, weights=sample_weight))
 

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -23,7 +23,11 @@ from skordinal.metrics import (
     spearmans_rho,
     weighted_kappa,
 )
-from skordinal.metrics._metrics import _check_metric_inputs, _check_proba_inputs
+from skordinal.metrics._metrics import (
+    _check_metric_inputs,
+    _check_metric_weight,
+    _check_proba_inputs,
+)
 
 _WEIGHTED_METRICS = [
     accuracy_off1_score,
@@ -517,6 +521,44 @@ def test_metric_zero_weight_excludes_sample():
     score_unit = accuracy_off1_score(y_t, y_p, sample_weight=unit_w)
     score_zero = accuracy_off1_score(y_t, y_p, sample_weight=zero_w)
     assert score_zero > score_unit
+
+
+@pytest.mark.parametrize(
+    "weight, match",
+    [
+        (np.array([1.0, -1.0, 1.0]), "Negative"),
+        (np.array([1.0, np.inf, 1.0]), "infinity"),
+        (np.array([1.0, np.nan, 1.0]), "NaN"),
+        (np.zeros(3), "non-zero"),
+        (np.ones((3, 2)), "1D array"),
+        (np.ones(2), "expected"),
+    ],
+    ids=["negative", "inf", "nan", "all_zero", "2d", "length_mismatch"],
+)
+def test_check_metric_weight_rejects_invalid(weight, match):
+    """Negative, non-finite, all-zero, 2-D, or mis-length weights all raise."""
+    with pytest.raises(ValueError, match=match):
+        _check_metric_weight(np.array([0, 1, 2]), weight)
+
+
+def test_check_metric_weight_ravels_column_vector():
+    """A (n, 1) weight is raveled to the same result as its 1-D form."""
+    y_t = np.array([0, 1, 2])
+    w_1d = np.array([1.0, 2.0, 3.0])
+    w_col = w_1d.reshape(-1, 1)
+    out_1d = _check_metric_weight(y_t, w_1d)
+    out_col = _check_metric_weight(y_t, w_col)
+    npt.assert_array_equal(out_1d, out_col)
+
+
+@pytest.mark.parametrize("fn", _WEIGHTED_METRICS, ids=_WEIGHTED_METRIC_IDS)
+def test_metric_routes_sample_weight_through_the_check(fn):
+    """Every weighted metric rejects an all-zero sample_weight."""
+    y_t = np.array([0, 1, 2, 1, 0, 2])
+    y_p = np.array([0, 1, 1, 2, 0, 2])
+    x = _Y_PROBA_6 if fn is ranked_probability_score else y_p
+    with pytest.raises(ValueError, match="non-zero"):
+        fn(y_t, x, sample_weight=np.zeros(len(y_t)))
 
 
 @pytest.mark.parametrize(

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -158,6 +158,22 @@ def test_check_metric_inputs_rejects_malformed_shape(y_t, y_p, match):
         _check_metric_inputs(y_t, y_p)
 
 
+@pytest.mark.parametrize(
+    "bad",
+    [
+        np.array([-0.5]),
+        np.array([0.5]),
+        np.array([1.7]),
+        np.array([0.5], dtype=object),
+    ],
+    ids=["negative_frac", "half", "above_one", "object_frac"],
+)
+def test_check_proba_inputs_rejects_non_integer_y_true(bad):
+    """A non-integer y_true raises instead of being truncated to a valid index."""
+    with pytest.raises(ValueError, match="integer-valued"):
+        _check_proba_inputs(bad, np.array([[0.1, 0.2, 0.7]]))
+
+
 def test_check_proba_inputs_2d_and_one_hot():
     """A valid 2-D y_proba passes through; one-hot y_true is collapsed."""
     y_t = np.array([0, 1, 2])

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -422,13 +422,33 @@ def test_ranked_probability_score_expands_binary_proba():
     npt.assert_allclose(ranked_probability_score(y_true, p.reshape(-1, 1)), expected)
 
 
-def test_ranked_probability_score_out_of_range():
-    """y_true values outside [0, n_classes) contribute 1.0 per-sample RPS."""
-    y_true = np.array([0, 5, 1])
-    y_proba = np.array([[1.0, 0.0, 0.0], [0.0, 0.5, 0.5], [0.0, 1.0, 0.0]])
+@pytest.mark.parametrize(
+    "y_true, y_proba, expected",
+    [
+        (
+            np.array([0, 5, 1]),
+            np.array([[1.0, 0.0, 0.0], [0.0, 0.5, 0.5], [0.0, 1.0, 0.0]]),
+            2.0 / 3,
+        ),
+        (np.array([5]), np.array([[0.2, 0.2, 0.2, 0.2, 0.2]]), 4.0),
+    ],
+    ids=["3_classes_mixed", "5_classes_single"],
+)
+def test_ranked_probability_score_out_of_range(y_true, y_proba, expected):
+    """An out-of-range y_true is penalised by n_classes - 1, not a fixed constant."""
     npt.assert_almost_equal(
-        ranked_probability_score(y_true, y_proba), 1.0 / 3, decimal=6
+        ranked_probability_score(y_true, y_proba), expected, decimal=6
     )
+
+
+def test_ranked_probability_score_out_of_range_no_better_than_worst_in_range():
+    """An out-of-range label scores no better than the worst in-range one."""
+    y_proba = np.array([[0.0, 0.0, 1.0]])
+    out_of_range = ranked_probability_score(np.array([9]), y_proba)
+    worst_in_range = max(
+        ranked_probability_score(np.array([label]), y_proba) for label in range(3)
+    )
+    assert out_of_range >= worst_in_range
 
 
 @pytest.mark.parametrize(

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -158,11 +158,8 @@ def test_check_metric_inputs_rejects_malformed_shape(y_t, y_p, match):
         _check_metric_inputs(y_t, y_p)
 
 
-def test_check_proba_inputs_requires_2d_proba():
-    """1-D y_proba raises; valid 2-D passes; one-hot y_true is collapsed."""
-    with pytest.raises(ValueError):
-        _check_proba_inputs(np.array([0, 1]), np.array([0.6, 0.4]))
-
+def test_check_proba_inputs_2d_and_one_hot():
+    """A valid 2-D y_proba passes through; one-hot y_true is collapsed."""
     y_t = np.array([0, 1, 2])
     y_p = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
     out_t, out_p = _check_proba_inputs(y_t, y_p)
@@ -171,6 +168,25 @@ def test_check_proba_inputs_requires_2d_proba():
 
     out_t_oh, _ = _check_proba_inputs(np.eye(3), y_p)
     assert np.array_equal(out_t_oh, y_t)
+
+
+@pytest.mark.parametrize("as_column", [False, True], ids=["1d", "column"])
+def test_check_proba_inputs_expands_binary_proba(as_column):
+    """A 1-D or (n, 1) y_proba is expanded to the [1 - p, p] positive-class columns."""
+    y_t = np.array([0, 1])
+    p = np.array([0.7, 0.3])
+    proba_input = p.reshape(-1, 1) if as_column else p
+    out_t, out_p = _check_proba_inputs(y_t, proba_input)
+    assert np.array_equal(out_t, y_t)
+    npt.assert_allclose(out_p, np.column_stack([1.0 - p, p]))
+
+
+def test_check_proba_inputs_rejects_out_of_range_entries():
+    """A y_proba entry outside [0, 1] raises, even if rows still sum to 1."""
+    y_t = np.array([0, 1, 2])
+    y_p = np.array([[1.4, -0.4, 0.0], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        _check_proba_inputs(y_t, y_p)
 
 
 def test_check_proba_inputs_column_vector_ravel():
@@ -221,17 +237,24 @@ def test_correlation_metrics_reject_invalid_input(fn, y_t, y_p, match):
 def test_check_proba_inputs_rejects_unnormalised_rows():
     """Rows not summing to 1 raise ValueError mentioning row-sum."""
     y_t = np.array([0, 1, 2])
-    y_p_bad = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]]) * 2
+    y_p_bad = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]]) * 0.5
     with pytest.raises(ValueError, match="row"):
         _check_proba_inputs(y_t, y_p_bad)
 
 
-def test_check_proba_inputs_accepts_within_atol():
-    """Rows summing to 1 within atol are accepted without error."""
+@pytest.mark.parametrize(
+    "delta, raises", [(5e-7, False), (5e-6, True)], ids=["within_atol", "rtol_zero"]
+)
+def test_check_proba_inputs_row_sum_atol_boundary(delta, raises):
+    """A row-sum delta is accepted within atol and rejected past it, rtol being 0."""
     y_t = np.array([0, 1, 2])
     y_p = np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]])
-    y_p[0, 0] += 5e-7
-    _check_proba_inputs(y_t, y_p)
+    y_p[0, 0] += delta
+    if raises:
+        with pytest.raises(ValueError, match="row"):
+            _check_proba_inputs(y_t, y_p)
+    else:
+        _check_proba_inputs(y_t, y_p)
 
 
 def test_accuracy_score():
@@ -388,6 +411,15 @@ def test_ranked_probability_score():
     npt.assert_almost_equal(
         ranked_probability_score(y_true, y_pred), 0.506875, decimal=6
     )
+
+
+def test_ranked_probability_score_expands_binary_proba():
+    """1-D and (n, 1) y_proba give the same RPS as the explicit two-column form."""
+    y_true = np.array([1, 0])
+    p = np.array([0.8, 0.3])
+    expected = ranked_probability_score(y_true, np.column_stack([1.0 - p, p]))
+    npt.assert_allclose(ranked_probability_score(y_true, p), expected)
+    npt.assert_allclose(ranked_probability_score(y_true, p.reshape(-1, 1)), expected)
 
 
 def test_ranked_probability_score_out_of_range():

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -85,6 +85,75 @@ def test_check_metric_inputs_length_mismatch_raises():
         _check_metric_inputs([0, 1, 2], [0, 1])
 
 
+@pytest.mark.parametrize(
+    "value, match", [(np.nan, "NaN"), (np.inf, "infinity")], ids=["nan", "inf"]
+)
+@pytest.mark.parametrize("which", ["y_true", "y_pred"])
+@pytest.mark.parametrize("shape", ["1d", "one_hot"])
+def test_check_metric_inputs_rejects_non_finite(value, match, which, shape):
+    """A non-finite value in either input raises before the argmax collapse hides it."""
+    y_t = np.array([0.0, 1.0, 2.0])
+    y_p = np.array([0.0, 1.0, 1.0])
+    if shape == "one_hot":
+        y_t = np.eye(3)
+        y_p = np.eye(3)[[0, 1, 1]]
+    arr = y_t if which == "y_true" else y_p
+    arr = arr.copy()
+    if arr.ndim == 1:
+        arr[0] = value
+    else:
+        arr[0, 0] = value
+    if which == "y_true":
+        y_t = arr
+    else:
+        y_p = arr
+    with pytest.raises(ValueError, match=match):
+        _check_metric_inputs(y_t, y_p)
+
+
+@pytest.mark.parametrize(
+    "y_t, match",
+    [
+        (np.array([0, 1, 2], dtype=np.int64), None),
+        (np.array([0, 1, 10**400], dtype=object), None),
+        (np.array(["low", "mid", "high"]), None),
+        (np.array([0, 1, np.nan], dtype=object), "NaN"),
+        (np.array([0.0, np.nan, "x"], dtype=object), "NaN"),
+        (np.array([0 + 0j, 1 + 0j, 2 + 0j]), "Complex"),
+    ],
+    ids=[
+        "int64",
+        "object_huge_int",
+        "strings",
+        "object_nan",
+        "object_mixed",
+        "complex",
+    ],
+)
+def test_check_metric_inputs_dtype_handling(y_t, match):
+    """Integer, huge-int and string labels pass; NaN and complex raise."""
+    y_p = np.array([0, 1, 1])
+    if match is None:
+        _check_metric_inputs(y_t, y_p)
+    else:
+        with pytest.raises(ValueError, match=match):
+            _check_metric_inputs(y_t, y_p)
+
+
+@pytest.mark.parametrize(
+    "y_t, y_p, match",
+    [
+        (np.zeros((2, 2, 3)), np.zeros((2, 2, 3)), "dim 3"),
+        (np.array([]), np.array([]), "0 sample"),
+    ],
+    ids=["3d", "empty"],
+)
+def test_check_metric_inputs_rejects_malformed_shape(y_t, y_p, match):
+    """A 3-D or empty input raises instead of collapsing to a plausible score."""
+    with pytest.raises(ValueError, match=match):
+        _check_metric_inputs(y_t, y_p)
+
+
 def test_check_proba_inputs_requires_2d_proba():
     """1-D y_proba raises; valid 2-D passes; one-hot y_true is collapsed."""
     with pytest.raises(ValueError):
@@ -107,6 +176,42 @@ def test_check_proba_inputs_column_vector_ravel():
     out_t, out_p = _check_proba_inputs(y_t_col, y_p)
     assert np.array_equal(out_t, np.array([0, 1, 2]))
     npt.assert_allclose(out_p, y_p)
+
+
+@pytest.mark.parametrize(
+    "y_t, y_p, match",
+    [
+        (
+            np.array([0.0, np.nan, 2.0]),
+            np.array([[0.7, 0.2, 0.1], [0.1, 0.6, 0.3], [0.2, 0.3, 0.5]]),
+            "NaN",
+        ),
+        (np.zeros((2, 2, 3)), np.full((2, 2), 0.5), "dim 3"),
+    ],
+    ids=["nan", "3d"],
+)
+def test_check_proba_inputs_routes_y_true_through_check_labels(y_t, y_p, match):
+    """The proba gateway rejects a malformed y_true before the argmax collapse."""
+    with pytest.raises(ValueError, match=match):
+        _check_proba_inputs(y_t, y_p)
+
+
+@pytest.mark.parametrize(
+    "fn", [kendalls_tau, spearmans_rho], ids=["kendalls_tau", "spearmans_rho"]
+)
+@pytest.mark.parametrize(
+    "y_t, y_p, match",
+    [
+        (np.array([0.0, 1.0, 2.0]), np.array([0.0, np.inf, 2.0]), "infinity"),
+        (np.zeros((2, 2, 3)), np.zeros((2, 2, 3)), "dim 3"),
+        (np.array([]), np.array([]), "0 sample"),
+    ],
+    ids=["inf", "3d", "empty"],
+)
+def test_correlation_metrics_reject_invalid_input(fn, y_t, y_p, match):
+    """kendalls_tau and spearmans_rho reject inf, 3-D and empty input."""
+    with pytest.raises(ValueError, match=match):
+        fn(y_t, y_p)
 
 
 def test_check_proba_inputs_rejects_unnormalised_rows():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Hardens `_check_metric_inputs` and `_check_proba_inputs`: both now validate their inputs through scikit-learn's `check_array`, so `argmax` can no longer mask a NaN row.

`sample_weight` is now validated for all 10 weighted metrics: negative, non-finite, or all-zero weights raise instead of silently producing a wrong or `nan` score.

`_check_proba_inputs` also rejects `y_proba` values outside `[0, 1]` and requires `y_true` to be integer-valued.

Behaviour change: `ranked_probability_score` now penalizes an out-of-range label with `n_classes - 1` instead of a fixed `1.0`, which could score better than a valid label.