### PR TITLE
REF: Slim _loaders.py to bundled wrappers over load_dataset

### DIFF
--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -125,6 +125,11 @@ def _read_csv_any(path):
     return X, y, feature_names, header_class_names
 
 
+def _bundled_csv_path(stem):
+    """Return the filesystem path of a bundled dataset CSV."""
+    return Path(str(resources.files(DATA_MODULE))) / f"{stem}.csv"
+
+
 def _resolve_csv_path(name, data_home=None):
     """Resolve a dataset name or path to its CSV file path."""
     name_str = str(name)
@@ -133,9 +138,7 @@ def _resolve_csv_path(name, data_home=None):
         return Path(data_home) / fname, None
     if Path(name_str).is_file():
         return Path(name_str), None
-    stem = name_str.removesuffix(".csv")
-    bundled_dir = Path(str(resources.files(DATA_MODULE)))
-    return bundled_dir / f"{stem}.csv", DATA_MODULE
+    return _bundled_csv_path(name_str.removesuffix(".csv")), DATA_MODULE
 
 
 def _load_descr(csv_path, data_module):
@@ -309,24 +312,31 @@ def clear_data_home(data_home=None) -> None:
     shutil.rmtree(get_data_home(data_home))
 
 
-def _load_bundled(stem, feature_names, *, caller_name, return_X_y, as_frame):
-    """Load a bundled dataset CSV under a fixed set of column names.
-
-    Resolves against the bundled data module only, so a same-named file in
-    the working directory cannot shadow a shipped dataset the way it can in
-    ``load_dataset``.
-    """
-    path = Path(str(resources.files(DATA_MODULE))) / f"{stem}.csv"
-    # The metadata header carries no column names, so _read_csv_any generates
-    # x0..xd-1 and the caller supplies the real ones instead
-    data, target, _, header_class_names = _read_csv_any(path)
-    if len(feature_names) != data.shape[1]:
+def _bunch_from_csv(
+    path, data_module, *, caller_name, feature_names=None, return_X_y, as_frame
+):
+    """Build the loader return value from a resolved CSV path."""
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+    data, target, csv_feature_names, header_class_names = _read_csv_any(path)
+    # A caller-supplied list overrides the generated x0..xd-1 names, since
+    # the metadata header carries no column names
+    if feature_names is None:
+        feature_names = csv_feature_names
+    elif len(feature_names) != data.shape[1]:
         raise ValueError(
             f"{caller_name}: {len(feature_names)} feature name(s) declared, "
             f"but {path.name} has {data.shape[1]} feature column(s)."
         )
-    feature_names = list(feature_names)
     target_names = _resolve_target_names(header_class_names, target)
+    n_classes = len(target_names)
+
+    descr = _load_descr(path, data_module)
+    if descr is None:
+        descr = (
+            f"Dataset '{path.stem}': {data.shape[0]} samples, "
+            f"{data.shape[1]} features, {n_classes} classes."
+        )
 
     frame = None
     if as_frame:
@@ -341,10 +351,24 @@ def _load_bundled(stem, feature_names, *, caller_name, return_X_y, as_frame):
         frame=frame,
         feature_names=feature_names,
         target_names=target_names,
-        n_classes=len(target_names),
-        DESCR=_load_descr(path, DATA_MODULE),
+        n_classes=n_classes,
+        DESCR=descr,
         filename=path.name,
-        data_module=DATA_MODULE,
+        data_module=data_module,
+    )
+
+
+def _load_bundled(stem, feature_names, *, return_X_y, as_frame):
+    """Load a bundled dataset CSV under a fixed set of column names."""
+    # Resolve against the bundled data module only, so a same-named file in
+    # the working directory cannot shadow a shipped dataset
+    return _bunch_from_csv(
+        _bundled_csv_path(stem),
+        DATA_MODULE,
+        caller_name=f"load_{stem}",
+        feature_names=feature_names,
+        return_X_y=return_X_y,
+        as_frame=as_frame,
     )
 
 
@@ -444,38 +468,12 @@ def load_dataset(name, *, data_home=None, return_X_y=False, as_frame=False):
     (1000, 4)
     """
     path, data_module_value = _resolve_csv_path(name, data_home)
-    if not path.exists():
-        raise FileNotFoundError(f"Dataset file not found: {path}")
-
-    data, target, feature_names, header_class_names = _read_csv_any(path)
-    target_names = _resolve_target_names(header_class_names, target)
-    n_classes = len(target_names)
-
-    descr = _load_descr(path, data_module_value)
-    if descr is None:
-        descr = (
-            f"Dataset '{path.stem}': {data.shape[0]} samples, "
-            f"{data.shape[1]} features, {n_classes} classes."
-        )
-
-    filename = path.name
-    frame = None
-    if as_frame:
-        frame, data, target = _convert_data_dataframe(
-            "load_dataset", data, target, feature_names, ["target"]
-        )
-    if return_X_y:
-        return data, target
-    return Bunch(
-        data=data,
-        target=target,
-        frame=frame,
-        feature_names=feature_names,
-        target_names=target_names,
-        n_classes=n_classes,
-        DESCR=descr,
-        filename=filename,
-        data_module=data_module_value,
+    return _bunch_from_csv(
+        path,
+        data_module_value,
+        caller_name="load_dataset",
+        return_X_y=return_X_y,
+        as_frame=as_frame,
     )
 
 

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -309,6 +309,45 @@ def clear_data_home(data_home=None) -> None:
     shutil.rmtree(get_data_home(data_home))
 
 
+def _load_bundled(stem, feature_names, *, caller_name, return_X_y, as_frame):
+    """Load a bundled dataset CSV under a fixed set of column names.
+
+    Resolves against the bundled data module only, so a same-named file in
+    the working directory cannot shadow a shipped dataset the way it can in
+    ``load_dataset``.
+    """
+    path = Path(str(resources.files(DATA_MODULE))) / f"{stem}.csv"
+    # The metadata header carries no column names, so _read_csv_any generates
+    # x0..xd-1 and the caller supplies the real ones instead
+    data, target, _, header_class_names = _read_csv_any(path)
+    if len(feature_names) != data.shape[1]:
+        raise ValueError(
+            f"{caller_name}: {len(feature_names)} feature name(s) declared, "
+            f"but {path.name} has {data.shape[1]} feature column(s)."
+        )
+    feature_names = list(feature_names)
+    target_names = _resolve_target_names(header_class_names, target)
+
+    frame = None
+    if as_frame:
+        frame, data, target = _convert_data_dataframe(
+            caller_name, data, target, feature_names, ["target"]
+        )
+    if return_X_y:
+        return data, target
+    return Bunch(
+        data=data,
+        target=target,
+        frame=frame,
+        feature_names=feature_names,
+        target_names=target_names,
+        n_classes=len(target_names),
+        DESCR=_load_descr(path, DATA_MODULE),
+        filename=path.name,
+        data_module=DATA_MODULE,
+    )
+
+
 @validate_params(
     {
         "name": [str, os.PathLike],

--- a/skordinal/datasets/_loaders.py
+++ b/skordinal/datasets/_loaders.py
@@ -1,89 +1,8 @@
 """Loaders for bundled ordinal classification datasets."""
 
-import csv
-from importlib import resources
-
-import numpy as np
-from sklearn.utils import Bunch
 from sklearn.utils._param_validation import validate_params
 
-DATA_MODULE = "skordinal.datasets.data"
-DESCR_MODULE = "skordinal.datasets.descr"
-
-
-def _load_csv_data(data_file_name, *, descr_file_name):
-    """Load a sklearn-style CSV with metadata header and a description file.
-
-    The CSV's first row stores ``n_samples,n_features,target_name_0,...``;
-    subsequent rows store ``feature_0,...,feature_d-1,target_int``.  Targets
-    are read as zero-indexed integers.
-    """
-    data_path = resources.files(DATA_MODULE) / data_file_name
-    with data_path.open("r", encoding="utf-8") as csv_file:
-        reader = csv.reader(csv_file)
-        header = next(reader)
-        n_samples = int(header[0])
-        n_features = int(header[1])
-        target_names = np.array(header[2:])
-        data = np.empty((n_samples, n_features), dtype=np.float64)
-        target = np.empty((n_samples,), dtype=np.int32)
-        for i, row in enumerate(reader):
-            data[i] = np.asarray(row[:-1], dtype=np.float64)
-            target[i] = int(row[-1])
-    descr = (resources.files(DESCR_MODULE) / descr_file_name).read_text(
-        encoding="utf-8"
-    )
-    return data, target, target_names, descr
-
-
-def _convert_data_dataframe(caller_name, data, target, feature_names, target_columns):
-    """Combine ``data`` and ``target`` into a pandas frame for ``as_frame=True``."""
-    try:
-        import pandas as pd
-    except (
-        ImportError
-    ) as exc:  # pragma: no cover - exercised in environments without pandas
-        raise ImportError(f"{caller_name} with as_frame=True requires pandas.") from exc
-    data_df = pd.DataFrame(data, columns=feature_names, copy=False)
-    target_df = pd.DataFrame(target, columns=target_columns)
-    combined_df = pd.concat([data_df, target_df], axis=1)
-    X = combined_df[feature_names]
-    y = combined_df[target_columns]
-    if y.shape[1] == 1:  # pragma: no branch
-        y = y.iloc[:, 0]
-    return combined_df, X, y
-
-
-def _bundle(
-    data,
-    target,
-    target_names,
-    descr,
-    feature_names,
-    filename,
-    *,
-    return_X_y,
-    as_frame,
-    caller_name,
-):
-    """Common return path for the public loaders."""
-    frame = None
-    if as_frame:
-        frame, data, target = _convert_data_dataframe(
-            caller_name, data, target, feature_names, ["target"]
-        )
-    if return_X_y:
-        return data, target
-    return Bunch(
-        data=data,
-        target=target,
-        frame=frame,
-        target_names=target_names,
-        DESCR=descr,
-        feature_names=feature_names,
-        filename=filename,
-        data_module=DATA_MODULE,
-    )
+from ._base import _load_bundled
 
 
 @validate_params(
@@ -94,7 +13,7 @@ def load_era(*, return_X_y=False, as_frame=False):
     """Load and return the ERA dataset (ordinal classification).
 
     Four ordinal input attributes describing job candidates; the target is
-    an overall acceptance level on a 1-9 scale (9 ordered classes).
+    an overall acceptance level on a 1-9 scale (9 ordered classes) [1]_.
 
     =================   ==============
     Classes                          9
@@ -127,6 +46,8 @@ def load_era(*, return_X_y=False, as_frame=False):
             ``["in1", "in2", "in3", "in4"]``.
         target_names : ndarray of str
             ``["1", "2", "3", "4", "5", "6", "7", "8", "9"]``.
+        n_classes : int
+            Number of ordered classes.
         frame : DataFrame of shape (1000, 5) or None
             ``None`` if ``as_frame=False``; otherwise a DataFrame
             combining ``data`` and ``target``.
@@ -144,6 +65,12 @@ def load_era(*, return_X_y=False, as_frame=False):
         column representing a feature. The second array of shape ``(1000,)``
         contains the ordinal target labels.
 
+    References
+    ----------
+    .. [1] A. Ben-David, "Automatic generation of symbolic multiattribute
+           ordinal knowledge-based DSSs: methodology and applications",
+           Decision Sciences, vol. 23, no. 6, pp. 1357-1372, 1992.
+
     Examples
     --------
     >>> from skordinal.datasets import load_era
@@ -153,28 +80,13 @@ def load_era(*, return_X_y=False, as_frame=False):
     >>> int(bunch.target.min()), int(bunch.target.max())
     (0, 8)
 
-    References
-    ----------
-    .. [1] A. Ben-David, "Automatic generation of symbolic multiattribute
-           ordinal knowledge-based DSSs: methodology and applications",
-           Decision Sciences, vol. 23, no. 6, pp. 1357-1372, 1992.
-
     """
-    filename = "era.csv"
-    data, target, target_names, descr = _load_csv_data(
-        filename, descr_file_name="era.rst"
-    )
-    feature_names = [f"in{i + 1}" for i in range(4)]
-    return _bundle(
-        data,
-        target,
-        target_names,
-        descr,
-        feature_names,
-        filename,
+    return _load_bundled(
+        "era",
+        [f"in{i + 1}" for i in range(4)],
+        caller_name="load_era",
         return_X_y=return_X_y,
         as_frame=as_frame,
-        caller_name="load_era",
     )
 
 
@@ -187,7 +99,7 @@ def load_esl(*, return_X_y=False, as_frame=False):
 
     Four ordinal psychometric scores assigned to industrial-job candidates
     by expert psychologists; the target is an overall fitness rating on a
-    1-9 scale (9 ordered classes).
+    1-9 scale (9 ordered classes) [1]_.
 
     =================   ==============
     Classes                          9
@@ -216,34 +128,25 @@ def load_esl(*, return_X_y=False, as_frame=False):
     (data, target) : tuple if ``return_X_y`` is True
         A tuple of two ndarrays; see :func:`load_era` for details.
 
-    Examples
-    --------
-    >>> from skordinal.datasets import load_esl
-    >>> load_esl().data.shape
-    (488, 4)
-
     References
     ----------
     .. [1] A. Ben-David, "Automatic generation of symbolic multiattribute
            ordinal knowledge-based DSSs: methodology and applications",
            Decision Sciences, vol. 23, no. 6, pp. 1357-1372, 1992.
 
+    Examples
+    --------
+    >>> from skordinal.datasets import load_esl
+    >>> load_esl().data.shape
+    (488, 4)
+
     """
-    filename = "esl.csv"
-    data, target, target_names, descr = _load_csv_data(
-        filename, descr_file_name="esl.rst"
-    )
-    feature_names = [f"in{i + 1}" for i in range(4)]
-    return _bundle(
-        data,
-        target,
-        target_names,
-        descr,
-        feature_names,
-        filename,
+    return _load_bundled(
+        "esl",
+        [f"in{i + 1}" for i in range(4)],
+        caller_name="load_esl",
         return_X_y=return_X_y,
         as_frame=as_frame,
-        caller_name="load_esl",
     )
 
 
@@ -256,7 +159,7 @@ def load_lev(*, return_X_y=False, as_frame=False):
 
     Four ordinal student-rating attributes collected in anonymous university
     course evaluations; the target is an overall lecturer rating on a
-    1-5 scale (5 ordered classes).
+    1-5 scale (5 ordered classes) [1]_.
 
     =================   ==============
     Classes                          5
@@ -285,34 +188,25 @@ def load_lev(*, return_X_y=False, as_frame=False):
     (data, target) : tuple if ``return_X_y`` is True
         A tuple of two ndarrays; see :func:`load_era` for details.
 
-    Examples
-    --------
-    >>> from skordinal.datasets import load_lev
-    >>> load_lev().data.shape
-    (1000, 4)
-
     References
     ----------
     .. [1] A. Ben-David, "Automatic generation of symbolic multiattribute
            ordinal knowledge-based DSSs: methodology and applications",
            Decision Sciences, vol. 23, no. 6, pp. 1357-1372, 1992.
 
+    Examples
+    --------
+    >>> from skordinal.datasets import load_lev
+    >>> load_lev().data.shape
+    (1000, 4)
+
     """
-    filename = "lev.csv"
-    data, target, target_names, descr = _load_csv_data(
-        filename, descr_file_name="lev.rst"
-    )
-    feature_names = [f"in{i + 1}" for i in range(4)]
-    return _bundle(
-        data,
-        target,
-        target_names,
-        descr,
-        feature_names,
-        filename,
+    return _load_bundled(
+        "lev",
+        [f"in{i + 1}" for i in range(4)],
+        caller_name="load_lev",
         return_X_y=return_X_y,
         as_frame=as_frame,
-        caller_name="load_lev",
     )
 
 
@@ -325,7 +219,7 @@ def load_swd(*, return_X_y=False, as_frame=False):
 
     Ten ordinal risk-assessment attributes filled in by qualified social
     workers for child-safety cases; the target is the ordinal risk level
-    used in family-court decisions, on a 1-4 scale (4 ordered classes).
+    used in family-court decisions, on a 1-4 scale (4 ordered classes) [1]_.
 
     =================   ==============
     Classes                          4
@@ -354,34 +248,25 @@ def load_swd(*, return_X_y=False, as_frame=False):
     (data, target) : tuple if ``return_X_y`` is True
         A tuple of two ndarrays; see :func:`load_era` for details.
 
-    Examples
-    --------
-    >>> from skordinal.datasets import load_swd
-    >>> load_swd().data.shape
-    (1000, 10)
-
     References
     ----------
     .. [1] A. Ben-David, "Automatic generation of symbolic multiattribute
            ordinal knowledge-based DSSs: methodology and applications",
            Decision Sciences, vol. 23, no. 6, pp. 1357-1372, 1992.
 
+    Examples
+    --------
+    >>> from skordinal.datasets import load_swd
+    >>> load_swd().data.shape
+    (1000, 10)
+
     """
-    filename = "swd.csv"
-    data, target, target_names, descr = _load_csv_data(
-        filename, descr_file_name="swd.rst"
-    )
-    feature_names = [f"in{i + 1}" for i in range(10)]
-    return _bundle(
-        data,
-        target,
-        target_names,
-        descr,
-        feature_names,
-        filename,
+    return _load_bundled(
+        "swd",
+        [f"in{i + 1}" for i in range(10)],
+        caller_name="load_swd",
         return_X_y=return_X_y,
         as_frame=as_frame,
-        caller_name="load_swd",
     )
 
 
@@ -392,9 +277,9 @@ def load_swd(*, return_X_y=False, as_frame=False):
 def load_balance_scale(*, return_X_y=False, as_frame=False):
     """Load and return the Balance Scale dataset (ordinal classification).
 
-    A synthetic dataset modelling Piaget-style balance-scale experiments.
-    Each sample describes the weight and distance of objects placed on the
-    left and right pans; the ordinal target indicates which way the scale
+    A synthetic dataset modelling Piaget-style balance-scale experiments
+    [1]_. Each sample describes the weight and distance of objects placed on
+    the left and right pans; the ordinal target indicates which way the scale
     tips: ``L`` (left), ``B`` (balanced), ``R`` (right).
 
     =================   ==============
@@ -426,6 +311,11 @@ def load_balance_scale(*, return_X_y=False, as_frame=False):
     (data, target) : tuple if ``return_X_y`` is True
         A tuple of two ndarrays; see :func:`load_era` for details.
 
+    References
+    ----------
+    .. [1] R. S. Siegler, "Three aspects of cognitive development",
+           Cognitive Psychology, vol. 8, pp. 481-520, 1976.
+
     Examples
     --------
     >>> from skordinal.datasets import load_balance_scale
@@ -435,30 +325,11 @@ def load_balance_scale(*, return_X_y=False, as_frame=False):
     >>> bunch.target_names.tolist()
     ['L', 'B', 'R']
 
-    References
-    ----------
-    .. [1] R. S. Siegler, "Three aspects of cognitive development",
-           Cognitive Psychology, vol. 8, pp. 481-520, 1976.
-
     """
-    filename = "balance_scale.csv"
-    data, target, target_names, descr = _load_csv_data(
-        filename, descr_file_name="balance_scale.rst"
-    )
-    feature_names = [
-        "left_weight",
-        "left_distance",
-        "right_weight",
-        "right_distance",
-    ]
-    return _bundle(
-        data,
-        target,
-        target_names,
-        descr,
-        feature_names,
-        filename,
+    return _load_bundled(
+        "balance_scale",
+        ["left_weight", "left_distance", "right_weight", "right_distance"],
+        caller_name="load_balance_scale",
         return_X_y=return_X_y,
         as_frame=as_frame,
-        caller_name="load_balance_scale",
     )

--- a/skordinal/datasets/_loaders.py
+++ b/skordinal/datasets/_loaders.py
@@ -84,7 +84,6 @@ def load_era(*, return_X_y=False, as_frame=False):
     return _load_bundled(
         "era",
         [f"in{i + 1}" for i in range(4)],
-        caller_name="load_era",
         return_X_y=return_X_y,
         as_frame=as_frame,
     )
@@ -144,7 +143,6 @@ def load_esl(*, return_X_y=False, as_frame=False):
     return _load_bundled(
         "esl",
         [f"in{i + 1}" for i in range(4)],
-        caller_name="load_esl",
         return_X_y=return_X_y,
         as_frame=as_frame,
     )
@@ -204,7 +202,6 @@ def load_lev(*, return_X_y=False, as_frame=False):
     return _load_bundled(
         "lev",
         [f"in{i + 1}" for i in range(4)],
-        caller_name="load_lev",
         return_X_y=return_X_y,
         as_frame=as_frame,
     )
@@ -264,7 +261,6 @@ def load_swd(*, return_X_y=False, as_frame=False):
     return _load_bundled(
         "swd",
         [f"in{i + 1}" for i in range(10)],
-        caller_name="load_swd",
         return_X_y=return_X_y,
         as_frame=as_frame,
     )
@@ -329,7 +325,6 @@ def load_balance_scale(*, return_X_y=False, as_frame=False):
     return _load_bundled(
         "balance_scale",
         ["left_weight", "left_distance", "right_weight", "right_distance"],
-        caller_name="load_balance_scale",
         return_X_y=return_X_y,
         as_frame=as_frame,
     )

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -16,7 +16,7 @@ from skordinal.datasets import (
     load_dataset,
     load_partitions,
 )
-from skordinal.datasets._base import _resolve_target_names
+from skordinal.datasets._base import _load_bundled, _resolve_target_names
 
 _NAMED_CSV = """\
 x_0,x_1,y
@@ -579,3 +579,15 @@ def test_resolve_target_names(header_class_names, target, expected):
     result = _resolve_target_names(header_class_names, target)
     assert list(result) == expected
     assert result.dtype.kind == "U"
+
+
+def test_load_bundled_rejects_feature_name_count_mismatch():
+    """Declaring the wrong number of column names for a bundled CSV raises."""
+    with pytest.raises(ValueError, match="feature name"):
+        _load_bundled(
+            "era",
+            ["in1", "in2"],
+            caller_name="load_era",
+            return_X_y=False,
+            as_frame=False,
+        )

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -584,10 +584,4 @@ def test_resolve_target_names(header_class_names, target, expected):
 def test_load_bundled_rejects_feature_name_count_mismatch():
     """Declaring the wrong number of column names for a bundled CSV raises."""
     with pytest.raises(ValueError, match="feature name"):
-        _load_bundled(
-            "era",
-            ["in1", "in2"],
-            caller_name="load_era",
-            return_X_y=False,
-            as_frame=False,
-        )
+        _load_bundled("era", ["in1", "in2"], return_X_y=False, as_frame=False)

--- a/skordinal/datasets/tests/test_loaders.py
+++ b/skordinal/datasets/tests/test_loaders.py
@@ -6,6 +6,7 @@ from sklearn.utils import Bunch
 
 from skordinal.datasets import (
     load_balance_scale,
+    load_dataset,
     load_era,
     load_esl,
     load_lev,
@@ -31,12 +32,14 @@ def test_loader_returns_bunch(loader):
         "target",
         "feature_names",
         "target_names",
+        "n_classes",
         "frame",
         "DESCR",
         "filename",
         "data_module",
     ):
         assert key in bunch
+    assert bunch.n_classes == len(bunch.target_names)
 
 
 @pytest.mark.parametrize("loader", ALL_LOADERS)
@@ -67,10 +70,11 @@ def test_loader_descr_nonempty(loader):
 
 
 @pytest.mark.parametrize("loader", ALL_LOADERS)
-def test_loader_data_dtype_float(loader):
-    """Feature matrix has floating-point dtype."""
+def test_loader_dtypes(loader):
+    """Feature matrix is float64 and the target is int32."""
     bunch = loader()
-    assert np.issubdtype(bunch.data.dtype, np.floating)
+    assert bunch.data.dtype == np.float64
+    assert bunch.target.dtype == np.int32
 
 
 @pytest.mark.parametrize("loader", ALL_LOADERS)
@@ -147,3 +151,37 @@ def test_load_balance_scale_feature_names():
         "right_weight",
         "right_distance",
     ]
+
+
+@pytest.mark.parametrize(
+    "loader,stem",
+    [
+        (load_era, "era"),
+        (load_esl, "esl"),
+        (load_lev, "lev"),
+        (load_swd, "swd"),
+        (load_balance_scale, "balance_scale"),
+    ],
+)
+def test_loader_matches_load_dataset(loader, stem):
+    """A bundled loader agrees with ``load_dataset`` on every shared field."""
+    wrapper = loader()
+    generic = load_dataset(stem)
+    np.testing.assert_array_equal(wrapper.data, generic.data)
+    np.testing.assert_array_equal(wrapper.target, generic.target)
+    np.testing.assert_array_equal(wrapper.target_names, generic.target_names)
+    assert wrapper.n_classes == generic.n_classes
+    assert wrapper.DESCR == generic.DESCR
+    assert wrapper.filename == generic.filename
+    assert wrapper.data_module == generic.data_module
+    # feature_names is the one field the wrapper overrides, since the metadata
+    # header carries no column names and load_dataset generates x0..xd-1
+    assert wrapper.feature_names != generic.feature_names
+
+
+def test_loader_ignores_cwd_file(tmp_path, monkeypatch):
+    """A same-named file in the working directory cannot shadow bundled data."""
+    (tmp_path / "era").write_text("junk\n", encoding="utf-8")
+    (tmp_path / "era.csv").write_text("1,1,a\n0.0,0\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    assert load_era().data.shape == (1000, 4)

--- a/skordinal/datasets/tests/test_loaders.py
+++ b/skordinal/datasets/tests/test_loaders.py
@@ -153,18 +153,10 @@ def test_load_balance_scale_feature_names():
     ]
 
 
-@pytest.mark.parametrize(
-    "loader,stem",
-    [
-        (load_era, "era"),
-        (load_esl, "esl"),
-        (load_lev, "lev"),
-        (load_swd, "swd"),
-        (load_balance_scale, "balance_scale"),
-    ],
-)
-def test_loader_matches_load_dataset(loader, stem):
+@pytest.mark.parametrize("loader", ALL_LOADERS)
+def test_loader_matches_load_dataset(loader):
     """A bundled loader agrees with ``load_dataset`` on every shared field."""
+    stem = loader.__name__.removeprefix("load_")
     wrapper = loader()
     generic = load_dataset(stem)
     np.testing.assert_array_equal(wrapper.data, generic.data)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Slims the five bundled dataset loaders (`load_era`, `load_esl`, `load_lev`, `load_swd`, `load_balance_scale`) down to thin wrappers over the shared CSV-reading and Bunch-assembly machinery in `_base.py`, removing a second, weaker CSV reader and frame builder that had drifted from the canonical one. All five loaders now include `n_classes` in the returned `Bunch`, matching `load_dataset`. Bundled loaders resolve strictly against the packaged data directory, so a same-named file in the working directory can no longer shadow shipped data.