### PR TITLE
FIX: Validate resample_id and wire the resume path

### DIFF
--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -84,6 +84,10 @@ class Benchmark:
         ``load_partitions`` call in ``run`` shares the same partitioning
         scheme.
 
+    overwrite : bool, default=False
+        If ``False``, resamples already saved are skipped, making runs
+        resumable. ``True`` recomputes every resample.
+
     verbose : bool, default=True
         If ``True``, progress messages are printed to stdout.
 
@@ -123,6 +127,7 @@ class Benchmark:
         n_jobs: int = 1,
         input_preprocessing: str | None = None,
         random_state: int | None = 0,
+        overwrite: bool = False,
         verbose: bool = True,
     ) -> None:
         if not models:
@@ -168,6 +173,7 @@ class Benchmark:
         if not isinstance(random_state, Integral):
             random_state = int(check_random_state(random_state).randint(2**31 - 1))
         self.random_state = random_state
+        self.overwrite = overwrite
         self.verbose = verbose
 
     @classmethod
@@ -225,7 +231,8 @@ class Benchmark:
         optimal values among the hyper-parameters to compare from.
 
         Uses the built model to get train and test metrics, storing all the
-        information into a Results object.
+        information into a Results object. Resamples already saved are
+        skipped unless ``overwrite`` is ``True``.
 
         Raises
         ------
@@ -269,6 +276,13 @@ class Benchmark:
                     resamples=self.resamples,
                     random_state=self.random_state,
                 ):
+                    if not self.overwrite and self._results.exists(
+                        label, dataset_name, b.resample_id
+                    ):
+                        if self.verbose:
+                            print("  Skipping resample", b.resample_id)
+                        continue
+
                     if self.verbose:
                         print("  Running resample", b.resample_id)
 

--- a/skordinal/experiments/_io.py
+++ b/skordinal/experiments/_io.py
@@ -24,6 +24,13 @@ def _check_path_component(name: Any, what: str) -> None:
         raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
 
 
+def _check_resample_id(resample_id: Any) -> None:
+    """Reject a resample id that is neither int-like nor a plain path component."""
+    if isinstance(resample_id, (int, np.integer)):
+        return
+    _check_path_component(str(resample_id), "resample_id")
+
+
 def _ensure_parent(path: Path) -> None:
     """Create path's parent directory, wrapping OSError with the failing path."""
     try:

--- a/skordinal/experiments/_recipes.py
+++ b/skordinal/experiments/_recipes.py
@@ -21,6 +21,7 @@ _OPTIONAL_KEYS: frozenset[str] = frozenset(
         "n_jobs",
         "input_preprocessing",
         "random_state",
+        "overwrite",
         "verbose",
     }
 )

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -17,6 +17,7 @@ from ._io import (
     _atomic_dump,
     _atomic_write,
     _check_path_component,
+    _check_resample_id,
     _format_proba_column,
     _sweep_orphaned_temp_files,
 )
@@ -242,15 +243,15 @@ class Results:
             a string.
 
         ValueError
-            If ``result.classifier_name`` or ``result.dataset_name`` is
-            empty, a dot segment, or contains a path separator, if
-            ``result`` lacks the true labels required for the ``Target``
-            column (``train_true_y``, or ``test_true_y`` when test
-            predictions are present), if a true or predicted label is not
-            one of ``best_model.classes_``, or if a probability matrix does
-            not hold one row per sample and one column per class. Files
-            already written for a preceding split are left in place;
-            nothing else is recorded for the partition.
+            If ``result.classifier_name``, ``result.dataset_name`` or a
+            non-int ``result.resample_id`` is empty, a dot segment, or
+            contains a path separator, if ``result`` lacks the true labels
+            required for the ``Target`` column (``train_true_y``, or
+            ``test_true_y`` when test predictions are present), if a true
+            or predicted label is not one of ``best_model.classes_``, or if
+            a probability matrix does not hold one row per sample and one
+            column per class. Files already written for a preceding split
+            are left in place; nothing else is recorded for the partition.
 
         OSError
             If a stale artefact cannot be removed or the folder cannot be
@@ -273,6 +274,7 @@ class Results:
                 "'result.test_true_y' is required to write the 'Target' "
                 "column of the test predictions file."
             )
+        _check_resample_id(result.resample_id)
 
         base_dir = self._pair_dir(result.classifier_name, result.dataset_name)
         seed_dir, model_path = self._resample_paths(base_dir, result.resample_id)

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -223,6 +224,8 @@ class Results:
         The report row is written last and acts as the commit marker read
         by ``exists``: a save interrupted at any earlier point leaves no
         row, so a rerun detects the partition as missing and rewrites it.
+        Re-saving a partition first deletes its previous seed directory and
+        model artefact, so no stale file outlives the row describing it.
 
         Parameters
         ----------
@@ -250,7 +253,8 @@ class Results:
             nothing else is recorded for the partition.
 
         OSError
-            If the folder cannot be created.
+            If a stale artefact cannot be removed or the folder cannot be
+            created.
 
         Examples
         --------
@@ -271,13 +275,14 @@ class Results:
             )
 
         base_dir = self._pair_dir(result.classifier_name, result.dataset_name)
-        seed_dir = base_dir / "predictions_by_seed" / f"seed_{result.resample_id}"
-        model_path = base_dir / "models" / f"{result.resample_id}.joblib"
+        seed_dir, model_path = self._resample_paths(base_dir, result.resample_id)
         # Clear any temp file left by a prior crash before writing new ones
         _sweep_orphaned_temp_files(base_dir)
         # Drop this resample's committed row so a crash mid-write cannot
         # leave a report row describing predictions no longer on disk
         self._uncommit_report_row(base_dir, result.resample_id)
+        # Must run before the writes below recreate what it deletes
+        self._remove_stale_artefacts(base_dir, result.resample_id)
 
         classes = np.asarray(result.best_model.classes_)
         _write_split_files(
@@ -315,6 +320,23 @@ class Results:
         _check_path_component(classifier_name, "classifier_name")
         _check_path_component(dataset_name, "dataset_name")
         return self._experiment_folder / classifier_name / dataset_name
+
+    def _resample_paths(self, base: Path, resample_id: int) -> tuple[Path, Path]:
+        """Return this resample's predictions directory and model artefact."""
+        return (
+            base / "predictions_by_seed" / f"seed_{resample_id}",
+            base / "models" / f"{resample_id}.joblib",
+        )
+
+    def _remove_stale_artefacts(self, base_dir: Path, resample_id: int) -> None:
+        """Delete this resample's seed directory and model from a prior run."""
+        seed_dir, model_path = self._resample_paths(base_dir, resample_id)
+        try:
+            if seed_dir.is_dir():
+                shutil.rmtree(seed_dir)
+            model_path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise OSError(f"Could not remove stale results under {base_dir}.") from exc
 
     def _uncommit_report_row(self, base_dir: Path, resample_id: int) -> None:
         """Drop this resample's row from report.csv before rewriting it."""

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -270,12 +270,9 @@ class Results:
                 "column of the test predictions file."
             )
 
-        base_dir, models_dir, seed_dir = self._ensure_dirs(
-            result.classifier_name,
-            result.dataset_name,
-            result.resample_id,
-            save_model=save_model,
-        )
+        base_dir = self._pair_dir(result.classifier_name, result.dataset_name)
+        seed_dir = base_dir / "predictions_by_seed" / f"seed_{result.resample_id}"
+        model_path = base_dir / "models" / f"{result.resample_id}.joblib"
         # Clear any temp file left by a prior crash before writing new ones
         _sweep_orphaned_temp_files(base_dir)
         # Drop this resample's committed row so a crash mid-write cannot
@@ -307,7 +304,7 @@ class Results:
             )
 
         if save_model:
-            _atomic_dump(models_dir / f"{result.resample_id}.joblib", result.best_model)
+            _atomic_dump(model_path, result.best_model)
 
         self._upsert_hyperparameters(result, base_dir)
         # Write the report row last: it is the commit marker for exists()
@@ -318,28 +315,6 @@ class Results:
         _check_path_component(classifier_name, "classifier_name")
         _check_path_component(dataset_name, "dataset_name")
         return self._experiment_folder / classifier_name / dataset_name
-
-    def _ensure_dirs(
-        self,
-        classifier_name: str,
-        dataset_name: str,
-        resample_id: int,
-        *,
-        save_model: bool,
-    ) -> tuple[Path, Path, Path]:
-        """Create required sub-directories and return their paths."""
-        base = self._pair_dir(classifier_name, dataset_name)
-        seed_dir = base / "predictions_by_seed" / f"seed_{resample_id}"
-        models_dir = base / "models"
-        try:
-            seed_dir.mkdir(parents=True, exist_ok=True)
-            if save_model:
-                models_dir.mkdir(exist_ok=True)
-        except OSError:
-            raise OSError(
-                f"Could not create folder {base} (or subfolders) to store results."
-            )
-        return base, models_dir, seed_dir
 
     def _uncommit_report_row(self, base_dir: Path, resample_id: int) -> None:
         """Drop this resample's row from report.csv before rewriting it."""

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -205,9 +205,10 @@ class Results:
     file's ``Target`` and ``Prediction`` columns.
     ``hyperparameter_configuration.csv`` records the best parameters per
     seed with the ``clf__`` pipeline prefix stripped; its ``Seed`` column
-    always holds the resample identifier. The root-level
-    ``train_summary.csv`` and ``test_summary.csv`` files are written by
-    ``save_summary`` and are absent until it is called.
+    always holds the resample identifier. ``report.csv`` is indexed by
+    ``resample_id``, in numeric order. The root-level ``train_summary.csv``
+    and ``test_summary.csv`` files are written by ``save_summary`` and are
+    absent until it is called.
 
     """
 
@@ -354,19 +355,24 @@ class Results:
             # Remove the commit marker entirely so exists() reports False
             csv_path.unlink()
             return
-        _atomic_write(csv_path, df.to_csv())
+        _atomic_write(csv_path, df.to_csv(index_label="resample_id"))
 
     def _append_report_row(self, result: ExperimentResult, base_dir: Path) -> None:
         """Append one metrics row to report.csv."""
         row: dict[str, Any] = {**result.train_metrics, **result.test_metrics}
 
         csv_path = base_dir / "report.csv"
-        df = pd.DataFrame([row], index=pd.Index([result.resample_id], dtype=str))
+        df = pd.DataFrame([row], index=pd.Index([str(result.resample_id)]))
         if csv_path.is_file():
             existing = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")
             existing.index = existing.index.astype(str)
             df = pd.concat([existing, df])
-        _atomic_write(csv_path, df.to_csv())
+        try:
+            df = df.sort_index(key=lambda index: index.map(int))
+        except ValueError:
+            # Fall back to lexicographic order for non-integer ids
+            df = df.sort_index()
+        _atomic_write(csv_path, df.to_csv(index_label="resample_id"))
 
     def _upsert_hyperparameters(self, result: ExperimentResult, base_dir: Path) -> None:
         """Upsert one seed's row in the hyperparameter configuration CSV."""
@@ -417,7 +423,7 @@ class Results:
         self,
         classifier_name: str,
         dataset_name: str,
-        resample_id: str,
+        resample_id: int | str,
     ) -> bool:
         """Return whether a partition result has already been saved.
 
@@ -429,7 +435,7 @@ class Results:
         dataset_name : str
             Name of the dataset.
 
-        resample_id : str
+        resample_id : int or str
             Partition identifier (the CSV row index).
 
         Returns
@@ -444,19 +450,21 @@ class Results:
             If ``classifier_name`` or ``dataset_name`` is not a string.
 
         ValueError
-            If ``classifier_name`` or ``dataset_name`` is empty, a dot
-            segment, or contains a path separator.
+            If ``classifier_name``, ``dataset_name`` or a non-int
+            ``resample_id`` is empty, a dot segment, or contains a path
+            separator.
 
         Examples
         --------
         >>> from skordinal.experiments import Results
         >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
-        >>> results.exists("SVC", "toy", "0")  # doctest: +SKIP
+        >>> results.exists("SVC", "toy", 0)  # doctest: +SKIP
         False
 
         """
+        _check_resample_id(resample_id)
         csv_path = self._pair_dir(classifier_name, dataset_name) / "report.csv"
         if not csv_path.is_file():
             return False
         df = pd.read_csv(csv_path, index_col=0)
-        return resample_id in df.index.astype(str)
+        return str(resample_id) in df.index.astype(str)

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -9,6 +9,7 @@ import pytest
 from sklearn.svm import SVC
 
 from skordinal.experiments import Benchmark, ModelConfig
+from skordinal.experiments._experiment import Experiment
 
 _SVC_CONF: dict[str, ModelConfig] = {"SVM": ModelConfig(SVC(), param_grid={"C": [1]})}
 _MINIMAL_CONF: dict[str, ModelConfig] = {"cfg": ModelConfig(SVC())}
@@ -264,6 +265,34 @@ def test_run_and_summarize_bundled_dataset(tmp_path):
     assert "SVM" in summary["classifier"].values
     assert "mean_absolute_error_test_mean" in summary.columns
     assert "n_completed" in summary.columns
+
+
+@pytest.mark.parametrize("overwrite, reruns", [(False, 0), (True, 3)])
+def test_run_overwrite_controls_rerun(tmp_path, monkeypatch, overwrite, reruns):
+    """A rerun recomputes already-saved resamples only when overwrite is True."""
+    kwargs = dict(
+        models=_SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path / "runs",
+        resamples=3,
+        cv=2,
+        verbose=False,
+        random_state=0,
+        overwrite=overwrite,
+    )
+    Benchmark(**kwargs).run()
+
+    calls = []
+    original = Experiment.run
+
+    def _counting_run(self, *args, **kw):
+        calls.append(1)
+        return original(self, *args, **kw)
+
+    monkeypatch.setattr(Experiment, "run", _counting_run)
+    Benchmark(**kwargs).run()
+    assert len(calls) == reruns
 
 
 def test_run_resamples_count_matches_requested(tmp_path):

--- a/skordinal/experiments/tests/test_io.py
+++ b/skordinal/experiments/tests/test_io.py
@@ -13,6 +13,7 @@ from skordinal.experiments._io import (
     _atomic_dump,
     _atomic_write,
     _check_path_component,
+    _check_resample_id,
     _ensure_parent,
     _format_proba_column,
     _parse_proba_column,
@@ -121,6 +122,19 @@ def test_check_path_component_rejects_non_str(bad):
     """_check_path_component rejects a non-string component."""
     with pytest.raises(TypeError):
         _check_path_component(bad, "classifier_name")
+
+
+@pytest.mark.parametrize("good", [0, -1, np.int64(3), "0"])
+def test_check_resample_id_accepts_int_like(good):
+    """_check_resample_id passes through ints, numpy ints and int-like strings."""
+    _check_resample_id(good)
+
+
+@pytest.mark.parametrize("bad", ["../../../../tmp/evil", "..", "", "a/b"])
+def test_check_resample_id_rejects_traversal(bad):
+    """_check_resample_id rejects a non-int id that fails path validation."""
+    with pytest.raises(ValueError, match="resample_id"):
+        _check_resample_id(bad)
 
 
 def test_sweep_orphaned_temp_files_ignores_missing_dir(tmp_path):

--- a/skordinal/experiments/tests/test_recipes.py
+++ b/skordinal/experiments/tests/test_recipes.py
@@ -67,6 +67,7 @@ def test_validate_recipe_all_optional_keys_accepted():
         "n_jobs": 1,
         "input_preprocessing": "std",
         "random_state": 0,
+        "overwrite": True,
         "verbose": False,
     }
     validate_recipe(full)

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -578,6 +578,49 @@ def test_exists(tmp_path):
     assert r.exists("SVC", "toy", "1") is False
 
 
+def test_save_removes_stale_artefacts(tmp_path):
+    """Re-saving without a test split drops the prior run's test files and model."""
+    r = Results(tmp_path)
+    r.save(
+        _make_result(
+            partition=0,
+            dataset="ds",
+            configuration="clf",
+            best_params={},
+            train_metrics={"mae_train": 0.1},
+            test_metrics={"mae_test": 0.1},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=True,
+    )
+    seed_dir = tmp_path / "clf" / "ds" / "predictions_by_seed" / "seed_0"
+    model_path = tmp_path / "clf" / "ds" / "models" / "0.joblib"
+    assert (seed_dir / "test_predictions.csv").is_file()
+    assert (seed_dir / "test_confusion_matrix.txt").is_file()
+    assert model_path.is_file()
+
+    r.save(
+        _make_result(
+            partition=0,
+            dataset="ds",
+            configuration="clf",
+            best_params={},
+            train_metrics={"mae_train": 0.2},
+            test_metrics={},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=None,
+        ),
+        save_model=False,
+    )
+    assert not (seed_dir / "test_predictions.csv").exists()
+    assert not (seed_dir / "test_confusion_matrix.txt").exists()
+    assert not model_path.exists()
+    assert (seed_dir / "train_predictions.csv").is_file()
+    df = pd.read_csv(tmp_path / "clf" / "ds" / "report.csv", index_col=0)
+    assert df.shape[0] == 1
+
+
 def test_save_rejects_traversal_before_writing(tmp_path):
     """save raises on a traversal component and writes nothing."""
     result = _make_result(
@@ -734,3 +777,30 @@ def test_stale_report_row_uncommitted_on_crash_resave(tmp_path, monkeypatch):
     monkeypatch.undo()
     r.save(_make_result(**kwargs), save_model=False)
     assert r.exists("clf", "ds", "0") is True
+
+
+def test_resave_crash_before_uncommit_leaves_prior_run_intact(tmp_path, monkeypatch):
+    """A re-save that crashes at the uncommit deletes nothing from the prior run."""
+    r = Results(tmp_path)
+    kwargs = dict(
+        partition=0,
+        dataset="ds",
+        configuration="clf",
+        best_params={},
+        train_metrics={"mae_train": 0.1},
+        test_metrics={"mae_test": 0.1},
+        train_predicted_y=np.array([1]),
+        test_predicted_y=np.array([1]),
+    )
+    r.save(_make_result(**kwargs), save_model=False)
+    monkeypatch.setattr(
+        Results,
+        "_uncommit_report_row",
+        lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("crash")),
+    )
+    with pytest.raises(RuntimeError):
+        r.save(_make_result(**kwargs), save_model=False)
+    # The committed row must never outlive the files it describes
+    assert r.exists("clf", "ds", "0") is True
+    seed = tmp_path / "clf" / "ds" / "predictions_by_seed" / "seed_0"
+    assert (seed / "train_predictions.csv").is_file()

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -576,6 +576,68 @@ def test_exists(tmp_path):
     )
     assert r.exists("SVC", "toy", "0") is True
     assert r.exists("SVC", "toy", "1") is False
+    # An int id must match the stringified CSV index just like its str form
+    assert r.exists("SVC", "toy", 0) is True
+    assert r.exists("SVC", "toy", 1) is False
+
+
+def test_exists_rejects_traversal_resample_id(tmp_path):
+    """exists() raises on a traversal-capable resample_id."""
+    with pytest.raises(ValueError, match="resample_id"):
+        Results(tmp_path).exists("SVC", "toy", "../../evil")
+
+
+def test_report_csv_index_label_and_numeric_order(tmp_path):
+    """report.csv's index column is labelled and rows sort numerically."""
+    r = Results(tmp_path)
+    for partition in (10, 2, 1):
+        r.save(
+            _make_result(
+                partition=partition,
+                dataset="ds",
+                configuration="clf",
+                best_params={},
+                train_metrics={"mae_train": 0.1},
+                test_metrics={"mae_test": 0.1},
+                train_predicted_y=np.array([1]),
+                test_predicted_y=np.array([1]),
+            ),
+            save_model=False,
+        )
+    csv_path = tmp_path / "clf" / "ds" / "report.csv"
+    assert csv_path.read_text().splitlines()[0].split(",")[0] == "resample_id"
+    df = pd.read_csv(csv_path, index_col=0)
+    assert list(df.index) == [1, 2, 10]
+
+
+def test_report_row_sort_preserves_pre_existing_duplicates(tmp_path):
+    """Sorting a report that already holds a duplicate row must not multiply it."""
+    _make_pair_csv(
+        tmp_path,
+        "clf",
+        "ds",
+        [{"mae_test": 0.1}, {"mae_test": 0.2}],
+    )
+    csv_path = tmp_path / "clf" / "ds" / "report.csv"
+    # Rewrite the index so row "1" is duplicated, as an older writer could leave it
+    df = pd.read_csv(csv_path, index_col=0)
+    df.index = pd.Index(["1", "1"])
+    df.to_csv(csv_path)
+
+    Results(tmp_path).save(
+        _make_result(
+            partition=2,
+            dataset="ds",
+            configuration="clf",
+            best_params={},
+            train_metrics={"mae_train": 0.3},
+            test_metrics={"mae_test": 0.3},
+            train_predicted_y=np.array([1]),
+            test_predicted_y=np.array([1]),
+        ),
+        save_model=False,
+    )
+    assert pd.read_csv(csv_path, index_col=0).shape[0] == 3
 
 
 def test_save_removes_stale_artefacts(tmp_path):

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -621,19 +621,29 @@ def test_save_removes_stale_artefacts(tmp_path):
     assert df.shape[0] == 1
 
 
-def test_save_rejects_traversal_before_writing(tmp_path):
-    """save raises on a traversal component and writes nothing."""
+@pytest.mark.parametrize(
+    "overrides, match",
+    [
+        ({"dataset": ".."}, "dataset_name"),
+        ({"partition": "../../evil"}, "resample_id"),
+    ],
+)
+def test_save_rejects_traversal_before_writing(tmp_path, overrides, match):
+    """save raises on a traversal name or resample id and writes nothing."""
     result = _make_result(
-        partition=0,
-        dataset="..",
-        configuration="clf",
-        best_params={},
-        train_metrics={"mae_train": 0.1},
-        test_metrics={"mae_test": 0.1},
-        train_predicted_y=np.array([1]),
-        test_predicted_y=np.array([1]),
+        **{
+            "partition": 0,
+            "dataset": "ds",
+            "configuration": "clf",
+            "best_params": {},
+            "train_metrics": {"mae_train": 0.1},
+            "test_metrics": {"mae_test": 0.1},
+            "train_predicted_y": np.array([1]),
+            "test_predicted_y": np.array([1]),
+            **overrides,
+        }
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         Results(tmp_path).save(result, save_model=False)
     assert list(tmp_path.iterdir()) == []
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Re-saving a resample left the prior run's seed directory and model artefact on disk under the fresh report row. `Results.save` now deletes them first. `resample_id` was also interpolated into filesystem paths without validation, letting a non-integer id escape the results tree. It is now validated before use.

`Results.exists` never matched an integer `resample_id` against the CSV index, so it always returned `False` for int input. It now converts the id first. `Benchmark.run` uses it to skip resamples already saved, controlled by a new `overwrite` flag, default `False`.

#### Any other comments?

`overwrite` changes `Benchmark.run`'s default behaviour: a rerun now skips resamples already saved instead of recomputing them. Pass `overwrite=True` to restore the previous behaviour.