### PR TITLE
FIX: Resolve the ordinal label set across the metric functions

### DIFF
--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -112,28 +112,20 @@ def _resolve_ordinal_labels(y_true, y_pred, labels):
     return labels
 
 
-def _check_proba_inputs(y_true, y_proba):
+def _check_proba_inputs(y_true, y_proba, *, labels=None):
     """Coerce and validate the inputs of a probabilistic ordinal metric.
 
-    ``y_true`` is collapsed as in ``_check_metric_inputs``, then required
-    to be integer-valued and returned as ``intp`` 0-based class indices.
-    ``y_proba`` must be coercible to ``float64`` with every entry in
-    ``[0, 1]``; a 1-D or single-column input is the positive-class
-    probability of a binary problem and is expanded to ``[1 - p, p]``, and
-    rows must then sum to 1 within ``atol=1e-6, rtol=0``. Raises
-    ``ValueError`` on a malformed or non-integer ``y_true``, a length
-    mismatch, an out-of-range entry, or a row that does not sum to 1.
+    Returns ``y_true`` as ``intp`` column indices into ``y_proba`` --
+    taken as given when ``labels`` is ``None`` or ``y_true`` was one-hot,
+    mapped through ``labels`` otherwise -- and ``y_proba`` as a validated
+    float64 matrix whose rows sum to 1, expanding a single column to
+    ``[1 - p, p]`` unless ``labels`` pins a one-class distribution.
     """
     y_true_arr = _check_labels(y_true, "y_true")
-    y_true_idx = y_true_arr.astype(np.intp)
-    # the intp cast truncates, so a non-integral float or object value would
-    # land on a different, valid class; a digit string keeps its parsed value
-    if y_true_arr.dtype.kind in "fO" and not np.array_equal(y_true_idx, y_true_arr):
-        raise ValueError(
-            "y_true must be integer-valued (0-based class indices); got "
-            "non-integer values."
-        )
-    y_true_arr = y_true_idx
+    # A one-hot y_true is argmax-collapsed to column indices, never re-mapped
+    shape = np.shape(y_true)
+    y_true_is_index = labels is None or (len(shape) == 2 and shape[1] > 1)
+
     y_proba_arr = check_array(
         y_proba, ensure_2d=False, dtype="float64", input_name="y_proba"
     )
@@ -147,8 +139,57 @@ def _check_proba_inputs(y_true, y_proba):
             f"y_proba entries must lie in [0, 1]; got range [{lo:.6g}, {hi:.6g}]"
         )
 
-    if y_proba_arr.shape[1] == 1:
+    if labels is not None:
+        labels = check_array(labels, ensure_2d=False, dtype=None, input_name="labels")
+        if labels.ndim != 1:
+            raise ValueError(f"labels must be a 1-D array; got shape {labels.shape}.")
+        # Columns follow classes_, so a lexicographic string order would be
+        # scored as the ordinal scale
+        if not _numeric_label_order(labels):
+            raise ValueError(
+                "ranked_probability_score requires numeric labels; encode "
+                "ordinal categories as integers reflecting their order."
+            )
+        if labels.size > 1 and not np.all(labels[1:] > labels[:-1]):
+            raise ValueError(
+                "labels must be sorted in strictly ascending order, to match "
+                f"the columns of y_proba; got {labels.tolist()}."
+            )
+
+    # A lone column is a binary positive-class probability, unless labels
+    # pins the width to one genuine class
+    expansion = ""
+    if y_proba_arr.shape[1] == 1 and (labels is None or labels.size != 1):
         y_proba_arr = np.hstack([1.0 - y_proba_arr, y_proba_arr])
+        expansion = " (a 1-D y_proba was expanded to two columns)"
+    n_classes = y_proba_arr.shape[1]
+
+    if labels is not None and labels.size != n_classes:
+        raise ValueError(
+            "the number of classes in labels differs from the number of y_proba "
+            f"columns: got {labels.size} labels for {n_classes} columns{expansion}."
+        )
+
+    if y_true_is_index:
+        y_true_idx = y_true_arr.astype(np.intp)
+        # The intp cast truncates, so a non-integral value would land on a
+        # different, valid class; a digit string keeps its parsed value
+        if y_true_arr.dtype.kind in "fO" and not np.array_equal(y_true_idx, y_true_arr):
+            raise ValueError(
+                "y_true must be integer-valued (0-based class indices); got "
+                "non-integer values."
+            )
+        outside = np.unique(y_true_idx[(y_true_idx < 0) | (y_true_idx >= n_classes)])
+        if outside.size:
+            raise ValueError(
+                f"y_true contains values {outside.tolist()} not belonging to "
+                f"the {n_classes} columns of y_proba; pass labels to map raw "
+                "class labels."
+            )
+        y_true_arr = y_true_idx
+    else:
+        _check_labels_cover(y_true_arr, labels, "y_true")
+        y_true_arr = np.searchsorted(labels, y_true_arr)
 
     row_sums = y_proba_arr.sum(axis=1)
     if not np.allclose(row_sums, 1.0, atol=1e-6, rtol=0):
@@ -739,11 +780,12 @@ def spearmans_rho(y_true, y_pred):
     {
         "y_true": ["array-like"],
         "y_proba": ["array-like"],
+        "labels": ["array-like", None],
         "sample_weight": ["array-like", None],
     },
     prefer_skip_nested_validation=True,
 )
-def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
+def ranked_probability_score(y_true, y_proba, *, labels=None, sample_weight=None):
     """Ranked probability score for ordinal class probabilities.
 
     Quadratic distance between the cumulative ground-truth indicator
@@ -754,14 +796,22 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     Parameters
     ----------
     y_true : array-like of shape (n_samples,)
-        Ground truth labels encoded as 0-based integer indices.
+        Ground truth labels: 0-based column indices into ``y_proba``, or
+        raw class labels when ``labels`` is given.
 
     y_proba : array-like of shape (n_samples, n_classes), (n_samples, 1), or (n_samples,)
         Predicted class probability distribution. A 1-D input, or a
         single-column 2-D input, is treated as the positive-class
         probability of a binary problem and expanded to two columns,
-        ``[1 - p, p]``. Every entry must lie in ``[0, 1]`` and each row
-        must sum to approximately ``1`` (``atol=1e-6, rtol=0``).
+        ``[1 - p, p]``, unless ``labels`` pins the single column to a
+        one-class distribution. Every entry must lie in ``[0, 1]`` and
+        each row must sum to approximately ``1`` (``atol=1e-6, rtol=0``).
+
+    labels : array-like of shape (n_classes,), default=None
+        Class values matching the columns of ``y_proba`` (typically a
+        fitted classifier's ``classes_``), numeric and sorted in strictly
+        ascending order. If ``None``, ``y_true`` must already be column
+        indices.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights forwarded to :func:`numpy.average`.
@@ -774,9 +824,8 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
 
     Notes
     -----
-    Samples whose ``y_true`` falls outside ``[0, n_classes)`` are
-    counted with a per-sample contribution of ``n_classes - 1``, the
-    worst per-sample loss attainable by any in-range label.
+    A ``y_true`` class with no matching ``y_proba`` column raises
+    ``ValueError``, as in :func:`sklearn.metrics.log_loss`.
 
     References
     ----------
@@ -794,23 +843,16 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     ...      [0.1, 0.05, 0.65, 0.2]])
     >>> ranked_probability_score(y_true, y_pred)
     0.5068750000000001
+    >>> ranked_probability_score(y_true + 1, y_pred, labels=np.array([1, 2, 3, 4]))
+    0.5068750000000001
     """
-    y_true, y_proba = _check_proba_inputs(y_true, y_proba)
-    n_samples, n_classes = y_proba.shape
+    y_true, y_proba = _check_proba_inputs(y_true, y_proba, labels=labels)
     sample_weight = _check_metric_weight(y_true, sample_weight)
 
-    in_range = (y_true >= 0) & (y_true < n_classes)
     y_oh = np.zeros_like(y_proba)
-    rows = np.arange(n_samples)[in_range]
-    y_oh[rows, y_true[in_range]] = 1.0
+    y_oh[np.arange(y_proba.shape[0]), y_true] = 1.0
 
-    y_oh_cum = y_oh.cumsum(axis=1)
-    y_proba_cum = y_proba.cumsum(axis=1)
-
-    per_sample = np.power(y_proba_cum - y_oh_cum, 2).sum(axis=1)
-    # n_classes - 1 cumulative steps, each contributing 1 squared
-    per_sample[~in_range] = float(n_classes - 1)
-
+    per_sample = np.power(y_proba.cumsum(axis=1) - y_oh.cumsum(axis=1), 2).sum(axis=1)
     return float(np.average(per_sample, weights=sample_weight))
 
 

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -1,5 +1,7 @@
 """Metrics for ordinal classification."""
 
+import numbers
+
 import numpy as np
 import scipy.stats
 from sklearn.metrics import (
@@ -62,6 +64,54 @@ def _check_metric_inputs(y_true, y_pred):
     return y_true_arr, y_pred_arr
 
 
+def _numeric_label_order(labels):
+    """Return True when sorting ``labels`` yields their ordinal order.
+
+    Numeric dtypes qualify; an object array only when every element is a
+    number, so digit strings cannot smuggle in a lexicographic order.
+    """
+    if labels.dtype.kind in "biuf":
+        return True
+    if labels.dtype.kind != "O":
+        return False
+    return all(isinstance(value, numbers.Number) for value in labels)
+
+
+def _check_labels_cover(values, labels, name):
+    """Raise ValueError if ``values`` holds anything outside ``labels``."""
+    missing = np.setdiff1d(values, labels)
+    if missing.size:
+        raise ValueError(
+            f"{name} contains values {missing.tolist()} not belonging to the "
+            f"passed labels {labels.tolist()}."
+        )
+
+
+def _resolve_ordinal_labels(y_true, y_pred, labels):
+    """Resolve the ordinal label set of one metric call.
+
+    An explicit ``labels`` is authoritative in the order given and must
+    cover ``y_true`` and ``y_pred``, so no sample can silently leave a
+    denominator. Without it the set comes from the data, whose sort order
+    is the ordinal order only when numeric.
+    """
+    if labels is not None:
+        labels = check_array(labels, ensure_2d=False, dtype=None, input_name="labels")
+        if labels.ndim != 1:
+            raise ValueError(f"labels must be a 1-D array; got shape {labels.shape}.")
+        _check_labels_cover(y_true, labels, "y_true")
+        _check_labels_cover(y_pred, labels, "y_pred")
+        return labels
+
+    labels = np.union1d(y_true, y_pred)
+    if not _numeric_label_order(labels):
+        raise ValueError(
+            "the ordinal order of non-numeric labels cannot be inferred; "
+            "pass labels=[...] listing the classes in ascending ordinal order."
+        )
+    return labels
+
+
 def _check_proba_inputs(y_true, y_proba):
     """Coerce and validate the inputs of a probabilistic ordinal metric.
 
@@ -122,32 +172,8 @@ def _recall_per_class(y_true, y_pred, *, labels=None, sample_weight=None):
     return np.asarray(recall[support > 0], dtype=np.float64)
 
 
-def _per_class_mae(y_true, y_pred, *, labels=None, sample_weight=None):
-    """Return per-class mean absolute error as a 1-D float64 ndarray.
-
-    Drops rows of the confusion matrix with no support (zero true
-    samples for that class) so divisions remain finite. Shared by
-    :func:`average_mean_absolute_error` and
-    :func:`maximum_mean_absolute_error`.
-
-    Parameters
-    ----------
-    y_true : ndarray of shape (n_samples,)
-        Ground truth labels.
-
-    y_pred : ndarray of shape (n_samples,)
-        Predicted labels.
-
-    labels : array-like of shape (n_classes,), default=None
-        Labels to index the confusion matrix.
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    Returns
-    -------
-    per_class_mae : ndarray of shape (n_classes_with_support,), dtype float64
-    """
+def _per_class_mae(y_true, y_pred, *, labels, sample_weight=None):
+    """Return per-class rank MAE over ``labels``, dropping zero-support classes."""
     cm = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
     n_class = cm.shape[0]
     costs = np.abs(np.arange(n_class)[:, None] - np.arange(n_class)[None, :])
@@ -161,17 +187,19 @@ def _per_class_mae(y_true, y_pred, *, labels=None, sample_weight=None):
     {
         "y_true": ["array-like"],
         "y_pred": ["array-like"],
+        "labels": ["array-like", None],
         "sample_weight": ["array-like", None],
     },
     prefer_skip_nested_validation=True,
 )
-def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
+def average_mean_absolute_error(y_true, y_pred, *, labels=None, sample_weight=None):
     """Compute the average per-class mean absolute error.
 
     For each class with at least one ground-truth sample, the mean
-    absolute error is computed using the class label as the numerical
-    score. The per-class errors are then averaged with equal weight,
-    which makes the metric robust to class imbalance.
+    absolute error is computed over class *ranks*: neighbouring classes
+    are one unit apart however their labels are numbered. The per-class
+    errors are then averaged with equal weight, which makes the metric
+    robust to class imbalance.
 
     Parameters
     ----------
@@ -180,6 +208,11 @@ def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
 
     y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    labels : array-like of shape (n_classes,), default=None
+        Classes in ascending ordinal order, covering every value in
+        ``y_true`` and ``y_pred``. If ``None``, inferred from the data,
+        which must then be numeric.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights forwarded to the confusion matrix.
@@ -204,7 +237,12 @@ def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
-    return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).mean())
+    labels = _resolve_ordinal_labels(y_true, y_pred, labels)
+    return float(
+        _per_class_mae(
+            y_true, y_pred, labels=labels, sample_weight=sample_weight
+        ).mean()
+    )
 
 
 @validate_params(
@@ -266,11 +304,12 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
     {
         "y_true": ["array-like"],
         "y_pred": ["array-like"],
+        "labels": ["array-like", None],
         "sample_weight": ["array-like", None],
     },
     prefer_skip_nested_validation=True,
 )
-def gmsec(y_true, y_pred, *, sample_weight=None):
+def gmsec(y_true, y_pred, *, labels=None, sample_weight=None):
     """Geometric mean of the sensitivities of the extreme ordinal classes.
 
     Proposed in :footcite:t:`vargas2024improving` to assess the
@@ -286,8 +325,13 @@ def gmsec(y_true, y_pred, *, sample_weight=None):
     y_pred : array-like of shape (n_samples,)
         Predicted labels.
 
+    labels : array-like of shape (n_classes,), default=None
+        Classes in ascending ordinal order, covering every value in
+        ``y_true`` and ``y_pred``. If ``None``, inferred from the data,
+        which must then be numeric.
+
     sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights forwarded to ``recall_score``.
+        Sample weights.
 
     Returns
     -------
@@ -309,7 +353,10 @@ def gmsec(y_true, y_pred, *, sample_weight=None):
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
-    sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
+    labels = _resolve_ordinal_labels(y_true, y_pred, labels)
+    sensitivities = _recall_per_class(
+        y_true, y_pred, labels=labels, sample_weight=sample_weight
+    )
     return float(np.sqrt(sensitivities[0] * sensitivities[-1]))
 
 
@@ -317,11 +364,12 @@ def gmsec(y_true, y_pred, *, sample_weight=None):
     {
         "y_true": ["array-like"],
         "y_pred": ["array-like"],
+        "labels": ["array-like", None],
         "sample_weight": ["array-like", None],
     },
     prefer_skip_nested_validation=True,
 )
-def mean_extreme_sensitivity(y_true, y_pred, *, sample_weight=None):
+def mean_extreme_sensitivity(y_true, y_pred, *, labels=None, sample_weight=None):
     """Arithmetic mean of the sensitivities of the extreme ordinal classes.
 
     Assesses the balanced performance between the extreme classes of an
@@ -336,8 +384,13 @@ def mean_extreme_sensitivity(y_true, y_pred, *, sample_weight=None):
     y_pred : array-like of shape (n_samples,)
         Predicted labels.
 
+    labels : array-like of shape (n_classes,), default=None
+        Classes in ascending ordinal order, covering every value in
+        ``y_true`` and ``y_pred``. If ``None``, inferred from the data,
+        which must then be numeric.
+
     sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights forwarded to ``recall_score``.
+        Sample weights.
 
     Returns
     -------
@@ -355,7 +408,10 @@ def mean_extreme_sensitivity(y_true, y_pred, *, sample_weight=None):
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
-    sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
+    labels = _resolve_ordinal_labels(y_true, y_pred, labels)
+    sensitivities = _recall_per_class(
+        y_true, y_pred, labels=labels, sample_weight=sample_weight
+    )
     return float((sensitivities[0] + sensitivities[-1]) / 2.0)
 
 
@@ -363,16 +419,17 @@ def mean_extreme_sensitivity(y_true, y_pred, *, sample_weight=None):
     {
         "y_true": ["array-like"],
         "y_pred": ["array-like"],
+        "labels": ["array-like", None],
         "sample_weight": ["array-like", None],
     },
     prefer_skip_nested_validation=True,
 )
-def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
+def maximum_mean_absolute_error(y_true, y_pred, *, labels=None, sample_weight=None):
     """Compute the maximum per-class mean absolute error.
 
-    Returns the largest per-class MAE across classes with at least one
-    ground-truth sample. Useful for monitoring the worst-performing
-    class under imbalance.
+    Returns the largest per-class MAE, measured over class ranks, across
+    classes with at least one ground-truth sample. Useful for monitoring
+    the worst-performing class under imbalance.
 
     Parameters
     ----------
@@ -381,6 +438,11 @@ def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
 
     y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    labels : array-like of shape (n_classes,), default=None
+        Classes in ascending ordinal order, covering every value in
+        ``y_true`` and ``y_pred``. If ``None``, inferred from the data,
+        which must then be numeric.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights forwarded to the confusion matrix.
@@ -405,7 +467,10 @@ def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
-    return float(_per_class_mae(y_true, y_pred, sample_weight=sample_weight).max())
+    labels = _resolve_ordinal_labels(y_true, y_pred, labels)
+    return float(
+        _per_class_mae(y_true, y_pred, labels=labels, sample_weight=sample_weight).max()
+    )
 
 
 @validate_params(
@@ -527,7 +592,8 @@ def kendalls_tau(y_true, y_pred):
     Notes
     -----
     Does not accept ``sample_weight`` because the underlying scipy
-    backend does not support it.
+    backend does not support it. Non-numeric labels are rejected: scipy
+    would coerce them and report a spurious ``0.0``.
 
     Examples
     --------
@@ -539,6 +605,11 @@ def kendalls_tau(y_true, y_pred):
     0.8140915784106943
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    if not (_numeric_label_order(y_true) and _numeric_label_order(y_pred)):
+        raise ValueError(
+            "kendalls_tau requires numeric labels; encode ordinal categories "
+            "as integers reflecting their order."
+        )
     if np.unique(y_true).size < 2 or np.unique(y_pred).size < 2:
         return 0.0
     corr, _ = scipy.stats.kendalltau(y_true, y_pred)
@@ -549,17 +620,18 @@ def kendalls_tau(y_true, y_pred):
     {
         "y_true": ["array-like"],
         "y_pred": ["array-like"],
+        "labels": ["array-like", None],
         "sample_weight": ["array-like", None],
     },
     prefer_skip_nested_validation=True,
 )
-def weighted_kappa(y_true, y_pred, *, sample_weight=None):
+def weighted_kappa(y_true, y_pred, *, labels=None, sample_weight=None):
     """Weighted Cohen's kappa with linear ordinal weights.
 
     A version of the kappa statistic that assigns different weights to
     different levels of disagreement, so off-by-one errors penalise the
-    score less than far-off ones. The current implementation uses
-    linear weights ``w_{ij} = |i - j|``.
+    score less than far-off ones. The current implementation uses linear
+    weights ``w_{ij} = |i - j|`` over class ranks.
 
     Parameters
     ----------
@@ -568,6 +640,11 @@ def weighted_kappa(y_true, y_pred, *, sample_weight=None):
 
     y_pred : array-like of shape (n_samples,)
         Predicted labels.
+
+    labels : array-like of shape (n_classes,), default=None
+        Classes in ascending ordinal order, covering every value in
+        ``y_true`` and ``y_pred``. If ``None``, inferred from the data,
+        which must then be numeric.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights forwarded to the confusion matrix.
@@ -588,7 +665,8 @@ def weighted_kappa(y_true, y_pred, *, sample_weight=None):
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
-    cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
+    labels = _resolve_ordinal_labels(y_true, y_pred, labels)
+    cm = confusion_matrix(y_true, y_pred, labels=labels, sample_weight=sample_weight)
     n_class = cm.shape[0]
     costs = np.abs(np.arange(n_class)[:, None] - np.arange(n_class)[None, :])
     f = 1 - costs
@@ -633,7 +711,8 @@ def spearmans_rho(y_true, y_pred):
     -----
     Does not accept ``sample_weight``: weighted Spearman is not
     implemented in scipy and the rank correlation has no canonical
-    weighted definition.
+    weighted definition. Non-numeric labels are rejected: scipy would
+    coerce them and report a spurious ``0.0``.
 
     Examples
     --------
@@ -645,6 +724,11 @@ def spearmans_rho(y_true, y_pred):
     0.8464861424907173
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
+    if not (_numeric_label_order(y_true) and _numeric_label_order(y_pred)):
+        raise ValueError(
+            "spearmans_rho requires numeric labels; encode ordinal categories "
+            "as integers reflecting their order."
+        )
     if np.unique(y_true).size < 2 or np.unique(y_pred).size < 2:
         return 0.0
     corr, _ = scipy.stats.spearmanr(y_true, y_pred)
@@ -754,8 +838,9 @@ def accuracy_off1_score(y_true, y_pred, *, labels=None, sample_weight=None):
         Predicted labels.
 
     labels : array-like of shape (n_classes,), default=None
-        Labels of the classes used to index the confusion matrix. If
-        ``None``, the labels are inferred from ``y_true``.
+        Classes in ascending ordinal order, covering every value in
+        ``y_true`` and ``y_pred``. If ``None``, inferred from the data,
+        which must then be numeric.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights forwarded to the confusion matrix.
@@ -768,7 +853,8 @@ def accuracy_off1_score(y_true, y_pred, *, labels=None, sample_weight=None):
     Notes
     -----
     Both adjacent diagonals are counted: a prediction one class above
-    or one class below the truth contributes to the score.
+    or one class below the truth contributes to the score. Every sample
+    reaches the denominator, however far off its prediction is.
 
     Examples
     --------
@@ -781,9 +867,7 @@ def accuracy_off1_score(y_true, y_pred, *, labels=None, sample_weight=None):
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
-    if labels is None:
-        labels = np.unique(y_true)
-
+    labels = _resolve_ordinal_labels(y_true, y_pred, labels)
     conf_mat = confusion_matrix(
         y_true, y_pred, labels=labels, sample_weight=sample_weight
     )

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -42,8 +42,7 @@ def _check_metric_weight(y_true, sample_weight):
     weights = _check_sample_weight(
         weights, y_true, dtype=np.float64, ensure_non_negative=True
     )
-    # scikit-learn < 1.9 accepts an all-zero vector and lets the 0/0
-    # surface as nan downstream
+    # Before scikit-learn 1.9 an all-zero vector was accepted, letting 0/0 be nan
     if not weights.any():
         raise ValueError("Sample weights must contain at least one non-zero number.")
     return weights
@@ -228,7 +227,6 @@ def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> average_mean_absolute_error(y_true, y_pred)
     0.125
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -281,7 +279,6 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> geometric_mean(y_true, y_pred)
     0.8408964152537145
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -337,7 +334,6 @@ def gmsec(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> gmsec(y_true, y_pred)
     0.7071067811865476
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -384,7 +380,6 @@ def mean_extreme_sensitivity(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> mean_extreme_sensitivity(y_true, y_pred)
     0.75
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -435,7 +430,6 @@ def maximum_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> maximum_mean_absolute_error(y_true, y_pred)
     0.5
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -481,7 +475,6 @@ def minimum_sensitivity(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> minimum_sensitivity(y_true, y_pred)
     0.5
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -527,7 +520,6 @@ def mean_zero_one_error(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> mean_zero_one_error(y_true, y_pred)
     0.2857142857142857
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -573,7 +565,6 @@ def kendalls_tau(y_true, y_pred):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> kendalls_tau(y_true, y_pred)
     0.8140915784106943
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     if np.unique(y_true).size < 2 or np.unique(y_pred).size < 2:
@@ -622,7 +613,6 @@ def weighted_kappa(y_true, y_pred, *, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> weighted_kappa(y_true, y_pred)
     0.7586206896551724
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
@@ -681,7 +671,6 @@ def spearmans_rho(y_true, y_pred):
     >>> y_pred = np.array([0, 1, 1, 2, 3, 0, 1])
     >>> spearmans_rho(y_true, y_pred)
     0.8464861424907173
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     if np.unique(y_true).size < 2 or np.unique(y_pred).size < 2:
@@ -749,7 +738,6 @@ def ranked_probability_score(y_true, y_proba, *, sample_weight=None):
     ...      [0.1, 0.05, 0.65, 0.2]])
     >>> ranked_probability_score(y_true, y_pred)
     0.5068750000000001
-
     """
     y_true, y_proba = _check_proba_inputs(y_true, y_proba)
     n_samples, n_classes = y_proba.shape
@@ -818,7 +806,6 @@ def accuracy_off1_score(y_true, y_pred, *, labels=None, sample_weight=None):
     >>> y_pred = np.array([0, 1, 1, 2, 0, 0, 1])
     >>> accuracy_off1_score(y_true, y_pred)
     0.8571428571428571
-
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -6,7 +6,7 @@ from sklearn.metrics import (
     accuracy_score,
     confusion_matrix,
     mean_absolute_error,
-    recall_score,
+    precision_recall_fscore_support,
 )
 from sklearn.utils import check_array, check_consistent_length
 from sklearn.utils._param_validation import validate_params
@@ -110,42 +110,16 @@ def _check_proba_inputs(y_true, y_proba):
 
 
 def _recall_per_class(y_true, y_pred, *, labels=None, sample_weight=None):
-    """Return per-class recall as a 1-D float64 ndarray.
-
-    Thin wrapper around :func:`sklearn.metrics.recall_score` with
-    ``average=None`` and ``zero_division=0``. Centralises the call so
-    public sensitivity-based metrics share one implementation.
-
-    Parameters
-    ----------
-    y_true : ndarray of shape (n_samples,)
-        Ground truth labels.
-
-    y_pred : ndarray of shape (n_samples,)
-        Predicted labels.
-
-    labels : array-like of shape (n_classes,), default=None
-        Labels in the order to score. If ``None``, all unique labels are
-        used.
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    Returns
-    -------
-    sensitivities : ndarray of shape (n_classes,), dtype float64
-    """
-    return np.asarray(
-        recall_score(
-            y_true,
-            y_pred,
-            labels=labels,
-            average=None,
-            sample_weight=sample_weight,
-            zero_division=0,
-        ),
-        dtype=np.float64,
+    """Return per-class recall, dropping zero-support classes."""
+    _, recall, _, support = precision_recall_fscore_support(
+        y_true,
+        y_pred,
+        labels=labels,
+        average=None,
+        sample_weight=sample_weight,
+        zero_division=0,
     )
+    return np.asarray(recall[support > 0], dtype=np.float64)
 
 
 def _per_class_mae(y_true, y_pred, *, labels=None, sample_weight=None):
@@ -244,10 +218,10 @@ def average_mean_absolute_error(y_true, y_pred, *, sample_weight=None):
 def geometric_mean(y_true, y_pred, *, sample_weight=None):
     """Compute the geometric mean of per-class sensitivities.
 
-    Sensitivity (recall) is computed for every class from the confusion
-    matrix and the result is the geometric mean across classes. The
-    metric penalises poor performance on minority classes more strongly
-    than a simple average.
+    Sensitivity (recall) is computed for every class present in
+    ``y_true`` and the result is the geometric mean across those classes.
+    The metric penalises poor performance on minority classes more
+    strongly than a simple average.
 
     Parameters
     ----------
@@ -258,7 +232,7 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
         Predicted labels.
 
     sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights forwarded to the confusion matrix.
+        Sample weights.
 
     Returns
     -------
@@ -267,9 +241,8 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
 
     Notes
     -----
-    Classes with no ground-truth samples are treated as sensitivity 1,
-    leaving them out of the geometric mean. This avoids collapsing the
-    score to zero when a class has no support.
+    Only classes present in ``y_true`` enter the geometric mean; a class
+    that is predicted but never true does not contribute a zero factor.
 
     Examples
     --------
@@ -282,12 +255,11 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
     """
     y_true, y_pred = _check_metric_inputs(y_true, y_pred)
     sample_weight = _check_metric_weight(y_true, sample_weight)
-    cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
-    sum_by_class = cm.sum(axis=1)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        sensitivities = np.diag(cm) / sum_by_class.astype("double")
-    sensitivities[sum_by_class == 0] = 1
-    return float(pow(np.prod(sensitivities), 1.0 / cm.shape[0]))
+    sensitivities = _recall_per_class(y_true, y_pred, sample_weight=sample_weight)
+    # A zero factor forces the product to 0; the mean of logs avoids underflow
+    if (sensitivities == 0).any():
+        return 0.0
+    return float(np.exp(np.log(sensitivities).mean()))
 
 
 @validate_params(
@@ -460,7 +432,7 @@ def minimum_sensitivity(y_true, y_pred, *, sample_weight=None):
         Predicted labels.
 
     sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights forwarded to ``recall_score``.
+        Sample weights.
 
     Returns
     -------

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -27,6 +27,8 @@ from skordinal.metrics._metrics import (
     _check_metric_inputs,
     _check_metric_weight,
     _check_proba_inputs,
+    _numeric_label_order,
+    _resolve_ordinal_labels,
 )
 
 _WEIGHTED_METRICS = [
@@ -43,6 +45,19 @@ _WEIGHTED_METRICS = [
 ]
 
 _WEIGHTED_METRIC_IDS = [fn.__name__ for fn in _WEIGHTED_METRICS]
+
+
+# Metrics whose result depends on the ordinal class order, so they take labels=
+_ORDERED_METRICS = [
+    accuracy_off1_score,
+    average_mean_absolute_error,
+    gmsec,
+    maximum_mean_absolute_error,
+    mean_extreme_sensitivity,
+    weighted_kappa,
+]
+
+_ORDERED_METRIC_IDS = [fn.__name__ for fn in _ORDERED_METRICS]
 
 
 @pytest.fixture
@@ -277,6 +292,49 @@ def test_check_proba_inputs_row_sum_atol_boundary(delta, raises):
         _check_proba_inputs(y_t, y_p)
 
 
+@pytest.mark.parametrize(
+    "labels, expected",
+    [
+        (np.array([2, 0, 1]), True),
+        (np.array([0.5, 1.5]), True),
+        (np.array(["low", "mid"]), False),
+        (np.array(["2020-01-01"], dtype="datetime64[D]"), False),
+        (np.array([1, 2], dtype=object), True),
+        (np.array(["low", "mid"], dtype=object), False),
+        (np.array(["1", "2", "10"], dtype=object), False),
+    ],
+    ids=["int", "float", "str", "datetime", "object_int", "object_str", "object_digit"],
+)
+def test_numeric_label_order(labels, expected):
+    """Only dtypes whose sort order is the ordinal order count as numeric."""
+    assert _numeric_label_order(labels) is expected
+
+
+def test_resolve_ordinal_labels_resolves():
+    """The set is the sorted union of the data, or the given labels as given."""
+    y_true, y_pred = np.array([0, 0, 1]), np.array([0, 1, 2])
+    npt.assert_array_equal(_resolve_ordinal_labels(y_true, y_pred, None), [0, 1, 2])
+    # Sorting these would give high, low, mid, so the given order is what counts
+    order = np.array(["low", "mid", "high"])
+    npt.assert_array_equal(_resolve_ordinal_labels(order, order, order), order)
+
+
+@pytest.mark.parametrize(
+    "y_true, y_pred, labels, match",
+    [
+        (["a", "b"], ["a", "b"], None, "ordinal order of non-numeric labels"),
+        (["a", "b"], ["a", "b"], np.array([[0, 1], [2, 3]]), "1-D"),
+        (["a", "b"], ["a", "b"], np.array(["b"]), "y_true contains values"),
+        ([0, 0, 1], [0, 1, 2], np.array([0, 1]), "y_pred contains values"),
+    ],
+    ids=["non_numeric_data", "2d", "uncovered_true", "uncovered_pred"],
+)
+def test_resolve_ordinal_labels_rejects(y_true, y_pred, labels, match):
+    """A malformed, uncovering, or unorderable label set raises ValueError."""
+    with pytest.raises(ValueError, match=match):
+        _resolve_ordinal_labels(np.array(y_true), np.array(y_pred), labels)
+
+
 def test_accuracy_score():
     """accuracy_score correctly classifies a known label sequence."""
     y_true = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3])
@@ -289,7 +347,9 @@ def test_accuracy_score():
     [
         ([0, 1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 0], 5 / 6),
         ([0, 1, 2, 3, 4], [0, 2, 1, 4, 3], 1.0),
+        ([1, 2, 3], [1, 2, -5], 2 / 3),
     ],
+    ids=["shifted", "swapped", "out_of_scale"],
 )
 def test_accuracy_off1_score(y_true, y_pred, expected):
     """accuracy_off1_score counts predictions within one ordinal class of truth."""
@@ -310,6 +370,7 @@ def test_accuracy_off1_score_lower_diagonal():
         ([0, 0, 1, 1, 2, 2], [0, 0, 1, 1, 2, 2], 0.0),
         ([0, 0, 2, 1], [0, 2, 0, 1], 1.0),
         ([0, 0, 2, 1, 3], [2, 2, 0, 3, 1], 2.0),
+        ([0, 0, 10, 20], [0, 10, 10, 20], 1 / 6),
     ],
 )
 def test_average_mean_absolute_error(y_true, y_pred, expected):
@@ -525,6 +586,38 @@ def test_spearmans_rho_constant_input():
     npt.assert_equal(spearmans_rho(np.array([1, 1, 1, 1]), np.array([0, 1, 2, 3])), 0.0)
 
 
+@pytest.mark.parametrize(
+    "fn",
+    _ORDERED_METRICS + [kendalls_tau, spearmans_rho],
+    ids=_ORDERED_METRIC_IDS + ["kendalls_tau", "spearmans_rho"],
+)
+def test_ordered_metrics_reject_non_numeric_labels(fn):
+    """Without labels, non-numeric classes raise instead of sorting alphabetically."""
+    with pytest.raises(ValueError, match="numeric"):
+        fn(["low", "mid", "high"], ["low", "high", "high"])
+
+
+@pytest.mark.parametrize(
+    "fn", [weighted_kappa, average_mean_absolute_error], ids=["kappa", "amae"]
+)
+def test_labels_scores_string_classes_as_their_ranks(fn):
+    """An explicit labels order scores strings exactly as the equivalent ranks."""
+    npt.assert_allclose(
+        fn(
+            ["low", "mid", "high"],
+            ["low", "high", "high"],
+            labels=["low", "mid", "high"],
+        ),
+        fn([0, 1, 2], [0, 2, 2]),
+    )
+
+
+def test_labels_must_cover_the_data():
+    """A metric's explicit labels must cover y_pred, so no sample is dropped."""
+    with pytest.raises(ValueError, match="y_pred contains values"):
+        accuracy_off1_score([0, 1, 2], [0, 1, 5], labels=[0, 1, 2])
+
+
 def test_metric_names_in_all():
     """All public metric names are present in skordinal.metrics.__all__."""
     import skordinal.metrics as m
@@ -556,9 +649,10 @@ def test_sample_weight_is_keyword_only(fn):
     assert sig.parameters["sample_weight"].kind == inspect.Parameter.KEYWORD_ONLY
 
 
-def test_accuracy_off1_score_labels_is_keyword_only():
-    """labels is a keyword-only parameter of accuracy_off1_score."""
-    sig = inspect.signature(accuracy_off1_score)
+@pytest.mark.parametrize("fn", _ORDERED_METRICS, ids=_ORDERED_METRIC_IDS)
+def test_labels_is_keyword_only(fn):
+    """labels is a keyword-only parameter of every order-dependent metric."""
+    sig = inspect.signature(fn)
     assert sig.parameters["labels"].kind == inspect.Parameter.KEYWORD_ONLY
 
 

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -333,8 +333,8 @@ def test_geometric_mean():
     npt.assert_almost_equal(geometric_mean(y_true, y_pred), 0.7991, decimal=4)
 
 
-def test_geometric_mean_empty_class_treated_as_one():
-    """A class with zero total weight is treated as sensitivity 1, not 0."""
+def test_geometric_mean_zero_support_class_excluded():
+    """A class whose whole support is zero-weighted leaves the geometric mean."""
     y_true = np.array([0, 0, 1, 1, 2, 2])
     y_pred = np.array([0, 0, 1, 1, 2, 2])
     w = np.array([0.0, 0.0, 1.0, 1.0, 1.0, 1.0])
@@ -408,6 +408,16 @@ def test_maximum_mean_absolute_error_pred_only_class_excluded():
 def test_minimum_sensitivity(y_true, y_pred, expected):
     """minimum_sensitivity returns the lowest per-class recall."""
     npt.assert_almost_equal(minimum_sensitivity(y_true, y_pred), expected, decimal=6)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [minimum_sensitivity, gmsec, mean_extreme_sensitivity, geometric_mean],
+    ids=["minimum_sensitivity", "gmsec", "mean_extreme_sensitivity", "geometric_mean"],
+)
+def test_sensitivity_metrics_ignore_pred_only_class(fn):
+    """A class predicted but never true does not enter a recall-based metric."""
+    npt.assert_almost_equal(fn([0, 0, 1, 1], [0, 1, 1, 2]), 0.5, decimal=6)
 
 
 def test_mean_zero_one_error():

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -46,7 +46,6 @@ _WEIGHTED_METRICS = [
 
 _WEIGHTED_METRIC_IDS = [fn.__name__ for fn in _WEIGHTED_METRICS]
 
-
 # Metrics whose result depends on the ordinal class order, so they take labels=
 _ORDERED_METRICS = [
     accuracy_off1_score,
@@ -58,6 +57,12 @@ _ORDERED_METRICS = [
 ]
 
 _ORDERED_METRIC_IDS = [fn.__name__ for fn in _ORDERED_METRICS]
+
+
+@pytest.fixture
+def y_proba_3():
+    """Two rows of three-class probabilities, with exact 0 and 1 entries."""
+    return np.array([[1.0, 0.0, 0.0], [0.0, 0.5, 0.5]])
 
 
 @pytest.fixture
@@ -513,33 +518,56 @@ def test_ranked_probability_score_expands_binary_proba():
     npt.assert_allclose(ranked_probability_score(y_true, p.reshape(-1, 1)), expected)
 
 
-@pytest.mark.parametrize(
-    "y_true, y_proba, expected",
-    [
-        (
-            np.array([0, 5, 1]),
-            np.array([[1.0, 0.0, 0.0], [0.0, 0.5, 0.5], [0.0, 1.0, 0.0]]),
-            2.0 / 3,
+def test_ranked_probability_score_labels():
+    """labels maps raw class labels onto the y_proba columns and pins their count."""
+    labels = np.array([1, 2, 3])
+    # Asymmetric columns, so a mapping that failed to shift would score differently
+    y_proba = np.array([[0.2, 0.4, 0.4], [0.7, 0.2, 0.1]])
+    npt.assert_allclose(
+        ranked_probability_score(np.array([2, 1]), y_proba, labels=labels),
+        ranked_probability_score(np.array([1, 0]), y_proba),
+    )
+    # A one-hot y_true is already column indices, so labels must not re-map it;
+    # column 0 is outside labels, so a re-mapping would raise here
+    npt.assert_allclose(
+        ranked_probability_score(np.eye(3)[[0, 2]], y_proba, labels=labels),
+        ranked_probability_score(np.array([0, 2]), y_proba),
+    )
+    # A single label pins a lone column as a genuine one-class distribution
+    npt.assert_equal(
+        ranked_probability_score(
+            np.array([7, 7]), np.array([[1.0], [1.0]]), labels=np.array([7])
         ),
-        (np.array([5]), np.array([[0.2, 0.2, 0.2, 0.2, 0.2]]), 4.0),
+        0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "y_true, labels, one_column, match",
+    [
+        ([0, 5], None, False, "not belonging to the 3 columns"),
+        ([0, -1], None, False, "not belonging to the 3 columns"),
+        ([2, 9], np.array([1, 2, 3]), False, "not belonging to the passed labels"),
+        ([0, 1], np.array([3, 1, 2]), False, "strictly ascending"),
+        ([0, 1], np.array([1, 2]), False, "2 labels for 3 columns"),
+        ([0, 1], np.array([1, 2, 3]), True, "expanded to two columns"),
+        ([0, 1], np.array(["low", "mid", "high"]), False, "requires numeric labels"),
     ],
-    ids=["3_classes_mixed", "5_classes_single"],
+    ids=[
+        "above",
+        "below",
+        "outside_labels",
+        "unsorted",
+        "width",
+        "width_expanded",
+        "non_numeric",
+    ],
 )
-def test_ranked_probability_score_out_of_range(y_true, y_proba, expected):
-    """An out-of-range y_true is penalised by n_classes - 1, not a fixed constant."""
-    npt.assert_almost_equal(
-        ranked_probability_score(y_true, y_proba), expected, decimal=6
-    )
-
-
-def test_ranked_probability_score_out_of_range_no_better_than_worst_in_range():
-    """An out-of-range label scores no better than the worst in-range one."""
-    y_proba = np.array([[0.0, 0.0, 1.0]])
-    out_of_range = ranked_probability_score(np.array([9]), y_proba)
-    worst_in_range = max(
-        ranked_probability_score(np.array([label]), y_proba) for label in range(3)
-    )
-    assert out_of_range >= worst_in_range
+def test_ranked_probability_score_rejects(y_proba_3, y_true, labels, one_column, match):
+    """A y_true with no matching column, or a malformed labels, raises ValueError."""
+    y_proba = np.array([0.8, 0.3]) if one_column else y_proba_3
+    with pytest.raises(ValueError, match=match):
+        ranked_probability_score(np.array(y_true), y_proba, labels=labels)
 
 
 @pytest.mark.parametrize(

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -44,16 +44,20 @@ _WEIGHTED_METRICS = [
 
 _WEIGHTED_METRIC_IDS = [fn.__name__ for fn in _WEIGHTED_METRICS]
 
-_Y_PROBA_6 = np.array(
-    [
-        [0.7, 0.2, 0.1],
-        [0.1, 0.6, 0.3],
-        [0.2, 0.3, 0.5],
-        [0.3, 0.5, 0.2],
-        [0.6, 0.3, 0.1],
-        [0.1, 0.2, 0.7],
-    ]
-)
+
+@pytest.fixture
+def y_proba_6():
+    """Six rows of three-class probabilities."""
+    return np.array(
+        [
+            [0.7, 0.2, 0.1],
+            [0.1, 0.6, 0.3],
+            [0.2, 0.3, 0.5],
+            [0.3, 0.5, 0.2],
+            [0.6, 0.3, 0.1],
+            [0.1, 0.2, 0.7],
+        ]
+    )
 
 
 def test_check_metric_inputs_1d_passthrough():
@@ -559,7 +563,7 @@ def test_correlation_metrics_reject_sample_weight():
 
 
 @pytest.mark.parametrize("fn", _WEIGHTED_METRICS, ids=_WEIGHTED_METRIC_IDS)
-def test_metric_unit_sample_weight_matches_unweighted(fn):
+def test_metric_unit_sample_weight_matches_unweighted(fn, y_proba_6):
     """All-ones sample_weight produces the same result as no weight."""
     y_t = np.array([0, 1, 2, 1, 0, 2])
     y_p = np.array([0, 1, 1, 2, 0, 2])
@@ -567,8 +571,8 @@ def test_metric_unit_sample_weight_matches_unweighted(fn):
     w = np.ones(n)
 
     if fn is ranked_probability_score:
-        unweighted = fn(y_t, _Y_PROBA_6)
-        weighted = fn(y_t, _Y_PROBA_6, sample_weight=w)
+        unweighted = fn(y_t, y_proba_6)
+        weighted = fn(y_t, y_proba_6, sample_weight=w)
     else:
         unweighted = fn(y_t, y_p)
         weighted = fn(y_t, y_p, sample_weight=w)
@@ -620,11 +624,11 @@ def test_check_metric_weight_ravels_column_vector():
 
 
 @pytest.mark.parametrize("fn", _WEIGHTED_METRICS, ids=_WEIGHTED_METRIC_IDS)
-def test_metric_routes_sample_weight_through_the_check(fn):
+def test_metric_routes_sample_weight_through_the_check(fn, y_proba_6):
     """Every weighted metric rejects an all-zero sample_weight."""
     y_t = np.array([0, 1, 2, 1, 0, 2])
     y_p = np.array([0, 1, 1, 2, 0, 2])
-    x = _Y_PROBA_6 if fn is ranked_probability_score else y_p
+    x = y_proba_6 if fn is ranked_probability_score else y_p
     with pytest.raises(ValueError, match="non-zero"):
         fn(y_t, x, sample_weight=np.zeros(len(y_t)))
 
@@ -634,13 +638,13 @@ def test_metric_routes_sample_weight_through_the_check(fn):
     _WEIGHTED_METRICS + [kendalls_tau, spearmans_rho],
     ids=_WEIGHTED_METRIC_IDS + ["kendalls_tau", "spearmans_rho"],
 )
-def test_metric_returns_python_float(fn):
+def test_metric_returns_python_float(fn, y_proba_6):
     """Every public metric returns a Python float, not a numpy scalar."""
     y_t = np.array([0, 1, 2, 1, 0, 2])
     y_p = np.array([0, 1, 1, 2, 0, 2])
 
     if fn is ranked_probability_score:
-        result = fn(y_t, _Y_PROBA_6)
+        result = fn(y_t, y_proba_6)
     else:
         result = fn(y_t, y_p)
 
@@ -651,6 +655,6 @@ def test_metric_returns_python_float(fn):
 
 def test_metric_rejects_non_array_like_y_true():
     """A scalar y_true is rejected at the parameter boundary."""
-    # decorator fires before _check_metric_inputs
+    # Decorator fires before _check_metric_inputs
     with pytest.raises(InvalidParameterError):
         average_mean_absolute_error(1.0, [1, 2])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Fixes the ordinal metrics to stop letting a class absent from `y_true` skew their score, and adds a `labels` parameter to state the class order when it can't be inferred (ascending, required for non-numeric classes). `ranked_probability_score` now raises on an out-of-range `y_true` instead of applying a fixed penalty.

#### Any other comments?

Changes published values for `minimum_sensitivity`, `gmsec`, `mean_extreme_sensitivity`, `geometric_mean`, and `accuracy_off1_score`.