### PR TITLE
ENH: Add the experiments results readers

### DIFF
--- a/skordinal/experiments/__init__.py
+++ b/skordinal/experiments/__init__.py
@@ -1,7 +1,7 @@
 """Experiments orchestration module."""
 
 from ._benchmark import Benchmark
-from ._evaluation import save_summary, summarize, tabulate_results
+from ._evaluation import evaluate, save_summary, summarize, tabulate_results
 from ._experiment import Experiment
 from ._model_config import ModelConfig
 from ._recipes import load_recipe, validate_recipe
@@ -13,6 +13,7 @@ __all__ = [
     "ExperimentResult",
     "ModelConfig",
     "Results",
+    "evaluate",
     "load_recipe",
     "save_summary",
     "summarize",

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -114,7 +114,6 @@ class Benchmark:
     ... )
     >>> benchmark.run()  # doctest: +SKIP
     >>> benchmark.summarize()  # doctest: +SKIP
-
     """
 
     def __init__(
@@ -245,7 +244,6 @@ class Benchmark:
         FileNotFoundError
             If a dataset name cannot be resolved by the dataset-loading layer
             (no matching path and not present in the bundled collection).
-
         """
         if self.verbose:
             print("\n###############################")

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -165,9 +165,9 @@ class Benchmark:
         self.data_home: str | Path | None = data_home
         self.datasets: list[str] = list(datasets)
         self.eval_metrics: list[str] = list(eval_metrics)
-        # Resolve once so a later chdir cannot split the write and read roots
-        self.results_path = Path(results_path).expanduser().resolve()
-        self._results = Results(self.results_path)
+        self._results = Results(results_path)
+        # Reuse the resolved root so a later chdir cannot split write from read
+        self.results_path = self._results.path
         self.resamples: int = resamples
         self.test_size: float = test_size
         self.tuning_metric = tuning_metric

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -1,25 +1,30 @@
 """Read-back aggregation over saved experiment results."""
 
 import math
-from pathlib import Path
 
 import pandas as pd
 
 from ._io import _atomic_write, _check_split
+from ._results import Results
 
 
-def _iter_pairs(results_path):
-    """Yield ``(classifier, dataset, csv_path)`` for each results pair."""
-    root = Path(results_path)
-    for clf_dir in sorted(root.iterdir()):
-        if not clf_dir.is_dir():
+def _existing_results(results_path):
+    """Return a Results over results_path, raising when the root is absent."""
+    results = Results(results_path)
+    if not results.path.is_dir():
+        raise FileNotFoundError(f"No results directory at {results.path}.")
+    return results
+
+
+def _iter_reports(results):
+    """Yield ``(classifier, dataset, report)`` for each pair that stores metrics."""
+    for clf, ds in results.iter_experiments():
+        try:
+            report = results.report(clf, ds)
+        except FileNotFoundError:
+            # A pair with predictions but no report.csv stores no metrics
             continue
-        for ds_dir in sorted(clf_dir.iterdir()):
-            if not ds_dir.is_dir():
-                continue
-            csv_path = ds_dir / "report.csv"
-            if csv_path.is_file():
-                yield clf_dir.name, ds_dir.name, csv_path
+        yield clf, ds, report
 
 
 def summarize(results_path, *, classifiers=None, split="test"):
@@ -61,6 +66,9 @@ def summarize(results_path, *, classifiers=None, split="test"):
         If ``classifiers`` is a bare string instead of an iterable of
         strings.
 
+    FileNotFoundError
+        If ``results_path`` does not exist.
+
     Examples
     --------
     >>> from skordinal.experiments import summarize
@@ -75,14 +83,12 @@ def summarize(results_path, *, classifiers=None, split="test"):
         )
 
     classifier_set = set(classifiers) if classifiers is not None else None
+    results = _existing_results(results_path)
     rows = []
 
-    for clf, ds, csv_path in _iter_pairs(results_path):
-        # Skip pairs not in the requested classifier filter
+    for clf, ds, df in _iter_reports(results):
         if classifier_set is not None and clf not in classifier_set:
             continue
-
-        df = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")
 
         # Select columns for the requested split
         if split == "test":
@@ -143,6 +149,9 @@ def tabulate_results(results_path, *, metric="mean_absolute_error", split="test"
     ValueError
         If ``split`` is not ``"test"`` or ``"train"``.
 
+    FileNotFoundError
+        If ``results_path`` does not exist.
+
     Examples
     --------
     >>> from skordinal.experiments import tabulate_results
@@ -155,10 +164,10 @@ def tabulate_results(results_path, *, metric="mean_absolute_error", split="test"
     _check_split(split, allow_both=False)
 
     col = f"{metric}_{split}"
+    results = _existing_results(results_path)
     rows = []
 
-    for clf, ds, csv_path in _iter_pairs(results_path):
-        df = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")
+    for clf, ds, df in _iter_reports(results):
         # Format as "mean +/- std", or "n/a" when metric is absent or all-NaN
         if col not in df.columns or df[col].isna().all():
             cell = "n/a"
@@ -208,18 +217,22 @@ def save_summary(results_path, *, split="test"):
         If ``split`` is not a recognised value (via ``summarize`` →
         ``_check_split``) or if there are no results in ``results_path``.
 
+    FileNotFoundError
+        If ``results_path`` does not exist.
+
     Examples
     --------
     >>> from skordinal.experiments import save_summary
     >>> path = save_summary("/path/to/my-run", split="test")  # doctest: +SKIP
     """
-    df = summarize(results_path, split=split)
+    root = _existing_results(results_path).path
+    df = summarize(root, split=split)
     if df.empty:
         raise ValueError("No results found to summarise.")
     flat = df.copy()
     flat.columns = [
         f"{outer}_{inner}" if inner else outer for outer, inner in flat.columns
     ]
-    out_path = Path(results_path) / f"{split}_summary.csv"
+    out_path = root / f"{split}_summary.csv"
     _atomic_write(out_path, flat.to_csv())
     return out_path

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -4,6 +4,8 @@ import math
 
 import pandas as pd
 
+from skordinal.metrics._metrics import _resolve_label_metric
+
 from ._io import _atomic_write, _check_split
 from ._results import Results
 
@@ -25,6 +27,133 @@ def _iter_reports(results):
             # A pair with predictions but no report.csv stores no metrics
             continue
         yield clf, ds, report
+
+
+def evaluate(
+    results_path,
+    classifier_name,
+    dataset_name,
+    *,
+    metrics=None,
+    split="test",
+):
+    """Recompute metrics from the saved per-seed predictions of one pair.
+
+    Useful for adding a metric to a finished benchmark without re-fitting any
+    estimator. Where a ``report.csv`` exists, only the resamples committed to
+    it are read. Where the pair has none, every seed directory holding the
+    split's predictions file is read, so a results tree written by another
+    tool sharing this layout is readable too.
+
+    Parameters
+    ----------
+    results_path : str or Path
+        Root folder of the experiment results.
+
+    classifier_name : str
+        Name of the classifier configuration.
+
+    dataset_name : str
+        Name of the dataset.
+
+    metrics : iterable of str or None, default=None
+        Metric names, from the registry ``Experiment``'s ``eval_metrics``
+        uses; scorer names like ``"neg_mean_absolute_error"`` are rejected.
+        ``None`` computes ``"mean_absolute_error"`` and ``"accuracy_score"``.
+
+    split : {"test", "train"}, default="test"
+        Which per-seed predictions file to read.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per resample read, indexed by ``resample_id`` and sorted
+        like ``report.csv``'s index, with one column per requested metric.
+        Empty, with those columns, when no predictions file is readable.
+
+    Raises
+    ------
+    ValueError
+        If ``split`` is not ``"test"`` or ``"train"``, if ``metrics`` is
+        empty or holds an unregistered name, if ``classifier_name`` or
+        ``dataset_name`` is empty, a dot segment, or contains a path
+        separator, or if a predictions file lacks the ``Target`` or
+        ``Prediction`` column.
+
+    TypeError
+        If ``classifier_name`` or ``dataset_name`` is not a string, or if
+        ``metrics`` is a bare string instead of an iterable of strings or
+        contains a non-string element.
+
+    FileNotFoundError
+        If ``results_path`` does not exist, or the pair has no
+        ``predictions_by_seed`` directory.
+
+    Warns
+    -----
+    RuntimeWarning
+        If a resample committed to ``report.csv`` with metrics for ``split``
+        has no predictions file for it.
+
+    Notes
+    -----
+    The stored ``Target`` and ``Prediction`` columns are zero-based ranks into
+    ``best_model.classes_``, so metrics are recomputed in rank space, where
+    adjacent categories are always distance 1. ``report.csv``'s own values are
+    computed on the raw labels, so the two agree only while the label set is
+    contiguous.
+
+    Examples
+    --------
+    >>> from skordinal.experiments import evaluate
+    >>> df = evaluate("/path/to/my-run", "LR", "era")  # doctest: +SKIP
+    """
+    _check_split(split, allow_both=False)
+
+    if isinstance(metrics, str):
+        raise TypeError(
+            "metrics must be an iterable of metric name strings, not a bare string; "
+            f"pass [{metrics!r}] to compute a single metric."
+        )
+    metric_names = (
+        tuple(metrics)
+        if metrics is not None
+        else ("mean_absolute_error", "accuracy_score")
+    )
+    if not metric_names:
+        raise ValueError("'metrics' must be non-empty; got an empty sequence.")
+    for name in metric_names:
+        if not isinstance(name, str):
+            raise TypeError(
+                "metrics must contain only metric name strings; got "
+                f"{type(name).__name__!r}."
+            )
+    # Key the columns by the stripped name, like Experiment's report.csv
+    metric_names = tuple(name.strip() for name in metric_names)
+    # Resolve up front so an unknown name raises before any file is read
+    resolved = {name: _resolve_label_metric(name) for name in metric_names}
+
+    results = _existing_results(results_path)
+    rows = {}
+    for resample_id, path in results._readable_seed_files(
+        classifier_name, dataset_name, split
+    ):
+        df = pd.read_csv(path)
+        missing = {"Target", "Prediction"} - set(df.columns)
+        if missing:
+            raise ValueError(
+                f"Malformed predictions file at {path}: missing the "
+                f"{sorted(missing)} column(s)."
+            )
+        y_true = df["Target"].to_numpy()
+        y_pred = df["Prediction"].to_numpy()
+        rows[resample_id] = {
+            name: float(metric(y_true, y_pred)) for name, metric in resolved.items()
+        }
+
+    return pd.DataFrame.from_dict(
+        rows, orient="index", columns=list(metric_names)
+    ).rename_axis("resample_id")
 
 
 def summarize(results_path, *, classifiers=None, split="test"):

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -5,14 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from ._io import _atomic_write
-
-
-def _check_split(split, *, allow_both):
-    """Raise ValueError when split is not a recognised value."""
-    valid = {"test", "train", "both"} if allow_both else {"test", "train"}
-    if split not in valid:
-        raise ValueError(f"split must be one of {sorted(valid)!r}, got {split!r}.")
+from ._io import _atomic_write, _check_split
 
 
 def _iter_pairs(results_path):

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -29,7 +29,7 @@ def _iter_pairs(results_path):
                 yield clf_dir.name, ds_dir.name, csv_path
 
 
-def summarize(results_path, *, labels=None, split="test"):
+def summarize(results_path, *, classifiers=None, split="test"):
     """Aggregate per-pair report CSVs into a multi-index summary DataFrame.
 
     Parameters
@@ -38,10 +38,10 @@ def summarize(results_path, *, labels=None, split="test"):
         Root folder of the experiment results. The function descends into
         ``<results_path>/<classifier>/<dataset>/report.csv`` for each pair.
 
-    labels : iterable of str or None, default=None
+    classifiers : iterable of str or None, default=None
         When provided, only pairs whose classifier name is contained in
-        ``labels`` are included.  Must be an iterable of strings, not a
-        bare string.
+        ``classifiers`` are included.  Must be an iterable of strings, not
+        a bare string.
 
     split : {"test", "train", "both"}, default="test"
         Which metric columns to include.
@@ -65,7 +65,8 @@ def summarize(results_path, *, labels=None, split="test"):
         If ``split`` is not ``"test"``, ``"train"``, or ``"both"``.
 
     TypeError
-        If ``labels`` is a bare string instead of an iterable of strings.
+        If ``classifiers`` is a bare string instead of an iterable of
+        strings.
 
     Examples
     --------
@@ -74,18 +75,18 @@ def summarize(results_path, *, labels=None, split="test"):
     """
     _check_split(split, allow_both=True)
 
-    if isinstance(labels, str):
+    if isinstance(classifiers, str):
         raise TypeError(
-            "labels must be an iterable of classifier name strings, not a bare string; "
-            f"pass [{labels!r}] to filter by a single classifier."
+            "classifiers must be an iterable of classifier name strings, not a bare "
+            f"string; pass [{classifiers!r}] to filter by a single classifier."
         )
 
-    label_set = set(labels) if labels is not None else None
+    classifier_set = set(classifiers) if classifiers is not None else None
     rows = []
 
     for clf, ds, csv_path in _iter_pairs(results_path):
-        # Skip pairs not in the requested label filter
-        if label_set is not None and clf not in label_set:
+        # Skip pairs not in the requested classifier filter
+        if classifier_set is not None and clf not in classifier_set:
             continue
 
         df = pd.read_csv(csv_path, index_col=0, float_precision="round_trip")

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -101,7 +101,6 @@ class Experiment:
     ...     classifier_name="SVM",
     ...     resample_id=0,
     ... )
-
     """
 
     def __init__(
@@ -202,7 +201,6 @@ class Experiment:
         -------
         ExperimentResult
             Fully populated result for this partition. No side effects.
-
         """
         # Apply preprocessing on local copies so the caller's arrays are not mutated.
         train_inputs: np.ndarray = X_train

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import numpy as np
 from sklearn import preprocessing
+from sklearn.base import BaseEstimator
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import get_ordinal_scorer
@@ -205,6 +206,7 @@ class Experiment:
         # Apply preprocessing on local copies so the caller's arrays are not mutated.
         train_inputs: np.ndarray = X_train
         test_inputs: np.ndarray | None = X_test
+        scaler: BaseEstimator | None = None
 
         if self.input_preprocessing in {"norm", "std"}:
             scaler_cls = (
@@ -310,4 +312,5 @@ class Experiment:
             train_index=train_index,
             test_index=test_index,
             train_y_proba=train_y_proba,
+            scaler=scaler,
         )

--- a/skordinal/experiments/_io.py
+++ b/skordinal/experiments/_io.py
@@ -31,6 +31,13 @@ def _check_resample_id(resample_id: Any) -> None:
     _check_path_component(str(resample_id), "resample_id")
 
 
+def _check_split(split: str, *, allow_both: bool) -> None:
+    """Raise ValueError when split is not a recognised value."""
+    valid = {"test", "train", "both"} if allow_both else {"test", "train"}
+    if split not in valid:
+        raise ValueError(f"split must be one of {sorted(valid)!r}, got {split!r}.")
+
+
 def _ensure_parent(path: Path) -> None:
     """Create path's parent directory, wrapping OSError with the failing path."""
     try:

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -1,13 +1,15 @@
-"""Results handling for storing and managing experiment results."""
+"""Persistence and read-back layer for experiment results."""
 
 from __future__ import annotations
 
 import shutil
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import joblib
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
@@ -18,7 +20,9 @@ from ._io import (
     _atomic_write,
     _check_path_component,
     _check_resample_id,
+    _check_split,
     _format_proba_column,
+    _parse_proba_column,
     _sweep_orphaned_temp_files,
 )
 
@@ -156,22 +160,22 @@ def _write_split_files(
 
 
 class Results:
-    """Handle all information from an experiment that needs to be saved.
+    """Persist experiment results under ``path`` and read them back.
 
     Parameters
     ----------
-    output_folder : str or Path
+    path : str or Path
         Directory where all results for this run will be stored. Used directly
         as the experiment root; no timestamp subfolder is created.
 
     Attributes
     ----------
-    _experiment_folder : Path
-        Path to the experiment folder.
+    path : Path
+        Expanded, absolute path to the experiment folder.
 
     Notes
     -----
-    On-disk layout under ``_experiment_folder``::
+    On-disk layout under ``path``::
 
         train_summary.csv
         test_summary.csv
@@ -207,8 +211,8 @@ class Results:
     absent until it is called.
     """
 
-    def __init__(self, output_folder: str | Path) -> None:
-        self._experiment_folder = Path(output_folder)
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser().resolve()
 
     def save(
         self,
@@ -316,9 +320,9 @@ class Results:
         """Validate both components and return the classifier/dataset dir."""
         _check_path_component(classifier_name, "classifier_name")
         _check_path_component(dataset_name, "dataset_name")
-        return self._experiment_folder / classifier_name / dataset_name
+        return self.path / classifier_name / dataset_name
 
-    def _resample_paths(self, base: Path, resample_id: int) -> tuple[Path, Path]:
+    def _resample_paths(self, base: Path, resample_id: int | str) -> tuple[Path, Path]:
         """Return this resample's predictions directory and model artefact."""
         return (
             base / "predictions_by_seed" / f"seed_{resample_id}",
@@ -389,12 +393,12 @@ class Results:
         _atomic_write(csv_path, df.convert_dtypes().to_csv(index=False))
 
     @classmethod
-    def load(cls, experiment_folder: str | Path) -> Results:
+    def load(cls, path: str | Path) -> Results:
         """Load an existing experiment folder for post-hoc analysis.
 
         Parameters
         ----------
-        experiment_folder : str or Path
+        path : str or Path
             Path to an already-populated experiment folder. The folder does not
             need to exist at construction time; it is only accessed when a
             method such as ``exists`` is called.
@@ -402,7 +406,7 @@ class Results:
         Returns
         -------
         Results
-            A ``Results`` instance pointing at ``experiment_folder``.
+            A ``Results`` instance pointing at ``path``.
 
         Examples
         --------
@@ -410,7 +414,210 @@ class Results:
         >>> from skordinal.experiments import Results
         >>> results = Results.load(Path("/path/to/my-run"))  # doctest: +SKIP
         """
-        return cls(experiment_folder)
+        return cls(path)
+
+    def report(self, classifier_name: str, dataset_name: str) -> pd.DataFrame:
+        """Return the stored per-seed metrics of one classifier/dataset pair.
+
+        Parameters
+        ----------
+        classifier_name : str
+            Name of the classifier configuration.
+
+        dataset_name : str
+            Name of the dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            Contents of ``report.csv``, indexed by resample id.
+
+        Raises
+        ------
+        TypeError
+            If ``classifier_name`` or ``dataset_name`` is not a string.
+
+        ValueError
+            If ``classifier_name`` or ``dataset_name`` is empty, a dot
+            segment, or contains a path separator.
+
+        FileNotFoundError
+            If the pair has no ``report.csv``.
+
+        Examples
+        --------
+        >>> from skordinal.experiments import Results
+        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
+        >>> results.report("SVC", "toy")  # doctest: +SKIP
+        """
+        path = self._pair_dir(classifier_name, dataset_name) / "report.csv"
+        if not path.is_file():
+            raise FileNotFoundError(f"No report found at {path}.")
+        return pd.read_csv(path, index_col=0, float_precision="round_trip")
+
+    def hyperparameters(self, classifier_name: str, dataset_name: str) -> pd.DataFrame:
+        """Return the per-seed best parameters of one classifier/dataset pair.
+
+        Parameters
+        ----------
+        classifier_name : str
+            Name of the classifier configuration.
+
+        dataset_name : str
+            Name of the dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            Contents of ``hyperparameter_configuration.csv``, one row per
+            resample, with the resample id in the ``Seed`` column.
+
+        Raises
+        ------
+        TypeError
+            If ``classifier_name`` or ``dataset_name`` is not a string.
+
+        ValueError
+            If ``classifier_name`` or ``dataset_name`` is empty, a dot
+            segment, or contains a path separator.
+
+        FileNotFoundError
+            If the pair has no ``hyperparameter_configuration.csv``.
+
+        Examples
+        --------
+        >>> from skordinal.experiments import Results
+        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
+        >>> results.hyperparameters("SVC", "toy")  # doctest: +SKIP
+        """
+        path = (
+            self._pair_dir(classifier_name, dataset_name)
+            / "hyperparameter_configuration.csv"
+        )
+        if not path.is_file():
+            raise FileNotFoundError(f"No hyperparameter configuration at {path}.")
+        return pd.read_csv(path, float_precision="round_trip")
+
+    def predictions(
+        self,
+        classifier_name: str,
+        dataset_name: str,
+        resample_id: int | str,
+        *,
+        split: str = "test",
+        parse_proba: bool = False,
+    ) -> pd.DataFrame:
+        """Return one resample's stored predictions for a single split.
+
+        Parameters
+        ----------
+        classifier_name : str
+            Name of the classifier configuration.
+
+        dataset_name : str
+            Name of the dataset.
+
+        resample_id : int or str
+            Partition identifier naming the seed directory.
+
+        split : {"test", "train"}, default="test"
+            Which of the two per-seed predictions files to read.
+
+        parse_proba : bool, default=False
+            Whether to expand the ``Prediction probabilities`` cells into
+            ``ndarray`` rows instead of leaving them as stored strings.
+
+        Returns
+        -------
+        pd.DataFrame
+            Contents of ``{split}_predictions.csv``, with the columns
+            described in the class ``Notes``.
+
+        Raises
+        ------
+        TypeError
+            If ``classifier_name`` or ``dataset_name`` is not a string.
+
+        ValueError
+            If ``classifier_name``, ``dataset_name`` or a non-int
+            ``resample_id`` is empty, a dot segment, or contains a path
+            separator, or if ``split`` is not ``"test"`` or ``"train"``.
+
+        FileNotFoundError
+            If the resample has no predictions file for ``split``.
+
+        Examples
+        --------
+        >>> from skordinal.experiments import Results
+        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
+        >>> results.predictions("SVC", "toy", 0, parse_proba=True)  # doctest: +SKIP
+        """
+        _check_resample_id(resample_id)
+        _check_split(split, allow_both=False)
+        seed_dir, _ = self._resample_paths(
+            self._pair_dir(classifier_name, dataset_name), resample_id
+        )
+        path = seed_dir / f"{split}_predictions.csv"
+        if not path.is_file():
+            raise FileNotFoundError(f"No predictions file at {path}.")
+        df = pd.read_csv(path)
+        if parse_proba and "Prediction probabilities" in df.columns:
+            df["Prediction probabilities"] = list(
+                _parse_proba_column(df["Prediction probabilities"])
+            )
+        return df
+
+    def model(
+        self,
+        classifier_name: str,
+        dataset_name: str,
+        resample_id: int | str,
+    ) -> BaseEstimator:
+        """Load one resample's persisted model artefact.
+
+        Parameters
+        ----------
+        classifier_name : str
+            Name of the classifier configuration.
+
+        dataset_name : str
+            Name of the dataset.
+
+        resample_id : int or str
+            Partition identifier naming the model artefact.
+
+        Returns
+        -------
+        estimator
+            The joblib-loaded fitted estimator.
+
+        Raises
+        ------
+        TypeError
+            If ``classifier_name`` or ``dataset_name`` is not a string.
+
+        ValueError
+            If ``classifier_name``, ``dataset_name`` or a non-int
+            ``resample_id`` is empty, a dot segment, or contains a path
+            separator.
+
+        FileNotFoundError
+            If the resample was saved with ``save_model=False`` or its
+            artefact has since been removed.
+
+        Examples
+        --------
+        >>> from skordinal.experiments import Results
+        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
+        >>> results.model("SVC", "toy", 0)  # doctest: +SKIP
+        """
+        _check_resample_id(resample_id)
+        _, model_path = self._resample_paths(
+            self._pair_dir(classifier_name, dataset_name), resample_id
+        )
+        if not model_path.is_file():
+            raise FileNotFoundError(f"No model artefact at {model_path}.")
+        return joblib.load(model_path)
 
     def exists(
         self,
@@ -460,3 +667,34 @@ class Results:
             return False
         df = pd.read_csv(csv_path, index_col=0)
         return str(resample_id) in df.index.astype(str)
+
+    def iter_experiments(self) -> Iterator[tuple[str, str]]:
+        """Yield every readable pair as ``(classifier_name, dataset_name)``.
+
+        A pair qualifies on a ``report.csv``, the commit marker, or failing
+        that on a ``predictions_by_seed`` directory, which is how a tree
+        written by another tool is discovered. Read a yielded pair with
+        ``report``, ``hyperparameters``, ``predictions`` or ``model``; each
+        raises ``FileNotFoundError`` when its own file is absent, so only
+        ``report`` is guaranteed to fail for a pair carrying no
+        ``report.csv``.
+
+        Yields
+        ------
+        tuple of (str, str)
+            Classifier name and dataset name of a readable pair.
+
+        Examples
+        --------
+        >>> from skordinal.experiments import Results
+        >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
+        >>> list(results.iter_experiments())  # doctest: +SKIP
+        """
+        if not self.path.is_dir():
+            return
+        for clf_dir in sorted(p for p in self.path.iterdir() if p.is_dir()):
+            for ds_dir in sorted(p for p in clf_dir.iterdir() if p.is_dir()):
+                if (ds_dir / "report.csv").is_file() or (
+                    ds_dir / "predictions_by_seed"
+                ).is_dir():
+                    yield clf_dir.name, ds_dir.name

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.metrics import confusion_matrix
+from sklearn.pipeline import Pipeline
 
 from ._io import (
     _atomic_dump,
@@ -28,7 +29,7 @@ from ._io import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ExperimentResult:
     """Result of running a single classifier on one dataset partition.
 
@@ -92,6 +93,11 @@ class ExperimentResult:
         Class-probability estimates on the training partition, columns
         ordered by ``best_model.classes_``. ``None`` when the estimator
         cannot provide probabilities.
+
+    scaler : transformer or None, default=None
+        Fitted scaler that produced the inputs ``best_model`` was fitted on,
+        or ``None`` when no preprocessing ran. ``best_model`` stays bare;
+        only the persisted artefact composes the two.
     """
 
     dataset_name: str
@@ -109,6 +115,7 @@ class ExperimentResult:
     train_index: np.ndarray | None = None
     test_index: np.ndarray | None = None
     train_y_proba: np.ndarray | None = None
+    scaler: BaseEstimator | None = None
 
 
 def _write_split_files(
@@ -204,6 +211,9 @@ class Results:
     estimates are stored alongside it. Each
     ``*_confusion_matrix.txt`` holds the confusion matrix of the same
     file's ``Target`` and ``Prediction`` columns.
+    Each ``models/<resample_id>.joblib`` holds the fitted estimator, or a
+    ``Pipeline`` of the run's scaler and that estimator when the inputs were
+    scaled, so the artefact always accepts raw features.
     ``hyperparameter_configuration.csv`` records the best parameters per
     seed with the ``clf__`` pipeline prefix stripped; its ``Seed`` column
     always holds the resample identifier. ``report.csv`` is indexed by
@@ -311,7 +321,13 @@ class Results:
             )
 
         if save_model:
-            _atomic_dump(model_path, result.best_model)
+            # Wrap the scaler in so the artefact accepts raw features
+            artefact = (
+                Pipeline([("scaler", result.scaler), ("clf", result.best_model)])
+                if result.scaler is not None
+                else result.best_model
+            )
+            _atomic_dump(model_path, artefact)
 
         self._upsert_hyperparameters(result, base_dir)
         # Write the report row last: it is the commit marker for exists()
@@ -660,7 +676,9 @@ class Results:
         Returns
         -------
         estimator
-            The joblib-loaded fitted estimator.
+            The joblib-loaded artefact: the bare fitted estimator, or a
+            ``Pipeline`` chaining the run's scaler and that estimator when
+            the partition was scaled.
 
         Raises
         ------

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import sys
+import warnings
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -415,6 +416,76 @@ class Results:
         >>> results = Results.load(Path("/path/to/my-run"))  # doctest: +SKIP
         """
         return cls(path)
+
+    def _readable_seed_files(
+        self, classifier_name: str, dataset_name: str, split: str
+    ) -> list[tuple[int | str, Path]]:
+        """Return sorted ``(resample_id, path)`` pairs of one split's readable seeds.
+
+        Where a ``report.csv`` exists it is the commit marker, so a seed
+        directory with no row in it was left behind by a crashed save and is
+        skipped, and a row that does carry ``{split}`` metrics but has no
+        predictions file is corruption, not a train-only run, and warns.
+
+        Where the pair has none there is no marker to consult, so every seed
+        holding the split's predictions file is read on the strength of that
+        file, which ``_atomic_write`` leaves either complete or absent. A save
+        that crashed before writing any report row falls here too.
+
+        Ids sort like ``report.csv``'s index.
+        """
+        seeds_dir = (
+            self._pair_dir(classifier_name, dataset_name) / "predictions_by_seed"
+        )
+        if not seeds_dir.is_dir():
+            raise FileNotFoundError(f"No predictions directory at {seeds_dir}.")
+        report: pd.DataFrame | None
+        try:
+            report = self.report(classifier_name, dataset_name)
+        except FileNotFoundError:
+            report = None
+        else:
+            report.index = report.index.astype(str)
+        split_cols = (
+            [c for c in report.columns if c.endswith(f"_{split}")]
+            if report is not None
+            else []
+        )
+
+        files: list[tuple[int | str, Path]] = []
+        for seed_dir in seeds_dir.iterdir():
+            if not seed_dir.is_dir() or not seed_dir.name.startswith("seed_"):
+                continue
+            str_id = seed_dir.name.removeprefix("seed_")
+            # Only report.csv membership decides: non-integer ids are legal
+            if report is not None and str_id not in report.index:
+                continue
+            try:
+                resample_id: int | str = int(str_id)
+            except ValueError:
+                resample_id = str_id
+            path = seed_dir / f"{split}_predictions.csv"
+            if path.is_file():
+                files.append((resample_id, path))
+            elif (
+                report is not None
+                and split_cols
+                and report.loc[str_id, split_cols].notna().any()
+            ):
+                warnings.warn(
+                    f"{classifier_name}/{dataset_name} seed {resample_id} is "
+                    f"committed to report.csv with {split} metrics, but {path} "
+                    "is missing.",
+                    RuntimeWarning,
+                    # Frames: here <- evaluate <- caller
+                    stacklevel=3,
+                )
+        try:
+            files.sort(key=lambda item: int(item[0]))
+        except ValueError:
+            # Fall back to lexicographic order for non-integer ids
+            files.sort(key=lambda item: str(item[0]))
+        return files
 
     def report(self, classifier_name: str, dataset_name: str) -> pd.DataFrame:
         """Return the stored per-seed metrics of one classifier/dataset pair.

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -87,7 +87,6 @@ class ExperimentResult:
         Class-probability estimates on the training partition, columns
         ordered by ``best_model.classes_``. ``None`` when the estimator
         cannot provide probabilities.
-
     """
 
     dataset_name: str
@@ -206,7 +205,6 @@ class Results:
     ``resample_id``, in numeric order. The root-level ``train_summary.csv``
     and ``test_summary.csv`` files are written by ``save_summary`` and are
     absent until it is called.
-
     """
 
     def __init__(self, output_folder: str | Path) -> None:
@@ -260,7 +258,6 @@ class Results:
         >>> from skordinal.experiments import Results
         >>> results = Results("/path/to/my-run")  # doctest: +SKIP
         >>> results.save(result)  # doctest: +SKIP
-
         """
         if result.train_true_y is None:
             raise ValueError(
@@ -412,7 +409,6 @@ class Results:
         >>> from pathlib import Path
         >>> from skordinal.experiments import Results
         >>> results = Results.load(Path("/path/to/my-run"))  # doctest: +SKIP
-
         """
         return cls(experiment_folder)
 
@@ -457,7 +453,6 @@ class Results:
         >>> results = Results.load("/path/to/my-run")  # doctest: +SKIP
         >>> results.exists("SVC", "toy", 0)  # doctest: +SKIP
         False
-
         """
         _check_resample_id(resample_id)
         csv_path = self._pair_dir(classifier_name, dataset_name) / "report.csv"

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -3,20 +3,35 @@
 import math
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
+from sklearn.svm import SVC
 
-from skordinal.experiments import save_summary, summarize, tabulate_results
+from skordinal.experiments import (
+    ExperimentResult,
+    Results,
+    evaluate,
+    save_summary,
+    summarize,
+    tabulate_results,
+)
+from skordinal.metrics import mean_absolute_error
+
+
+def _write_report(base, classifier, dataset, rows):
+    """Write report.csv from a {resample_id: metrics} mapping."""
+    pair_dir = base / classifier / dataset
+    pair_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = pair_dir / "report.csv"
+    frame = pd.DataFrame(list(rows.values()), index=pd.Index(list(rows)))
+    frame.to_csv(csv_path, index_label="resample_id")
+    return csv_path
 
 
 def _make_pair_csv(base, classifier, dataset, rows):
-    """Write a minimal report.csv under base/classifier/dataset/."""
-    pair_dir = base / classifier / dataset
-    pair_dir.mkdir(parents=True, exist_ok=True)
-    df = pd.DataFrame(rows)
-    csv_path = pair_dir / "report.csv"
-    df.to_csv(csv_path)
-    return csv_path
+    """Write a report.csv whose resample ids are 0..len(rows) - 1."""
+    return _write_report(base, classifier, dataset, dict(enumerate(rows)))
 
 
 @pytest.fixture
@@ -65,6 +80,126 @@ def _write_seed(
     return seed_dir
 
 
+@pytest.fixture
+def seed_folder(tmp_path):
+    """One pair with resamples 2 and 10 committed, each split differing."""
+    _write_report(
+        tmp_path,
+        "A",
+        "d1",
+        {
+            2: {"mean_absolute_error_train": 0.5, "mean_absolute_error_test": 0.25},
+            10: {"mean_absolute_error_train": 0.5, "mean_absolute_error_test": 1.0},
+        },
+    )
+    _write_seed(tmp_path, "A", "d1", 2, "test", [0, 1, 2, 2], [0, 1, 1, 2])
+    _write_seed(tmp_path, "A", "d1", 10, "test", [0, 1, 2, 2], [2, 1, 0, 2])
+    _write_seed(tmp_path, "A", "d1", 2, "train", [0, 1, 2], [2, 1, 2])
+    _write_seed(tmp_path, "A", "d1", 10, "train", [0, 1, 2], [0, 1, 2])
+    return tmp_path
+
+
+def test_evaluate_recomputes_metrics_per_seed(seed_folder):
+    """evaluate scores every committed seed, in numeric resample order."""
+    df = evaluate(seed_folder, "A", "d1")
+    assert list(df.columns) == ["mean_absolute_error", "accuracy_score"]
+    assert df.index.name == "resample_id"
+    # 10 sorts after 2 numerically but before it lexicographically
+    assert list(df.index) == [2, 10]
+    assert list(df["mean_absolute_error"]) == pytest.approx([0.25, 1.0])
+    assert list(df["accuracy_score"]) == pytest.approx([0.75, 0.5])
+
+
+def test_evaluate_reads_the_requested_split(seed_folder):
+    """evaluate scores the train files when split='train'."""
+    df = evaluate(seed_folder, "A", "d1", split="train")
+    assert list(df["mean_absolute_error"]) == pytest.approx([2 / 3, 0.0])
+
+
+def test_evaluate_includes_string_resample_ids(tmp_path):
+    """A committed non-integer resample id is evaluated, not silently dropped."""
+    _write_report(
+        tmp_path,
+        "A",
+        "d1",
+        {
+            2: {"mean_absolute_error_test": 0.0},
+            "fold": {"mean_absolute_error_test": 1.0},
+        },
+    )
+    _write_seed(tmp_path, "A", "d1", 2, "test", [0, 1], [0, 1])
+    _write_seed(tmp_path, "A", "d1", "fold", "test", [0, 2], [0, 0])
+    df = evaluate(tmp_path, "A", "d1")
+    assert list(df.index) == [2, "fold"]
+    assert df.loc["fold", "mean_absolute_error"] == pytest.approx(1.0)
+
+
+def test_evaluate_skips_uncommitted_seed(seed_folder):
+    """A seed directory with no report.csv row is not evaluated."""
+    _write_seed(seed_folder, "A", "d1", 99, "test", [0, 1, 2, 2], [2, 2, 2, 2])
+    df = evaluate(seed_folder, "A", "d1")
+    assert list(df.index) == [2, 10]
+
+
+def test_evaluate_skips_entries_that_are_not_seed_directories(tmp_path, recwarn):
+    """Only a directory named ``seed_<id>`` counts, even when the id is committed."""
+    _write_report(
+        tmp_path,
+        "A",
+        "d1",
+        {2: {"mean_absolute_error_test": 0.0}, 10: {"mean_absolute_error_test": 0.0}},
+    )
+    _write_seed(tmp_path, "A", "d1", 2, "test", [0, 1], [0, 1])
+    seeds_dir = tmp_path / "A" / "d1" / "predictions_by_seed"
+    # Taken for a seed, a file with no predictions file inside warns
+    (seeds_dir / "seed_10").write_text("noise")
+    # Taken for a seed, an unprefixed directory contributes foreign predictions
+    unprefixed = seeds_dir / "10"
+    unprefixed.mkdir()
+    pd.DataFrame({"Pattern ID": [0], "Target": [0], "Prediction": [2]}).to_csv(
+        unprefixed / "test_predictions.csv", index=False
+    )
+
+    df = evaluate(tmp_path, "A", "d1")
+    assert list(df.index) == [2]
+    assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
+
+
+def test_evaluate_warns_when_a_committed_predictions_file_is_missing(tmp_path):
+    """A committed row with metrics for the split but no file is corruption."""
+    _write_report(tmp_path, "A", "d1", {3: {"mean_absolute_error_test": 0.5}})
+    _write_seed(tmp_path, "A", "d1", 3, "test")
+    with pytest.warns(RuntimeWarning, match="is missing"):
+        df = evaluate(tmp_path, "A", "d1")
+    assert df.empty
+
+
+def test_evaluate_is_silent_for_a_train_only_row(tmp_path, recwarn):
+    """A committed row with no test metrics is a train-only run, not corruption."""
+    _write_report(
+        tmp_path,
+        "A",
+        "d1",
+        {
+            3: {
+                "mean_absolute_error_train": 0.5,
+                "mean_absolute_error_test": float("nan"),
+            }
+        },
+    )
+    _write_seed(tmp_path, "A", "d1", 3, "train", [0, 1], [0, 1])
+    assert evaluate(tmp_path, "A", "d1").empty
+    assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
+
+
+def test_evaluate_reads_a_pair_without_a_report(seed_folder):
+    """With no commit marker at all, every seed on disk scores as it would with one."""
+    (seed_folder / "A" / "d1" / "report.csv").unlink()
+    df = evaluate(seed_folder, "A", "d1")
+    assert list(df.index) == [2, 10]
+    assert list(df["mean_absolute_error"]) == pytest.approx([0.25, 1.0])
+
+
 def test_summarize_and_tabulate_skip_a_pair_without_a_report(tmp_path):
     """A pair holding only predictions stores no metrics, so both readers skip it."""
     _make_pair_csv(tmp_path, "A", "d1", [{"mae_test": 0.3}])
@@ -74,6 +209,103 @@ def test_summarize_and_tabulate_skip_a_pair_without_a_report(tmp_path):
     table = tabulate_results(tmp_path, metric="mae")
     assert list(table.index) == ["A"]
     assert list(table.columns) == ["d1"]
+
+
+@pytest.mark.parametrize(
+    "args,kwargs,exception,match",
+    [
+        ((1, "d1"), {}, TypeError, "must be a str"),
+        ((("..", "d1")), {}, ValueError, "dot segment"),
+        (("A", "a/b"), {}, ValueError, "path separator"),
+        (("A", "d1"), {"split": "both"}, ValueError, "split must be"),
+        (
+            ("A", "d1"),
+            {"metrics": "mean_absolute_error"},
+            TypeError,
+            "not a bare string",
+        ),
+        (("A", "d1"), {"metrics": []}, ValueError, "non-empty"),
+        (
+            ("A", "d1"),
+            {"metrics": [mean_absolute_error]},
+            TypeError,
+            "only metric name strings",
+        ),
+        (("A", "d1"), {"metrics": ["not_a_metric"]}, ValueError, "Unknown metric name"),
+    ],
+    ids=[
+        "name-type",
+        "name-dot",
+        "name-separator",
+        "split",
+        "metrics-string",
+        "metrics-empty",
+        "metrics-element",
+        "metrics-unknown",
+    ],
+)
+def test_evaluate_rejects_invalid_arguments(tmp_path, args, kwargs, exception, match):
+    """Each guard reports its own error before any results file is read.
+
+    ``tmp_path`` holds no tree, so a guard that fails to fire surfaces
+    ``FileNotFoundError`` instead of the pinned message.
+    """
+    with pytest.raises(exception, match=match):
+        evaluate(tmp_path, *args, **kwargs)
+
+
+def test_evaluate_missing_predictions_directory_raises(tmp_path):
+    """evaluate raises FileNotFoundError when the pair was never written."""
+    with pytest.raises(FileNotFoundError, match="predictions_by_seed"):
+        evaluate(tmp_path, "A", "d1")
+
+
+def test_evaluate_computes_exactly_the_requested_metrics(seed_folder):
+    """Only the requested metrics become columns, keyed by their stripped name."""
+    df = evaluate(seed_folder, "A", "d1", metrics=[" accuracy_score "])
+    assert list(df.columns) == ["accuracy_score"]
+    assert list(df["accuracy_score"]) == pytest.approx([0.75, 0.5])
+
+
+def test_evaluate_reports_a_malformed_predictions_file(tmp_path):
+    """A committed predictions file without the label columns fails loud."""
+    _write_report(tmp_path, "A", "d1", {0: {"mean_absolute_error_test": 0.5}})
+    seed_dir = _write_seed(tmp_path, "A", "d1", 0, "test")
+    pd.DataFrame({"Pattern ID": [0, 1]}).to_csv(
+        seed_dir / "test_predictions.csv", index=False
+    )
+    with pytest.raises(ValueError, match="Malformed predictions file"):
+        evaluate(tmp_path, "A", "d1")
+
+
+def test_evaluate_scores_in_rank_space_not_raw_labels(tmp_path):
+    """Recomputed values use ranks, so a gapped label set diverges from report.csv."""
+    classes = np.array([0, 5, 10])
+    features = np.repeat(classes, 4).reshape(-1, 1).astype(float)
+    estimator = SVC().fit(features, np.repeat(classes, 4))
+    true_y = np.array([0, 5, 10])
+    predicted_y = np.array([0, 0, 10])
+    Results(tmp_path).save(
+        ExperimentResult(
+            dataset_name="d1",
+            classifier_name="A",
+            resample_id=0,
+            train_predicted_y=predicted_y,
+            test_predicted_y=predicted_y,
+            y_proba=None,
+            train_metrics={},
+            test_metrics={"mean_absolute_error_test": 5 / 3},
+            best_params={},
+            best_model=estimator,
+            train_true_y=true_y,
+            test_true_y=true_y,
+        ),
+        save_model=False,
+    )
+    df = evaluate(tmp_path, "A", "d1")
+    # Ranks make 0 and 5 adjacent, so the recomputed error is 1/3, not 5/3
+    assert df.loc[0, "mean_absolute_error"] == pytest.approx(1 / 3)
+    assert mean_absolute_error(true_y, predicted_y) == pytest.approx(5 / 3)
 
 
 def test_summarize_aggregates_metrics(two_pair_folder):
@@ -290,11 +522,12 @@ def test_save_summary_empty_folder_raises(tmp_path):
 @pytest.mark.parametrize(
     "call",
     [
+        lambda root: evaluate(root, "A", "d1"),
         summarize,
         tabulate_results,
         save_summary,
     ],
-    ids=["summarize", "tabulate_results", "save_summary"],
+    ids=["evaluate", "summarize", "tabulate_results", "save_summary"],
 )
 def test_missing_results_root_raises(tmp_path, call):
     """Every entry point fails loud on an absent root, never with an empty result."""

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -74,16 +74,16 @@ def test_summarize_selects_columns_by_split(two_pair_folder, split, expected):
 
 
 @pytest.mark.parametrize(
-    "labels,expected_clfs",
+    "classifiers,expected_clfs",
     [
         (["A"], {"A"}),
         (["nonexistent"], set()),
     ],
     ids=["subset", "absent"],
 )
-def test_summarize_filters_by_labels(two_pair_folder, labels, expected_clfs):
-    """summarize with labels keeps only matching classifiers or empty."""
-    df = summarize(two_pair_folder, split="test", labels=labels)
+def test_summarize_filters_by_classifiers(two_pair_folder, classifiers, expected_clfs):
+    """summarize with classifiers keeps only matching pairs or empty."""
+    df = summarize(two_pair_folder, split="test", classifiers=classifiers)
     if expected_clfs:
         assert {clf for clf, _ in df.index} == expected_clfs
     else:
@@ -130,10 +130,10 @@ def test_summarize_empty_folder_returns_empty(tmp_path):
     assert summarize(tmp_path).empty
 
 
-def test_summarize_rejects_string_labels(two_pair_folder):
-    """summarize raises TypeError when labels is a bare string."""
+def test_summarize_rejects_string_classifiers(two_pair_folder):
+    """summarize raises TypeError when classifiers is a bare string."""
     with pytest.raises(TypeError, match="iterable"):
-        summarize(two_pair_folder, labels="A")
+        summarize(two_pair_folder, classifiers="A")
 
 
 def test_summarize_rejects_unknown_split(two_pair_folder):

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -46,6 +46,36 @@ def two_pair_folder(tmp_path):
     return tmp_path
 
 
+def _write_seed(
+    base, classifier, dataset, resample_id, split, target=None, prediction=None
+):
+    """Create one seed directory, writing its {split}_predictions.csv when given."""
+    seed_dir = (
+        base / classifier / dataset / "predictions_by_seed" / f"seed_{resample_id}"
+    )
+    seed_dir.mkdir(parents=True, exist_ok=True)
+    if target is not None:
+        pd.DataFrame(
+            {
+                "Pattern ID": range(len(target)),
+                "Target": target,
+                "Prediction": prediction,
+            }
+        ).to_csv(seed_dir / f"{split}_predictions.csv", index=False)
+    return seed_dir
+
+
+def test_summarize_and_tabulate_skip_a_pair_without_a_report(tmp_path):
+    """A pair holding only predictions stores no metrics, so both readers skip it."""
+    _make_pair_csv(tmp_path, "A", "d1", [{"mae_test": 0.3}])
+    _write_seed(tmp_path, "B", "d1", 0, "test", [0, 1], [0, 1])
+
+    assert list(summarize(tmp_path).index) == [("A", "d1")]
+    table = tabulate_results(tmp_path, metric="mae")
+    assert list(table.index) == ["A"]
+    assert list(table.columns) == ["d1"]
+
+
 def test_summarize_aggregates_metrics(two_pair_folder):
     """summarize returns a MultiIndex frame with mean, std, and count."""
     df = summarize(two_pair_folder, split="test")
@@ -240,10 +270,36 @@ def test_save_summary_writes_csv_and_returns_path(
     )
 
 
+def test_save_summary_writes_under_the_expanded_root(monkeypatch, tmp_path):
+    """A ~ root is expanded for the write too, not turned into a literal dir."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _make_pair_csv(tmp_path / "run", "A", "d1", [{"mae_test": 0.1}])
+    out_path = save_summary("~/run")
+    assert out_path == tmp_path / "run" / "test_summary.csv"
+    assert out_path.is_file()
+    assert not (tmp_path / "~").exists()
+
+
 def test_save_summary_empty_folder_raises(tmp_path):
     """save_summary raises ValueError when there are no results."""
     with pytest.raises(ValueError, match="No results"):
         save_summary(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        summarize,
+        tabulate_results,
+        save_summary,
+    ],
+    ids=["summarize", "tabulate_results", "save_summary"],
+)
+def test_missing_results_root_raises(tmp_path, call):
+    """Every entry point fails loud on an absent root, never with an empty result."""
+    with pytest.raises(FileNotFoundError, match="No results directory"):
+        call(tmp_path / "absent")
 
 
 def test_summarize_round_trip_precision(tmp_path):

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -5,6 +5,7 @@ import math
 import numpy as np
 import numpy.testing as npt
 import pytest
+from sklearn.preprocessing import MinMaxScaler, StandardScaler
 from sklearn.svm import SVC
 
 from skordinal.experiments import Experiment, ExperimentResult, ModelConfig
@@ -293,3 +294,27 @@ def test_run_proba_none_when_predict_proba_raises(split_with_test, monkeypatch):
 
     assert result.train_y_proba is None
     assert result.y_proba is None
+
+
+@pytest.mark.parametrize(
+    "input_preprocessing,expected_type",
+    [("std", StandardScaler), ("norm", MinMaxScaler), (None, type(None))],
+)
+def test_run_records_the_fitted_scaler(
+    split_with_test, input_preprocessing, expected_type
+):
+    """run() hands back the scaler it fitted, so save can persist it."""
+    X_train, y_train, X_test, y_test = split_with_test
+    result = _call_run(
+        _make_experiment(input_preprocessing=input_preprocessing),
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+    )
+    assert isinstance(result.scaler, expected_type)
+    if input_preprocessing is not None:
+        npt.assert_allclose(
+            result.scaler.transform(X_train)[0],
+            expected_type().fit(X_train).transform(X_train)[0],
+        )

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -612,9 +612,194 @@ def test_load(tmp_path):
     """Results.load() returns a Results pointing at the given folder; does not raise if folder is absent."""
     r = Results.load(tmp_path)
     assert isinstance(r, Results)
-    assert r._experiment_folder == tmp_path
+    assert r.path == tmp_path
 
     Results.load("/nonexistent/path/that/does/not/exist")
+
+
+def test_path_is_expanded_and_absolute(monkeypatch, tmp_path):
+    """Results.path expands a leading ~ and resolves a relative path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert Results("~/my-run").path == tmp_path / "my-run"
+    monkeypatch.chdir(tmp_path)
+    assert Results("my-run").path == tmp_path / "my-run"
+
+
+def test_report_and_hyperparameters_round_trip(tmp_path):
+    """report and hyperparameters read back what save wrote, without precision loss."""
+    results = Results(tmp_path)
+    results.save(
+        _make_result(
+            partition=7,
+            dataset="toy",
+            configuration="conf_1",
+            best_params={"clf__C": 0.12345678901234566},
+            train_metrics={"mae_train": 0.12345678901234566},
+            test_metrics={"mae_test": 0.25},
+            train_predicted_y=np.array([1, 2, 3]),
+            test_predicted_y=np.array([1, 2, 2]),
+        ),
+        save_model=False,
+    )
+
+    report = results.report("conf_1", "toy")
+    assert list(report.index.astype(str)) == ["7"]
+    assert report.loc[7, "mae_train"] == 0.12345678901234566
+    assert report.loc[7, "mae_test"] == 0.25
+
+    hyper = results.hyperparameters("conf_1", "toy")
+    assert list(hyper["Seed"]) == [7]
+    assert hyper.loc[0, "C"] == 0.12345678901234566
+
+
+def test_predictions_reads_the_requested_split(tmp_path):
+    """predictions returns the split's own rows, not the other split's."""
+    results = Results(tmp_path)
+    results.save(
+        _make_result(
+            partition=0,
+            dataset="toy",
+            configuration="conf_1",
+            best_params={},
+            train_metrics={},
+            test_metrics={},
+            train_predicted_y=np.array([1, 2, 3, 3]),
+            test_predicted_y=np.array([1, 1]),
+            train_true_y=np.array([1, 2, 3, 1]),
+            test_true_y=np.array([1, 3]),
+        ),
+        save_model=False,
+    )
+
+    test_df = results.predictions("conf_1", "toy", 0)
+    npt.assert_array_equal(test_df["Target"], [0, 2])
+    npt.assert_array_equal(test_df["Prediction"], [0, 0])
+
+    train_df = results.predictions("conf_1", "toy", 0, split="train")
+    npt.assert_array_equal(train_df["Target"], [0, 1, 2, 0])
+    npt.assert_array_equal(train_df["Prediction"], [0, 1, 2, 2])
+
+
+def test_predictions_parse_proba(tmp_path):
+    """parse_proba expands the stored cells into rows; the default leaves strings."""
+    proba = np.array([[0.7, 0.2, 0.1], [0.1, 0.3, 0.6]])
+    results = Results(tmp_path)
+    results.save(
+        _make_result(
+            partition=0,
+            dataset="toy",
+            configuration="conf_1",
+            best_params={},
+            train_metrics={},
+            test_metrics={},
+            train_predicted_y=np.array([1, 2]),
+            test_predicted_y=np.array([1, 3]),
+            y_proba=proba,
+        ),
+        save_model=False,
+    )
+
+    parsed = results.predictions("conf_1", "toy", 0, parse_proba=True)
+    npt.assert_allclose(np.vstack(parsed["Prediction probabilities"]), proba)
+
+    raw = results.predictions("conf_1", "toy", 0)
+    assert raw["Prediction probabilities"].iloc[0].startswith("[")
+
+
+def test_model_round_trip(tmp_path):
+    """model loads back the estimator save persisted."""
+    estimator = _fitted_svc()
+    results = Results(tmp_path)
+    results.save(
+        _make_result(
+            partition=0,
+            dataset="toy",
+            configuration="conf_1",
+            best_params={},
+            train_metrics={},
+            test_metrics={},
+            train_predicted_y=np.array([1, 2]),
+            test_predicted_y=None,
+            estimator=estimator,
+        )
+    )
+
+    loaded = results.model("conf_1", "toy", 0)
+    npt.assert_array_equal(loaded.classes_, estimator.classes_)
+
+
+@pytest.mark.parametrize(
+    "reader,args",
+    [
+        ("report", ("conf_1", "toy")),
+        ("hyperparameters", ("conf_1", "toy")),
+        ("predictions", ("conf_1", "toy", 0)),
+        ("model", ("conf_1", "toy", 0)),
+    ],
+)
+def test_readers_raise_for_a_missing_artefact(tmp_path, reader, args):
+    """Every reader reports the absent path rather than an empty result."""
+    with pytest.raises(FileNotFoundError):
+        getattr(Results(tmp_path), reader)(*args)
+
+
+@pytest.mark.parametrize(
+    "reader,args",
+    [
+        ("report", (1, "toy")),
+        ("hyperparameters", ("conf_1", 1)),
+        ("predictions", (1, "toy", 0)),
+        ("model", ("conf_1", 1, 0)),
+    ],
+)
+def test_readers_reject_non_string_names(tmp_path, reader, args):
+    """Every reader validates its path components the way exists does."""
+    with pytest.raises(TypeError, match="must be a str"):
+        getattr(Results(tmp_path), reader)(*args)
+
+
+@pytest.mark.parametrize(
+    "reader,args",
+    [
+        ("report", ("..", "toy")),
+        ("hyperparameters", ("conf_1", "a/b")),
+        ("predictions", ("conf_1", "toy", "..")),
+        ("model", ("conf_1", "toy", "a/b")),
+    ],
+)
+def test_readers_reject_escaping_names(tmp_path, reader, args):
+    """Every reader rejects components that would escape the results tree."""
+    with pytest.raises(ValueError):
+        getattr(Results(tmp_path), reader)(*args)
+
+
+def test_predictions_rejects_unknown_split(tmp_path):
+    """predictions has no 'both' split to read."""
+    with pytest.raises(ValueError, match="split must be"):
+        Results(tmp_path).predictions("conf_1", "toy", 0, split="both")
+
+
+def test_iter_experiments_yields_readable_pairs_sorted(tmp_path):
+    """A report.csv or a predictions directory qualifies a pair; nothing else does."""
+    _make_pair_csv(tmp_path, "clf_b", "ds_2", [{"mae_test": 0.1}])
+    _make_pair_csv(tmp_path, "clf_a", "ds_2", [{"mae_test": 0.2}])
+    _make_pair_csv(tmp_path, "clf_a", "ds_1", [{"mae_test": 0.3}])
+    # Predictions without a report.csv, as in a tree written by another tool
+    (tmp_path / "clf_a" / "ds_3" / "predictions_by_seed").mkdir(parents=True)
+    (tmp_path / "clf_a" / "ds_0").mkdir()
+    (tmp_path / "stray.txt").write_text("noise")
+
+    assert list(Results(tmp_path).iter_experiments()) == [
+        ("clf_a", "ds_1"),
+        ("clf_a", "ds_2"),
+        ("clf_a", "ds_3"),
+        ("clf_b", "ds_2"),
+    ]
+
+
+def test_iter_experiments_on_a_missing_folder_is_empty(tmp_path):
+    """iter_experiments yields nothing rather than raising on an absent root."""
+    assert list(Results(tmp_path / "absent").iter_experiments()) == []
 
 
 def test_exists(tmp_path):

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -6,6 +6,8 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from sklearn.metrics import confusion_matrix
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 from skordinal.classifiers import LogisticAT
@@ -44,6 +46,7 @@ def _make_result(
     train_index=None,
     test_index=None,
     y_proba=None,
+    scaler=None,
 ) -> ExperimentResult:
     if estimator is None:
         estimator = _fitted_svc()
@@ -66,6 +69,7 @@ def _make_result(
         test_true_y=test_true_y,
         train_index=train_index,
         test_index=test_index,
+        scaler=scaler,
     )
 
 
@@ -706,8 +710,8 @@ def test_predictions_parse_proba(tmp_path):
     assert raw["Prediction probabilities"].iloc[0].startswith("[")
 
 
-def test_model_round_trip(tmp_path):
-    """model loads back the estimator save persisted."""
+def test_model_round_trips_the_bare_estimator(tmp_path):
+    """Without a scaler, model loads back the estimator itself, not a Pipeline."""
     estimator = _fitted_svc()
     results = Results(tmp_path)
     results.save(
@@ -725,6 +729,7 @@ def test_model_round_trip(tmp_path):
     )
 
     loaded = results.model("conf_1", "toy", 0)
+    assert not isinstance(loaded, Pipeline)
     npt.assert_array_equal(loaded.classes_, estimator.classes_)
 
 
@@ -1125,3 +1130,34 @@ def test_resave_crash_before_uncommit_leaves_prior_run_intact(tmp_path, monkeypa
     assert r.exists("clf", "ds", "0") is True
     seed = tmp_path / "clf" / "ds" / "predictions_by_seed" / "seed_0"
     assert (seed / "train_predictions.csv").is_file()
+
+
+def test_save_composes_the_scaler_into_the_model_artefact(tmp_path):
+    """A scaled run persists a Pipeline that accepts raw, unscaled features."""
+    raw = np.repeat([[1.0], [100.0], [10000.0]], 4, axis=0)
+    labels = np.repeat([1, 2, 3], 4)
+    scaler = StandardScaler().fit(raw)
+    estimator = SVC().fit(scaler.transform(raw), labels)
+
+    results = Results(tmp_path)
+    results.save(
+        _make_result(
+            partition=0,
+            dataset="toy",
+            configuration="conf_1",
+            best_params={},
+            train_metrics={},
+            test_metrics={},
+            train_predicted_y=estimator.predict(scaler.transform(raw)),
+            test_predicted_y=None,
+            estimator=estimator,
+            train_true_y=labels,
+            scaler=scaler,
+        )
+    )
+
+    artefact = results.model("conf_1", "toy", 0)
+    assert isinstance(artefact, Pipeline)
+    npt.assert_array_equal(
+        artefact.predict(raw), estimator.predict(scaler.transform(raw))
+    )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Ports `evaluate` and the `Results` readers from `dev/preview`, adding a public API to read back a saved benchmark:

- `evaluate()` recomputes metrics from stored per-seed predictions without re-fitting, even for a pair with no `report.csv`, as in a tree written by another tool.
- `Results` gains `report`, `hyperparameters`, `predictions`, `model`, and `iter_experiments`. Its constructor and `load` now take `path=` (was `output_folder=` and `experiment_folder=`), exposed as the public `Results.path`.
- The fitted scaler is now saved with the model as a `Pipeline`, so a loaded model accepts raw features instead of silently producing wrong predictions. `ExperimentResult` becomes keyword-only.
- `summarize()`'s `labels=` filter is renamed to `classifiers=`.

#### Any other comments?

On a gapped label set such as `[0, 10, 20]`, `evaluate()`'s `mean_absolute_error` differs from `report.csv`'s. It is the only metric affected, being sklearn's regression MAE in an otherwise rank-based registry, so the fix belongs there rather than here.