### PR TITLE
MNT: Clean up the CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           languages: python
           queries: security-and-quality
+          config: |
+            paths-ignore:
+              # Vendored upstream C/C++ backends, excluded from ruff and mypy too
+              - skordinal/classifiers/src
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4.37.3

--- a/skordinal/classifiers/_nnop.py
+++ b/skordinal/classifiers/_nnop.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math as math
 import warnings
 from numbers import Integral, Real
 

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -315,4 +315,7 @@ class Benchmark:
             try:
                 save_summary(self.results_path, split=split)
             except ValueError:
-                pass
+                # No stored metrics to summarise for this split: either nothing
+                # has been run yet, or no pair produced a report
+                if self.verbose:
+                    print("  No metrics to summarise for the", split, "split")

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -453,3 +453,19 @@ def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
     # Results land under the construction-time root, not the new cwd
     assert (work_a / "runs" / "SVM" / _BUNDLED_DS / "report.csv").is_file()
     assert not (work_b / "runs").exists()
+
+
+def test_summarize_without_results_reports_instead_of_raising(tmp_path, capsys):
+    """summarize() over a folder with no stored metrics warns instead of raising."""
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path,
+        resamples=2,
+        cv=2,
+        verbose=True,
+        random_state=0,
+    )
+    b.summarize()
+    assert "No metrics to summarise" in capsys.readouterr().out

--- a/skordinal/metrics/tests/test_metrics.py
+++ b/skordinal/metrics/tests/test_metrics.py
@@ -646,30 +646,6 @@ def test_labels_must_cover_the_data():
         accuracy_off1_score([0, 1, 2], [0, 1, 5], labels=[0, 1, 2])
 
 
-def test_metric_names_in_all():
-    """All public metric names are present in skordinal.metrics.__all__."""
-    import skordinal.metrics as m
-
-    expected = [
-        "accuracy_score",
-        "average_mean_absolute_error",
-        "geometric_mean",
-        "mean_absolute_error",
-        "maximum_mean_absolute_error",
-        "mean_extreme_sensitivity",
-        "minimum_sensitivity",
-        "mean_zero_one_error",
-        "kendalls_tau",
-        "weighted_kappa",
-        "spearmans_rho",
-        "ranked_probability_score",
-        "gmsec",
-        "accuracy_off1_score",
-    ]
-    for name in expected:
-        assert name in m.__all__, f"{name!r} missing from __all__"
-
-
 @pytest.mark.parametrize("fn", _WEIGHTED_METRICS, ids=_WEIGHTED_METRIC_IDS)
 def test_sample_weight_is_keyword_only(fn):
     """sample_weight is a keyword-only parameter in every weighted metric."""

--- a/skordinal/metrics/tests/test_scorers.py
+++ b/skordinal/metrics/tests/test_scorers.py
@@ -68,13 +68,6 @@ def test_scorer_names_match_expected():
     assert get_ordinal_scorer_names() is not names
 
 
-def test_scorers_not_in_public_all():
-    """Private symbol _SCORERS is not exported from skordinal.metrics."""
-    import skordinal.metrics as m
-
-    assert "_SCORERS" not in m.__all__
-
-
 def test_get_ordinal_scorer_returns_fresh_copy():
     """Mutating a returned scorer does not affect subsequent lookups."""
     first = get_ordinal_scorer("neg_mean_absolute_error")


### PR DESCRIPTION
#### Reference Issues/PRs

Closes code-scanning alerts #1, #2, #3, #11, #12, #15, #16, #17, #18, #19, #20, #21, #23, #26, #29.

#### What does this implement/fix? Explain your changes

Excludes the vendored `skordinal/classifiers/src` tree from CodeQL via `paths-ignore`, consistent with the existing ruff and mypy exclusions and closing eleven alerts raised against `libsvmrank/grid.py`, a vendored script we do not maintain. Removes an unused `import math as math` from `NNOP`. Replaces the bare `except ValueError: pass` in the summary writer with a comment explaining the cause and a notice printed under `verbose`, so a run with no stored metrics to summarise no longer passes silently. Drops two tests in `skordinal.metrics` that only checked its `__all__` list, a contract nothing else in the codebase or docs relies on.