### PR TITLE
DOC: Add the Sphinx documentation scaffold and wire Read the Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/api/generated/
 
 # PyBuilder
 target/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,13 @@
+# Minimal makefile for Sphinx documentation
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/api/classifiers.rst
+++ b/docs/api/classifiers.rst
@@ -1,0 +1,29 @@
+Classifiers
+===========
+
+Every classifier here models the order of the target rather than treating the
+classes as unrelated labels. They do so in different ways: by placing learned
+thresholds on a latent scale, by predicting the cumulative distribution over
+classes, or by decomposing the problem into ordered binary subproblems. The
+three meta-estimators at the end build an ordinal classifier out of an
+ordinary classifier or regressor.
+
+.. currentmodule:: skordinal.classifiers
+
+.. autosummary::
+   :toctree: generated/
+
+   POM
+   LogisticAT
+   LogisticIT
+   NNPOM
+   NNOP
+   ELMOP
+   KDLOR
+   REDSVM
+   SVOREX
+   SVORIM
+   ORBoost
+   OrdinalDecomposition
+   RegressorWrapper
+   CostSensitiveWrapper

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -1,0 +1,27 @@
+Datasets
+========
+
+skordinal ships five classic ordinal benchmark datasets that can be loaded
+without any external download. Each loader follows the scikit-learn
+:class:`~sklearn.utils.Bunch` API: call with ``return_X_y=True`` to receive
+``(X, y)`` NumPy arrays directly. Any other CSV dataset is resolved by name or
+path with :func:`~skordinal.datasets.load_dataset`, its train/test resamples
+are yielded by :func:`~skordinal.datasets.load_partitions`, and
+:func:`~skordinal.datasets.make_ordinal_classification` generates synthetic
+ordinal problems.
+
+.. currentmodule:: skordinal.datasets
+
+.. autosummary::
+   :toctree: generated/
+
+   load_balance_scale
+   load_era
+   load_esl
+   load_lev
+   load_swd
+   load_dataset
+   load_partitions
+   make_ordinal_classification
+   get_data_home
+   clear_data_home

--- a/docs/api/experiments.rst
+++ b/docs/api/experiments.rst
@@ -1,0 +1,103 @@
+Experiments
+===========
+
+The experiments module provides three coordinated concepts for running
+ordinal classification studies at any scale, from a single evaluation to a
+full multi-classifier × multi-dataset benchmark.
+
+**ModelConfig — method configuration**
+  :class:`~skordinal.experiments.ModelConfig` pairs a classifier instance
+  with an optional hyperparameter grid.  It is immutable and carries no
+  evaluation protocol::
+
+      from skordinal.classifiers import POM, SVOREX
+      from skordinal.experiments import ModelConfig
+
+      pom = ModelConfig(POM())
+      svorex = ModelConfig(SVOREX(), param_grid={"C": [0.1, 1, 10]})
+
+**Experiment — single execution**
+  :class:`~skordinal.experiments.Experiment` runs one
+  :class:`~skordinal.experiments.ModelConfig` on a single dataset partition.
+  The evaluation protocol (``eval_metrics``, ``tuning_metric``, ``cv``,
+  ``input_preprocessing``, ``random_state``) is fixed at construction, while
+  the data split and the labels identifying it are passed to
+  :meth:`~skordinal.experiments.Experiment.run`::
+
+      from skordinal.experiments import Experiment
+
+      exp = Experiment(
+          pom,
+          eval_metrics=["mean_absolute_error", "weighted_kappa"],
+          tuning_metric="neg_mean_absolute_error",
+          cv=5,
+          random_state=0,
+      )
+      result = exp.run(
+          X_train,
+          y_train,
+          X_test,
+          y_test,
+          dataset_name="era",
+          classifier_name="POM",
+          resample_id=0,
+      )
+
+  ``result`` is an :class:`~skordinal.experiments.ExperimentResult` dataclass
+  containing predictions, metric scores, best hyperparameters, and timing.
+  Nothing is written to disk.
+
+**Benchmark — the cross product**
+  :class:`~skordinal.experiments.Benchmark` holds a labelled set of
+  :class:`~skordinal.experiments.ModelConfig` objects and one shared
+  evaluation protocol.  It builds and runs an
+  :class:`~skordinal.experiments.Experiment` for every
+  ``(model, dataset, resample)`` cell, collecting all
+  :class:`~skordinal.experiments.ExperimentResult` values and writing them
+  to disk::
+
+      from skordinal.experiments import Benchmark
+
+      bench = Benchmark(
+          models={"POM": pom, "SVOREX": svorex},
+          datasets=["era", "esl"],
+          eval_metrics=["mean_absolute_error", "weighted_kappa"],
+          results_path="./results/",
+          resamples=30,
+          tuning_metric="neg_mean_absolute_error",
+          cv=5,
+          random_state=0,
+      )
+      bench.run()
+      bench.summarize()
+
+  Resamples already saved are skipped unless ``overwrite=True``, so a run is
+  resumable.  :meth:`~skordinal.experiments.Benchmark.summarize` writes the
+  aggregated train and test summaries.
+
+  The quickest way to run a study is via the recipe interface.  Define a
+  ``RECIPE`` dict in a standalone Python file (see ``examples/recipes/`` for
+  templates) and run it from the command line::
+
+      python examples/run_recipe.py examples/recipes/full_demo.py
+
+  :meth:`~skordinal.experiments.Benchmark.from_recipe` reads the recipe and
+  constructs the :class:`~skordinal.experiments.Benchmark` automatically:
+  ``models`` becomes the positional argument and the remaining keys are
+  forwarded as keyword arguments.
+
+.. currentmodule:: skordinal.experiments
+
+.. autosummary::
+   :toctree: generated/
+
+   ModelConfig
+   Experiment
+   ExperimentResult
+   Benchmark
+   Results
+   load_recipe
+   validate_recipe
+   summarize
+   save_summary
+   tabulate_results

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,12 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   classifiers
+   metrics
+   datasets
+   experiments
+   preprocessing
+   utils

--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -1,0 +1,38 @@
+Metrics
+=======
+
+An ordinal prediction can be wrong by one class or by five, and these metrics
+tell those cases apart, which plain accuracy cannot. Thirteen of them score
+predicted labels and fall into five groups: distance to the true class (MAE,
+AMAE, MMAE), exact and off-by-one accuracy and its complement the error rate
+(MZE), per-class sensitivity (MS, GMSEC, the geometric mean of the
+sensitivities and the mean extreme sensitivity), agreement corrected for
+chance (weighted kappa) and rank correlation (Kendall's tau, Spearman's rho).
+The fourteenth, :func:`~skordinal.metrics.ranked_probability_score`, scores a
+full predicted distribution instead.
+
+:func:`~skordinal.metrics.get_ordinal_scorer` wraps any of them, except
+:func:`~skordinal.metrics.ranked_probability_score`, as a scikit-learn scorer
+for :class:`~sklearn.model_selection.GridSearchCV`.
+
+.. currentmodule:: skordinal.metrics
+
+.. autosummary::
+   :toctree: generated/
+
+   mean_absolute_error
+   average_mean_absolute_error
+   maximum_mean_absolute_error
+   mean_zero_one_error
+   accuracy_score
+   accuracy_off1_score
+   geometric_mean
+   gmsec
+   minimum_sensitivity
+   mean_extreme_sensitivity
+   kendalls_tau
+   spearmans_rho
+   weighted_kappa
+   ranked_probability_score
+   get_ordinal_scorer
+   get_ordinal_scorer_names

--- a/docs/api/preprocessing.rst
+++ b/docs/api/preprocessing.rst
@@ -1,0 +1,14 @@
+Preprocessing
+=============
+
+The preprocessing module provides ordinal-specific coding utilities, such as
+building the coding matrix used by ordinal decomposition methods.
+
+.. currentmodule:: skordinal.preprocessing
+
+.. autosummary::
+   :toctree: generated/
+
+   build_coding_matrix
+   ordinal_to_binary_cumulative
+   binary_cumulative_to_ordinal

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,0 +1,17 @@
+Utilities
+=========
+
+A small public utility tier for ordinal estimator authors, covering target
+validation and cumulative-probability helpers used by classifiers and metrics
+throughout skordinal.
+
+.. currentmodule:: skordinal.utils
+
+.. autosummary::
+   :toctree: generated/
+
+   check_ordinal_targets
+   check_thresholds
+   proba_to_cumproba
+   cumproba_to_proba
+   repair_cumproba

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,145 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# Source-docstring compatibility notes
+# -------------------------------------
+# All classifier docstrings include fitted-attribute names such as
+# ``n_features_in_`` in type strings (e.g. "ndarray of shape
+# (n_features_in_,)").  In plain RST, a word ending with ``_`` is a
+# hyperlink reference, producing "Unknown target name" errors.  An
+# ``autodoc-process-docstring`` hook escapes those trailing underscores
+# to ``\_`` inside parenthesised shape expressions.
+
+import inspect
+import re
+import sys
+from pathlib import Path
+
+# --- Project metadata -------------------------------------------------------
+import skordinal  # noqa: E402
+
+project = "skordinal"
+copyright = "2026, AYRNA – Universidad de Córdoba"
+author = "Ángel Sevilla Molina, Pedro A. Gutiérrez Peña, David Guijo Rubio"
+release = skordinal.__version__
+
+# --- Extensions -------------------------------------------------------------
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
+    "numpydoc",
+]
+
+# --- Theme ------------------------------------------------------------------
+
+html_theme = "pydata_sphinx_theme"
+
+html_theme_options = {
+    "github_url": "https://github.com/ayrna/skordinal",
+}
+
+# --- Intersphinx ------------------------------------------------------------
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    "sklearn": ("https://scikit-learn.org/stable", None),
+}
+
+# --- Autodoc / autosummary --------------------------------------------------
+
+# Each api/*.rst lists its public names in an ``autosummary`` toctree, so the
+# stub pages under api/generated/ are built from scratch on every run.
+autosummary_generate = True
+
+# The C extension modules are compiled separately; mock them so autodoc can
+# import the pure-Python wrappers without a compiled extension present.
+autodoc_mock_imports = [
+    "skordinal.classifiers._libsvmrank",
+    "skordinal.classifiers._libsvorex",
+    "skordinal.classifiers._libsvorim",
+    "skordinal.classifiers._orensemble",
+]
+
+# --- Source links -----------------------------------------------------------
+
+# ``viewcode`` would republish the source of every documented object inside the
+# site, scikit-learn's ``accuracy_score`` and ``mean_absolute_error`` included,
+# since ``skordinal.metrics`` re-exports them. ``linkcode`` points at the real
+# file on GitHub instead, and skips anything that is not skordinal source.
+
+_SOURCE_URL = (
+    "https://github.com/ayrna/skordinal/blob/main/skordinal/{path}#L{start}-L{end}"
+)
+
+
+def linkcode_resolve(domain, info):
+    """Return the GitHub URL for a documented object, or ``None`` to omit it."""
+    if domain != "py" or (info.get("module") or "").split(".")[0] != "skordinal":
+        return None
+
+    obj = sys.modules.get(info["module"])
+    for part in info["fullname"].split("."):
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+
+    try:
+        file = inspect.getsourcefile(inspect.unwrap(obj))
+        lines, start = inspect.getsourcelines(inspect.unwrap(obj))
+    except (OSError, TypeError):
+        return None
+    if file is None:
+        return None
+
+    try:
+        path = (
+            Path(file).resolve().relative_to(Path(skordinal.__file__).resolve().parent)
+        )
+    except ValueError:
+        return None
+
+    return _SOURCE_URL.format(
+        path=path.as_posix(), start=start, end=start + len(lines) - 1
+    )
+
+
+# --- numpydoc ---------------------------------------------------------------
+
+numpydoc_show_class_members = False
+
+# --- Build targets ----------------------------------------------------------
+
+exclude_patterns = ["_build"]
+
+# --- Docstring post-processing ----------------------------------------------
+
+# Trailing underscores in plain text inside RST are treated as hyperlink
+# references (RST ``target_`` syntax).  Fitted sklearn attribute names such
+# as ``n_features_in_`` appear bare in shape descriptions and cause
+# "Unknown target name" ERROR nodes.  Escape them to ``\_``.
+_TRAILING_UNDERSCORE_RE = re.compile(
+    r"(?<![`\\])"  # not already escaped or inside a backtick role
+    r"([A-Za-z][A-Za-z0-9_]*)"  # identifier
+    r"_"  # trailing underscore (RST hyperlink ref syntax)
+    r"(?![_`a-zA-Z])",  # not followed by another _ or backtick
+)
+
+
+def _fixup_docstring(app, what, name, obj, options, lines):
+    """Normalise docstring lines for clean RST rendering.
+
+    Escapes bare trailing-underscore identifiers (fitted attribute names)
+    that RST would interpret as hyperlink references.
+    """
+    for i, line in enumerate(lines):
+        line = _TRAILING_UNDERSCORE_RE.sub(r"\1\\_", line)
+        lines[i] = line
+
+
+def setup(app):
+    app.connect("autodoc-process-docstring", _fixup_docstring)
+    return {"version": "0.1", "parallel_read_safe": True}

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,50 @@
+Getting Started
+===============
+
+Installation
+------------
+
+Install the latest release from PyPI::
+
+   pip install skordinal
+
+Binary wheels are published for Linux x86-64. On every other platform pip
+builds the four C extensions (``REDSVM``, ``SVOREX``, ``SVORIM``, ``ORBoost``)
+from source, which requires a C/C++ compiler.
+
+For a development install, in editable mode and with every optional
+dependency::
+
+   git clone https://github.com/ayrna/skordinal.git
+   cd skordinal
+   pip install -e ".[dev,docs]"
+
+Quickstart
+----------
+
+The example below loads a bundled ordinal dataset, trains a ``POM``
+classifier, and evaluates it with two ordinal metrics::
+
+   from sklearn.model_selection import train_test_split
+
+   from skordinal.datasets import load_era
+   from skordinal.classifiers import POM
+   from skordinal.metrics import mean_absolute_error, weighted_kappa
+
+   X, y = load_era(return_X_y=True)
+   X_train, X_test, y_train, y_test = train_test_split(
+       X, y, test_size=0.2, random_state=0, stratify=y
+   )
+
+   clf = POM()
+   clf.fit(X_train, y_train)
+   y_pred = clf.predict(X_test)
+
+   print(f"MAE:   {mean_absolute_error(y_test, y_pred):.3f}")
+   print(f"Kappa: {weighted_kappa(y_test, y_pred):.3f}")
+
+Every classifier implements the standard scikit-learn ``fit`` / ``predict``
+interface, so it composes with :class:`~sklearn.pipeline.Pipeline`,
+:func:`~sklearn.model_selection.cross_val_score` and
+:class:`~sklearn.model_selection.GridSearchCV` without adaptation. The
+:doc:`api/index` documents every class and function.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,57 @@
+skordinal
+=========
+
+**skordinal** is a scikit-learn compatible library for **ordinal
+classification**, the supervised task whose class labels have a natural order
+but no known distance between them, such as a rating from ``poor`` to
+``excellent`` or a disease graded from ``I`` to ``IV``.
+
+A nominal classifier ignores that order, so confusing ``poor`` with
+``excellent`` costs it exactly as much as confusing ``poor`` with ``fair``.
+The estimators here model the order instead, and the metrics score a
+prediction against it.
+
+Every estimator follows the scikit-learn API, so it drops unchanged into
+:class:`~sklearn.pipeline.Pipeline`,
+:class:`~sklearn.model_selection.GridSearchCV` and the rest of the ecosystem.
+See :doc:`getting_started` to install it and fit the first model.
+
+At a glance
+-----------
+
+**Fourteen ordinal classifiers**: threshold models
+(:class:`~skordinal.classifiers.POM`,
+:class:`~skordinal.classifiers.LogisticAT`,
+:class:`~skordinal.classifiers.LogisticIT`), neural networks
+(:class:`~skordinal.classifiers.NNPOM`,
+:class:`~skordinal.classifiers.NNOP`,
+:class:`~skordinal.classifiers.ELMOP`), kernel discriminants
+(:class:`~skordinal.classifiers.KDLOR`), support vector machines
+(:class:`~skordinal.classifiers.REDSVM`,
+:class:`~skordinal.classifiers.SVOREX`,
+:class:`~skordinal.classifiers.SVORIM`), boosting
+(:class:`~skordinal.classifiers.ORBoost`) and three meta-estimators
+(:class:`~skordinal.classifiers.OrdinalDecomposition`,
+:class:`~skordinal.classifiers.RegressorWrapper`,
+:class:`~skordinal.classifiers.CostSensitiveWrapper`) that build an ordinal
+classifier out of an ordinary one.
+
+**Fourteen metrics** spanning the ways an ordinal prediction can be judged:
+distance to the true class (MAE, AMAE, MMAE), exact and off-by-one accuracy
+and its complement the error rate (MZE), per-class sensitivity (MS, GMSEC and
+two more), agreement corrected for chance (weighted kappa), rank correlation
+(Kendall's tau, Spearman's rho) and the full predicted distribution (ranked
+probability score). All but the last are available as scikit-learn scorers
+through :func:`~skordinal.metrics.get_ordinal_scorer`.
+
+**Datasets and an experiment harness**: five bundled ordinal datasets, a
+loader for your own CSV files with reproducible resamples, and a
+:class:`~skordinal.experiments.Benchmark` that fits every combination of
+model, dataset and resample and writes the aggregated results to disk.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents
+
+   getting_started
+   api/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ git-only = [
     ".codecov.yml",
     ".coveragerc",
     ".gitignore",
+    "docs/**",
     "examples/**",
     "skordinal/**/tests/**",
     "skordinal/classifiers/src/libsvmrank/grid.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ git-only = [
     ".codecov.yml",
     ".coveragerc",
     ".gitignore",
+    ".readthedocs.yaml",
     "docs/**",
     "examples/**",
     "skordinal/**/tests/**",

--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -94,7 +94,8 @@ class NNOP(ClassifierMixin, BaseEstimator):
     its output is not in general ``classes_[argmax(predict_proba(X), axis=1)]``;
     see ``predict`` for the rationale.
 
-    This file is part of ORCA: https://github.com/ayrna/orca
+    Ported from the ORCA MATLAB toolbox by P. A. Gutiérrez, M. Pérez-Ortiz
+    and J. Sánchez-Monedero, https://github.com/ayrna/orca.
 
     References
     ----------
@@ -107,20 +108,6 @@ class NNOP(ClassifierMixin, BaseEstimator):
            experimental study", IEEE Transactions on Knowledge and Data
            Engineering, Vol. 28. Issue 1, 2016,
            http://dx.doi.org/10.1109/TKDE.2015.2457911
-
-    Copyright
-    ---------
-    This software is released under the The GNU General Public License v3.0 licence
-    available at http://www.gnu.org/licenses/gpl-3.0.html
-
-    Authors
-    -------
-    Pedro Antonio Gutiérrez, María Pérez Ortiz, Javier Sánchez Monedero
-
-    Citation
-    --------
-    If you use this code, please cite the associated paper
-    http://www.uco.es/grupos/ayrna/orreview
 
     """
 

--- a/skordinal/classifiers/_nnpom.py
+++ b/skordinal/classifiers/_nnpom.py
@@ -99,6 +99,9 @@ class NNPOM(ClassifierMixin, BaseEstimator):
     If the L-BFGS-B solver stops before converging, a ``ConvergenceWarning``
     is raised and ``n_iter_`` reports the iterations actually run.
 
+    Ported from the ORCA MATLAB toolbox by P. A. Gutiérrez, M. Pérez-Ortiz
+    and J. Sánchez-Monedero, https://github.com/ayrna/orca.
+
     References
     ----------
     .. [1] P. McCullagh, "Regression models for ordinal data", Journal of the
@@ -113,20 +116,6 @@ class NNPOM(ClassifierMixin, BaseEstimator):
            study", IEEE Transactions on Knowledge and Data Engineering, Vol. 28. Issue
            1, 2016,
            https://doi.org/10.1109/TKDE.2015.2457911
-
-    Copyright
-    ---------
-    This software is released under the The GNU General Public License v3.0 licence
-    available at http://www.gnu.org/licenses/gpl-3.0.html
-
-    Authors
-    -------
-    Pedro Antonio Gutiérrez, María Pérez Ortiz, Javier Sánchez Monedero
-
-    Citation
-    --------
-    If you use this code, please cite the associated paper
-    http://www.uco.es/grupos/ayrna/orreview
 
     """
 

--- a/skordinal/classifiers/_redsvm.py
+++ b/skordinal/classifiers/_redsvm.py
@@ -29,15 +29,16 @@ class REDSVM(ClassifierMixin, BaseEstimator):
 
     kernel : str, default="rbf"
         Set type of kernel function.
-        - linear: u'*v
-        - polynomial: (gamma*u'*v + coef0)^degree
-        - rbf: exp(-gamma*|u-v|^2)
-        - sigmoid: tanh(gamma*u'*v + coef0)
-        - stump: -|u-v|_1 + coef0
-        - perceptron: -|u-v|_2 + coef0
-        - laplacian: exp(-gamma*|u-v|_1)
-        - exponential: exp(-gamma*|u-v|_2)
-        - precomputed: kernel values in training_instance_matrix
+
+        - linear: ``u'*v``
+        - polynomial: ``(gamma*u'*v + coef0)^degree``
+        - rbf: ``exp(-gamma*|u-v|^2)``
+        - sigmoid: ``tanh(gamma*u'*v + coef0)``
+        - stump: ``-|u-v|_1 + coef0``
+        - perceptron: ``-|u-v|_2 + coef0``
+        - laplacian: ``exp(-gamma*|u-v|_1)``
+        - exponential: ``exp(-gamma*|u-v|_2)``
+        - precomputed: kernel values in ``training_instance_matrix``
 
     degree : int, default=3
         Set degree in kernel function.

--- a/skordinal/metrics/_metrics.py
+++ b/skordinal/metrics/_metrics.py
@@ -353,10 +353,10 @@ def geometric_mean(y_true, y_pred, *, sample_weight=None):
 def gmsec(y_true, y_pred, *, labels=None, sample_weight=None):
     """Geometric mean of the sensitivities of the extreme ordinal classes.
 
-    Proposed in :footcite:t:`vargas2024improving` to assess the
-    classification performance on the first and the last classes of an
-    ordinal scale. Returns the geometric mean of the recall of the
-    lowest and the highest classes that appear in ``y_true``.
+    Proposed in [1]_ to assess the classification performance on the
+    first and the last classes of an ordinal scale. Returns the geometric
+    mean of the recall of the lowest and the highest classes that appear
+    in ``y_true``.
 
     Parameters
     ----------
@@ -381,7 +381,11 @@ def gmsec(y_true, y_pred, *, labels=None, sample_weight=None):
 
     References
     ----------
-    .. footbibliography::
+    .. [1] V. M. Vargas, P. A. Gutiérrez, J. Barbero-Gómez and
+           C. Hervás-Martínez, "Improving the classification of extreme
+           classes by means of loss regularisation and generalised beta
+           distributions", arXiv:2407.12417, 2024,
+           https://doi.org/10.48550/arXiv.2407.12417
 
     Examples
     --------
@@ -790,8 +794,8 @@ def ranked_probability_score(y_true, y_proba, *, labels=None, sample_weight=None
 
     Quadratic distance between the cumulative ground-truth indicator
     function and the cumulative predicted distribution, averaged over
-    samples. The lower the value, the better. Defined for ordinal
-    targets in :footcite:t:`janitza2016random`.
+    samples. The lower the value, the better. Defined for ordinal targets
+    in [1]_.
 
     Parameters
     ----------
@@ -829,7 +833,10 @@ def ranked_probability_score(y_true, y_proba, *, labels=None, sample_weight=None
 
     References
     ----------
-    .. footbibliography::
+    .. [1] S. Janitza, G. Tutz and A.-L. Boulesteix, "Random forest for ordinal
+           responses: prediction and variable selection", Computational
+           Statistics & Data Analysis, vol. 96, pp. 57-73, 2016,
+           https://doi.org/10.1016/j.csda.2015.10.005
 
     Examples
     --------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds the Sphinx documentation scaffold under `docs/`: a landing page, a getting-started guide, and one generated page per public class or function via `autosummary`. Source links point to GitHub instead of vendoring third-party source. The build is warning-free.

Fixes RST issues the build surfaced: broken markup from raw `*`/`|` characters in the `REDSVM` kernel-formula list, two `footcite` references in `_metrics.py` never wired to a bibliography, and a stale GPL notice in `NNOP`/`NNPOM` that contradicted the package's BSD-3-Clause license.

Adds `.readthedocs.yaml` to build the docs on Read the Docs from `docs/conf.py`.

#### Any other comments?

Read the Docs still needs the project imported on readthedocs.org. The YAML alone does not publish anything.