### PR TITLE
FIX: Record predict() output in the Prediction column

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ results/
 Each predictions CSV lists the `Pattern ID`, the zero-based `Target` class
 index, a `Prediction probabilities` column with the per-class probabilities
 (for estimators that support `predict_proba`), and the zero-based
-`Prediction` class index — the argmax of the probabilities when they are
-present, or the estimator's own prediction otherwise. Confusion matrices are
-written alongside as plain-text `.txt` files, the fitted estimator for each
-seed is stored under a `models/` subfolder, and aggregated
+`Prediction` class index, which always records the estimator's own
+`predict` output, even when probabilities are present. Confusion matrices
+are written alongside as plain-text `.txt` files, the fitted estimator for
+each seed is stored under a `models/` subfolder, and aggregated
 `train_summary.csv` and `test_summary.csv` files are produced across all
 runs.
 

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -125,6 +125,12 @@ def _write_split_files(
         )
     pattern_id = index if index is not None else np.arange(predicted_y.shape[0])
     target = np.searchsorted(classes, true_y)
+    if not np.isin(predicted_y, classes).all():
+        raise ValueError(
+            f"'{split}' predicted labels contain classes unknown to the fitted model."
+        )
+    # Record the estimator's actual decision, never a proba argmax substitute
+    prediction = np.searchsorted(classes, predicted_y)
 
     columns: dict[str, object] = {"Pattern ID": pattern_id, "Target": target}
     if proba is not None:
@@ -134,15 +140,6 @@ def _write_split_files(
                 f"({true_y.shape[0]}, {classes.size})."
             )
         columns["Prediction probabilities"] = _format_proba_column(proba)
-        # Derive the prediction as the argmax index of the probabilities
-        prediction = np.argmax(proba, axis=1)
-    else:
-        if not np.isin(predicted_y, classes).all():
-            raise ValueError(
-                f"'{split}' predicted labels contain classes unknown to the "
-                "fitted model."
-            )
-        prediction = np.searchsorted(classes, predicted_y)
     columns["Prediction"] = prediction
     _atomic_write(
         seed_dir / f"{split}_predictions.csv",
@@ -198,9 +195,9 @@ class Results:
     and ``Prediction`` are zero-based class indices into
     ``best_model.classes_``; ``Pattern ID`` is the sample's position in the
     original dataset array, or its position within the partition when no
-    sample indices were recorded. When probabilities are present,
-    ``Prediction`` is their argmax index, which may differ from the
-    estimator's own decision rule reflected in ``report.csv``. Each
+    sample indices were recorded. ``Prediction`` always reflects the
+    estimator's own ``predict`` decision, even when probability
+    estimates are stored alongside it. Each
     ``*_confusion_matrix.txt`` holds the confusion matrix of the same
     file's ``Target`` and ``Prediction`` columns.
     ``hyperparameter_configuration.csv`` records the best parameters per

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -187,20 +187,34 @@ def test_save_model_false(tmp_path):
 
 def test_save_proba_written_to_disk(tmp_path):
     """Probability columns are persisted in both prediction files."""
-    rng = np.random.default_rng(0)
     estimator = _fitted_svc(probability=True)
     q = estimator.classes_.size
 
-    raw_train = rng.random((3, q))
-    raw_test = rng.random((4, q))
-    train_y_proba = raw_train / raw_train.sum(axis=1, keepdims=True)
-    y_proba = raw_test / raw_test.sum(axis=1, keepdims=True)
+    # predicted_y encodes to [0, 2, 1] while the proba argmax is [0, 0, 2]
+    train_predicted_y = np.array([1, 3, 2])
+    train_y_proba = np.array(
+        [
+            [0.6, 0.3, 0.1],
+            [0.5, 0.3, 0.2],
+            [0.2, 0.3, 0.5],
+        ]
+    )
+    # predicted_y encodes to [0, 1, 2, 0] while the proba argmax is [2, 1, 2, 1]
+    test_predicted_y = np.array([1, 2, 3, 1])
+    y_proba = np.array(
+        [
+            [0.1, 0.2, 0.7],
+            [0.1, 0.8, 0.1],
+            [0.05, 0.05, 0.9],
+            [0.3, 0.4, 0.3],
+        ]
+    )
     result = ExperimentResult(
         dataset_name="toy",
         classifier_name="conf_1",
         resample_id=0,
-        train_predicted_y=np.array([1, 2, 3]),
-        test_predicted_y=np.array([1, 2, 3, 1]),
+        train_predicted_y=train_predicted_y,
+        test_predicted_y=test_predicted_y,
         y_proba=y_proba,
         train_metrics={"ccr_train": 0.9},
         test_metrics={"ccr_test": 0.8},
@@ -213,15 +227,15 @@ def test_save_proba_written_to_disk(tmp_path):
     Results(tmp_path).save(result, save_model=False)
 
     seed_dir = tmp_path / "conf_1" / "toy" / "predictions_by_seed" / "seed_0"
-    for name, proba in (
-        ("train_predictions.csv", train_y_proba),
-        ("test_predictions.csv", y_proba),
+    for name, proba, expected in (
+        ("train_predictions.csv", train_y_proba, [0, 2, 1]),
+        ("test_predictions.csv", y_proba, [0, 1, 2, 0]),
     ):
         df = pd.read_csv(seed_dir / name)
         assert "Prediction probabilities" in df.columns
         assert set(df["Target"]) <= set(range(q))
-        # Check Prediction equals the argmax index of the probabilities
-        npt.assert_array_equal(df["Prediction"].values, np.argmax(proba, axis=1))
+        # Check Prediction records predict(), not the argmax of the probabilities
+        npt.assert_array_equal(df["Prediction"].values, expected)
         for cell, source in zip(df["Prediction probabilities"], proba):
             parsed = np.fromstring(cell.strip("[]"), sep=",")
             assert parsed.shape == (q,)

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -8,9 +8,16 @@ import pytest
 from sklearn.metrics import confusion_matrix
 from sklearn.svm import SVC
 
-from skordinal.experiments import ExperimentResult, Results
+from skordinal.classifiers import LogisticAT
+from skordinal.experiments import (
+    Experiment,
+    ExperimentResult,
+    ModelConfig,
+    Results,
+)
 from skordinal.experiments._io import _TEMP_PREFIX
 from skordinal.experiments._results import _write_split_files
+from skordinal.metrics import accuracy_score, mean_absolute_error
 
 
 def _fitted_svc(classes=(1, 2, 3), probability=False):
@@ -36,6 +43,7 @@ def _make_result(
     test_true_y=None,
     train_index=None,
     test_index=None,
+    y_proba=None,
 ) -> ExperimentResult:
     if estimator is None:
         estimator = _fitted_svc()
@@ -49,7 +57,7 @@ def _make_result(
         resample_id=partition,
         train_predicted_y=train_predicted_y,
         test_predicted_y=test_predicted_y,
-        y_proba=None,
+        y_proba=y_proba,
         train_metrics=train_metrics,
         test_metrics=test_metrics,
         best_params=best_params,
@@ -243,6 +251,41 @@ def test_save_proba_written_to_disk(tmp_path):
             npt.assert_allclose(parsed.sum(), 1.0, atol=1e-8)
 
 
+def test_csv_reproduces_report_metrics(tmp_path):
+    """Report metrics recompute from the saved CSV for rank-encoded labels."""
+    rng = np.random.default_rng(0)
+    X_train, X_test = rng.standard_normal((30, 4)), rng.standard_normal((15, 4))
+    y_train, y_test = np.tile([0, 1, 2], 10), np.tile([0, 1, 2], 5)
+    metrics = {
+        "accuracy_score": accuracy_score,
+        "mean_absolute_error": mean_absolute_error,
+    }
+    result = Experiment(ModelConfig(LogisticAT()), eval_metrics=list(metrics)).run(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        dataset_name="ds",
+        classifier_name="clf",
+        resample_id=0,
+    )
+    assert not np.array_equal(
+        np.argmax(result.y_proba, axis=1), result.test_predicted_y
+    )
+    Results(tmp_path).save(result, save_model=False)
+
+    pair_dir = tmp_path / "clf" / "ds"
+    predictions = pd.read_csv(
+        pair_dir / "predictions_by_seed" / "seed_0" / "test_predictions.csv"
+    )
+    report = pd.read_csv(
+        pair_dir / "report.csv", index_col=0, float_precision="round_trip"
+    )
+    for name, metric in metrics.items():
+        recomputed = metric(predictions["Target"], predictions["Prediction"])
+        assert recomputed == pytest.approx(report.loc[0, f"{name}_test"])
+
+
 def test_save_requires_true_labels(tmp_path):
     """save raises ValueError when a split lacks its true labels."""
     base = dict(
@@ -273,6 +316,13 @@ def test_save_requires_true_labels(tmp_path):
         ({"train_true_y": np.array([1, 2, 4])}, "'train' true labels"),
         ({"test_true_y": np.array([1, 2, 4])}, "'test' true labels"),
         ({"test_predicted_y": np.array([1, 2, 4])}, "'test' predicted labels"),
+        (
+            {
+                "test_predicted_y": np.array([1, 2, 4]),
+                "y_proba": np.full((3, 3), 1 / 3),
+            },
+            "'test' predicted labels",
+        ),
     ],
 )
 def test_save_rejects_unknown_labels(tmp_path, overrides, match):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`Prediction` and its confusion matrix now record the estimator's own `predict()` output instead of `argmax(predict_proba())`, which disagreed for threshold models such as `LogisticAT` and silently contradicted the metrics in `report.csv`. Predicted labels are now validated in that case too.