### PR TITLE
DOC: Settle the NNOP predict decision rule

### DIFF
--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -90,6 +90,10 @@ class NNOP(ClassifierMixin, BaseEstimator):
     If the L-BFGS-B solver stops before converging, a ``ConvergenceWarning``
     is raised and ``n_iter_`` reports the iterations actually run.
 
+    ``predict`` uses the first-crossing rule on the raw cumulative outputs, so
+    its output is not in general ``classes_[argmax(predict_proba(X), axis=1)]``;
+    see ``predict`` for the rationale.
+
     This file is part of ORCA: https://github.com/ayrna/orca
 
     References
@@ -246,10 +250,11 @@ class NNOP(ClassifierMixin, BaseEstimator):
     def predict(self, X: ArrayLike) -> np.ndarray:
         """Perform classification on samples in X.
 
-        The predicted class is the first class whose (raw, unrepaired)
-        cumulative estimate ``P(y <= k | x)`` exceeds 0.5 (the
-        median/first-crossing rule). This is not in general the same
-        class as ``classes_[argmax(predict_proba(X), axis=1)]``; see the
+        The predicted class is the first class whose raw cumulative
+        estimate ``P(y <= k | x)`` exceeds 0.5 (the first-crossing
+        rule). The isotonic repair applied by ``predict_proba`` is
+        post-processing, not part of the model, so the result is not in
+        general ``classes_[argmax(predict_proba(X), axis=1)]``; see the
         Notes on ``predict_proba``.
 
         Parameters
@@ -345,13 +350,12 @@ class NNOP(ClassifierMixin, BaseEstimator):
 
         Notes
         -----
-        Because ``predict`` follows the canonical NNOP decision rule of
-        picking the first class whose raw cumulative estimate exceeds
-        0.5 (a median/first-crossing rule), rather than the argmax of
-        this method's output, ``classes_[argmax(predict_proba(X),
-        axis=1)]`` is not in general equal to ``predict(X)``. Users
-        needing calibrated, argmax-consistent probabilities should wrap
-        the estimator with ``sklearn.calibration.CalibratedClassifierCV``.
+        ``predict`` applies the first-crossing rule to the raw cumulative
+        estimates instead of taking the argmax of this method's output, so
+        ``classes_[argmax(predict_proba(X), axis=1)]`` is not in general
+        equal to ``predict(X)``. Users needing calibrated,
+        argmax-consistent probabilities should wrap the estimator with
+        ``sklearn.calibration.CalibratedClassifierCV``.
 
         """
         check_is_fitted(self)

--- a/skordinal/classifiers/tests/test_nnop.py
+++ b/skordinal/classifiers/tests/test_nnop.py
@@ -292,6 +292,27 @@ def test_nnop_predict_cumproba_repairs_non_monotone_raw_row():
     np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-8)
 
 
+def test_nnop_predict_follows_first_crossing_not_argmax():
+    """predict uses the raw first crossing, not the repaired proba argmax."""
+    clf = NNOP(n_hidden=1, max_iter=1).fit(
+        np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]]),
+        np.array([0, 0, 1, 1, 2, 2]),
+    )
+    # Overwrite fitted state so the raw row crosses 0.5 at column 0 while
+    # the isotonic repair averages both columns below 0.5, moving the
+    # proba argmax to the top class
+    clf.theta1_ = np.zeros((1, 2))
+    clf.theta2_ = np.array([[1.0, 0.0], [-2.0, 0.0]])
+
+    probe = np.array([[0.0]])
+    raw = clf._cumproba(probe)
+    assert raw[0, 0] > 0.5 > raw[0, 1]
+
+    modal = clf.classes_[np.argmax(clf.predict_proba(probe), axis=1)]
+    np.testing.assert_array_equal(clf.predict(probe), [0])
+    np.testing.assert_array_equal(modal, [2])
+
+
 def test_nnop_convergence_warning_only_at_insufficient_max_iter(ordinal_data):
     """ConvergenceWarning fires at max_iter=1, not with the default budget."""
     X, y = ordinal_data


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`NNOP.predict` picks the first class whose raw cumulative output crosses 0.5, while `predict_proba` uses the isotonically repaired cumulatives. The two can disagree, so `predict(X)` is not always `classes_[argmax(predict_proba(X), axis=1)]`. This was already documented in `predict`, but not in the class summary, and no test pinned it. This PR adds the missing docstring note and a regression test.