### PR TITLE
CI: Split coverage into its own job, skip macOS on 3.14

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          # Python 3.14 is a pre-release, skip macOS until it reaches GA
+          - os: macos-latest
+            python-version: "3.14"
         include:
           # Extra job: verify compatibility with NumPy 2.x.
           - os: ubuntu-latest
@@ -45,6 +49,24 @@ jobs:
           fi
 
       - name: Run tests
+        run: pytest -m "not network"
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests with coverage
         run: pytest -m "not network" --cov=skordinal --cov-report=xml
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Coverage moves to a single dedicated job that runs `pytest --cov` and uploads to Codecov, while the matrix jobs run plain `pytest`. macOS is excluded on the Python 3.14 pre-release, where scientific-stack wheels may not exist yet.