### PR TITLE
BLD: Modernise the pyproject packaging metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ dev = [
     "mypy>=1.9",
     "pre-commit",
 ]
+docs = [
+    "sphinx>=7",
+    "pydata-sphinx-theme",
+    "numpydoc",
+    "sphinx-gallery",
+    "matplotlib",
+]
 
 [project.urls]
 Homepage = "https://github.com/ayrna/skordinal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,12 @@ ext-modules = [
 
 [tool.pytest.ini_options]
 testpaths = ["skordinal"]
-addopts = ["--color=yes", "--import-mode=importlib"]
+addopts = ["--color=yes", "--import-mode=importlib", "-m", "not network"]
+markers = [
+    "slow: benchmarks and long-running tests",
+    "integration: end-to-end sklearn pipeline integration",
+    "network: tests that require a live internet connection",
+]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=74.1.0", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.1.0rc1"
 description = "Ordinal classification for Python, scikit-learn compatible"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 authors = [
     {name = "David Guijo-Rubio", email = "dguijo@uco.es"},
     {name = "Ángel Sevilla Molina", email = "asevilla@uco.es"},
@@ -25,7 +26,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: Unix",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Modernises `pyproject.toml` packaging metadata:

- Adds a `docs` optional-dependency extra (`sphinx`, `pydata-sphinx-theme`, `numpydoc`, `sphinx-gallery`, `matplotlib`).
- Migrates licence metadata to PEP 639: `license = "BSD-3-Clause"` with `license-files = ["LICENSE"]`, drops the deprecated License classifier, and raises the build requirement to `setuptools>=77`, clearing two `SetuptoolsDeprecationWarning`s on every build.
- Registers the `slow`, `integration` and `network` pytest markers, preventing unknown-marker warnings, and moves `-m "not network"` into `addopts` so a bare `pytest` run matches CI's filter.