### PR TITLE
ENH: Validate Benchmark and Experiment arguments at construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ optional and fall back to the `Benchmark` defaults.
 
 ```python
 from sklearn.calibration import CalibratedClassifierCV
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 from skordinal.classifiers import OrdinalDecomposition
@@ -90,7 +91,7 @@ RECIPE = {
     "datasets": ["balance_scale", "era", "esl"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",
@@ -180,8 +181,9 @@ These keys control how the benchmark is executed.
   passed to `GridSearchCV` to select the best hyperparameters.
 - **`cv`** (default `3`): number of cross-validation folds.
 - **`n_jobs`** (default `1`): parallel jobs for `GridSearchCV`.
-- **`input_preprocessing`** (default `None`): `"std"` for standardisation,
-  `"norm"` for normalisation, `None` for no scaling.
+- **`input_preprocessing`** (default `None`): a transformer instance (e.g.
+  `StandardScaler()` or a `Pipeline`) fitted on each training split, or
+  `None` for no preprocessing.
 - **`resamples`** (default `30`): number of train/test resamples per dataset,
   or the explicit list of resample ids to run.
 - **`test_size`** (default `0.3`): fraction of samples held out for testing

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## What is skordinal?
 
-**skordinal** is an experimental framework built on Python that integrates with scikit-learn to automate machine learning experiments through simple JSON configuration files. Initially designed for ordinal classification, it supports regular classification algorithms as long as they are compatible with scikit-learn, making it easy to run reproducible experiments across multiple datasets and classification methods.
+**skordinal** is an experimental framework built on Python that integrates with scikit-learn to automate machine learning experiments through simple Python recipe files. Initially designed for ordinal classification, it supports regular classification algorithms as long as they are compatible with scikit-learn, making it easy to run reproducible experiments across multiple datasets and classification methods.
 
 ## Table of Contents
 
@@ -182,12 +182,17 @@ These keys control how the benchmark is executed.
 - **`n_jobs`** (default `1`): parallel jobs for `GridSearchCV`.
 - **`input_preprocessing`** (default `None`): `"std"` for standardisation,
   `"norm"` for normalisation, `None` for no scaling.
-- **`resamples`** (default `30`): number of train/test resamples per dataset.
+- **`resamples`** (default `30`): number of train/test resamples per dataset,
+  or the explicit list of resample ids to run.
 - **`test_size`** (default `0.3`): fraction of samples held out for testing
   when partitions are generated rather than read from a masks file.
 - **`data_home`** (default `None`): base directory for dataset files; `None`
   uses the bundled datasets.
-- **`random_state`** (default `None`): integer seed for reproducibility.
+- **`random_state`** (default `0`): integer seed for reproducibility. A
+  non-integer (including `None`) is resolved to one concrete seed at
+  construction, so every resample of a run shares one partitioning scheme.
+- **`overwrite`** (default `False`): recompute resamples that are already
+  saved; `False` makes a run resumable.
 - **`verbose`** (default `True`): print progress during the run.
 
 ### models

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ All dependencies are managed through `pyproject.toml` and include:
    pip install -e .[dev]
    ```
 
+   Progress bars during a benchmark run need one optional extra:
+   ```bash
+   pip install skordinal[progress]
+   ```
+
 ### Testing Installation
 
 Test your installation with the provided example:
@@ -195,7 +200,11 @@ These keys control how the benchmark is executed.
   construction, so every resample of a run shares one partitioning scheme.
 - **`overwrite`** (default `False`): recompute resamples that are already
   saved; `False` makes a run resumable.
-- **`verbose`** (default `True`): print progress during the run.
+- **`verbose`** (default `True`): report progress during the run — INFO
+  messages on the `skordinal.experiments` logger (printed to stdout when
+  the application has not configured logging) and, with
+  `pip install skordinal[progress]`, a tqdm bar per (model, dataset) pair
+  on a terminal.
 
 ### models
 

--- a/README.md
+++ b/README.md
@@ -204,10 +204,12 @@ These keys control how the benchmark is executed.
 `param_grid`.
 
 - **`ModelConfig(estimator, param_grid=None)`**: wraps any estimator that
-  implements the scikit-learn estimator interface. `param_grid` is a dict of
-  hyperparameter name → list of values for `GridSearchCV`. For meta-estimators
-  (e.g. `OrdinalDecomposition`) use the double-underscore syntax
-  (`"estimator__C"`) to target nested parameters.
+  implements the scikit-learn estimator interface. `param_grid` maps a
+  hyperparameter name to either a sequence of candidate values (list, tuple
+  or array, e.g. `np.logspace(-3, 3, 7)`) searched by `GridSearchCV`, or a
+  single value held fixed. For meta-estimators (e.g. `OrdinalDecomposition`)
+  use the double-underscore syntax (`"estimator__C"`) to target nested
+  parameters.
 
 ## Running Experiments
 

--- a/docs/api/experiments.rst
+++ b/docs/api/experiments.rst
@@ -75,6 +75,15 @@ full multi-classifier × multi-dataset benchmark.
   resumable.  :meth:`~skordinal.experiments.Benchmark.summarize` writes the
   aggregated train and test summaries.
 
+  Progress is reported through the ``skordinal.experiments`` logger rather
+  than printed.  With ``verbose=True`` the records are emitted at INFO, and a
+  plain stdout handler is attached for the duration of the call only when the
+  application has configured no logging of its own, so an application that
+  sets up handlers keeps a single emission under its own formatting.
+  Installing the ``progress`` extra (``pip install "skordinal[progress]"``)
+  additionally draws a tqdm bar per (model, dataset) pair when running on a
+  terminal.
+
   The quickest way to run a study is via the recipe interface.  Define a
   ``RECIPE`` dict in a standalone Python file (see ``examples/recipes/`` for
   templates) and run it from the command line::

--- a/docs/api/experiments.rst
+++ b/docs/api/experiments.rst
@@ -101,3 +101,4 @@ full multi-classifier × multi-dataset benchmark.
    summarize
    save_summary
    tabulate_results
+   evaluate

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -12,6 +12,10 @@ Binary wheels are published for Linux x86-64. On every other platform pip
 builds the four C extensions (``REDSVM``, ``SVOREX``, ``SVORIM``, ``ORBoost``)
 from source, which requires a C/C++ compiler.
 
+Progress bars during a benchmark run need one optional extra::
+
+   pip install "skordinal[progress]"
+
 For a development install, in editable mode and with every optional
 dependency::
 

--- a/examples/recipes/full_demo.py
+++ b/examples/recipes/full_demo.py
@@ -2,6 +2,7 @@
 
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 from skordinal.classifiers import REDSVM, SVOREX, SVORIM, OrdinalDecomposition
@@ -11,7 +12,7 @@ RECIPE = {
     "datasets": ["balance_scale", "era", "esl"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",

--- a/examples/recipes/nnop_demo.py
+++ b/examples/recipes/nnop_demo.py
@@ -1,5 +1,7 @@
 """NNOP ordinal neural network classifier on balance_scale."""
 
+from sklearn.preprocessing import StandardScaler
+
 from skordinal.classifiers import NNOP
 from skordinal.experiments import ModelConfig
 
@@ -7,7 +9,7 @@ RECIPE = {
     "datasets": ["balance_scale"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",

--- a/examples/recipes/nnpom_demo.py
+++ b/examples/recipes/nnpom_demo.py
@@ -1,5 +1,7 @@
 """NNPOM ordinal neural network classifier on balance_scale."""
 
+from sklearn.preprocessing import StandardScaler
+
 from skordinal.classifiers import NNPOM
 from skordinal.experiments import ModelConfig
 
@@ -7,7 +9,7 @@ RECIPE = {
     "datasets": ["balance_scale"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",

--- a/examples/recipes/redsvm_demo.py
+++ b/examples/recipes/redsvm_demo.py
@@ -1,5 +1,7 @@
 """REDSVM SVM-based ordinal classifier on balance_scale."""
 
+from sklearn.preprocessing import StandardScaler
+
 from skordinal.classifiers import REDSVM
 from skordinal.experiments import ModelConfig
 
@@ -7,7 +9,7 @@ RECIPE = {
     "datasets": ["balance_scale"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",

--- a/examples/recipes/svmop_demo.py
+++ b/examples/recipes/svmop_demo.py
@@ -1,6 +1,7 @@
 """SVMOP ordered-partitions SVC decomposition on balance_scale."""
 
 from sklearn.calibration import CalibratedClassifierCV
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 from skordinal.classifiers import OrdinalDecomposition
@@ -10,7 +11,7 @@ RECIPE = {
     "datasets": ["balance_scale"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",

--- a/examples/recipes/svorex_demo.py
+++ b/examples/recipes/svorex_demo.py
@@ -1,5 +1,7 @@
 """SVOREX kernel and regularisation grid search on balance_scale."""
 
+from sklearn.preprocessing import StandardScaler
+
 from skordinal.classifiers import SVOREX
 from skordinal.experiments import ModelConfig
 
@@ -7,7 +9,7 @@ RECIPE = {
     "datasets": ["balance_scale"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",

--- a/examples/recipes/svorim_demo.py
+++ b/examples/recipes/svorim_demo.py
@@ -1,5 +1,7 @@
 """SVORIM kernel and regularisation grid search on balance_scale."""
 
+from sklearn.preprocessing import StandardScaler
+
 from skordinal.classifiers import SVORIM
 from skordinal.experiments import ModelConfig
 
@@ -7,7 +9,7 @@ RECIPE = {
     "datasets": ["balance_scale"],
     "cv": 3,
     "n_jobs": 1,
-    "input_preprocessing": "std",
+    "input_preprocessing": StandardScaler(),
     "results_path": "results/",
     "eval_metrics": [
         "accuracy_score",

--- a/examples/run_recipe.py
+++ b/examples/run_recipe.py
@@ -42,6 +42,9 @@ def main(argv: list[str] | None = None) -> None:
     overrides: dict[str, object] = {}
     if args.results_dir is not None:
         overrides["results_path"] = args.results_dir
+    # Only force it on, so the recipe's own value survives without the flag
+    if args.overwrite:
+        overrides["overwrite"] = True
 
     benchmark = Benchmark.from_recipe(args.recipe, **overrides)
     benchmark.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+progress = [
+    "tqdm>=4.66",
+]
 dev = [
+    "skordinal[progress]",
     "pytest>=7.0",
     "pytest-cov",
     "pytest-xdist[psutil]",

--- a/skordinal/__init__.py
+++ b/skordinal/__init__.py
@@ -1,4 +1,12 @@
 """skordinal."""
 
+import logging
+
 __all__: list[str] = []
 __version__ = "0.1.0"
+
+# Library convention: emit records, never configure handlers for the app
+_logger = logging.getLogger("skordinal")
+if not any(isinstance(h, logging.NullHandler) for h in _logger.handlers):
+    _logger.addHandler(logging.NullHandler())
+del _logger

--- a/skordinal/experiments/_base.py
+++ b/skordinal/experiments/_base.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+from functools import lru_cache
+from inspect import signature
 from typing import Any
 
 import numpy as np
@@ -68,6 +70,27 @@ def _check_metric_names(metrics: Any, *, param: str) -> list[str]:
     for name in metrics:
         _resolve_label_metric(name)
     return metrics
+
+
+@lru_cache(maxsize=None)
+def _metric_takes_labels(name: str) -> bool:
+    """Report whether a registered label metric accepts a labels argument."""
+    return "labels" in signature(_resolve_label_metric(name)).parameters
+
+
+def _compute_metric(
+    name: str, y_true: Any, y_pred: Any, *, labels: Any = None
+) -> float:
+    """Score one metric, naming the full ordinal scale when it accepts one.
+
+    Without ``labels`` a split that holds neither the true nor the predicted
+    form of an intermediate class collapses the gap it spans, which reports a
+    perfect ``accuracy_off1_score`` for a model confusing the extremes.
+    """
+    metric = _resolve_label_metric(name)
+    if labels is not None and _metric_takes_labels(name):
+        return float(metric(y_true, y_pred, labels=labels))
+    return float(metric(y_true, y_pred))
 
 
 def _check_input_preprocessing(input_preprocessing: Any) -> None:

--- a/skordinal/experiments/_base.py
+++ b/skordinal/experiments/_base.py
@@ -1,0 +1,32 @@
+"""Shared internal helpers for the experiments package."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+
+def _check_path_component(name: Any, what: str) -> None:
+    """Reject a path component that is empty, dotted or holds a separator."""
+    if not isinstance(name, str):
+        raise TypeError(f"{what} must be a str; got {type(name).__name__}.")
+    if name in ("", ".", ".."):
+        raise ValueError(f"{what} must not be empty or a dot segment; got {name!r}.")
+    if any(sep in name for sep in (os.sep, "/", os.altsep) if sep):
+        raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
+
+
+def _check_resample_id(resample_id: Any) -> None:
+    """Reject a resample id that is neither int-like nor a plain path component."""
+    if isinstance(resample_id, (int, np.integer)):
+        return
+    _check_path_component(str(resample_id), "resample_id")
+
+
+def _check_split(split: str, *, allow_both: bool) -> None:
+    """Raise ValueError when split is not a recognised value."""
+    valid = {"test", "train", "both"} if allow_both else {"test", "train"}
+    if split not in valid:
+        raise ValueError(f"split must be one of {sorted(valid)!r}, got {split!r}.")

--- a/skordinal/experiments/_base.py
+++ b/skordinal/experiments/_base.py
@@ -9,13 +9,17 @@ import numpy as np
 
 
 def _check_path_component(name: Any, what: str) -> None:
-    """Reject a path component that is empty, dotted or holds a separator."""
+    """Reject a path component that cannot safely name one directory."""
     if not isinstance(name, str):
         raise TypeError(f"{what} must be a str; got {type(name).__name__}.")
     if name in ("", ".", ".."):
         raise ValueError(f"{what} must not be empty or a dot segment; got {name!r}.")
-    if any(sep in name for sep in (os.sep, "/", os.altsep) if sep):
+    # os.altsep is None on POSIX, so a backslash escapes only once read on Windows
+    if any(sep in name for sep in (os.sep, "/", "\\", os.altsep) if sep):
         raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
+    # On Windows "D:" resolves outside the results root and "C:" drops a level
+    if ":" in name:
+        raise ValueError(f"{what} must not contain a colon; got {name!r}.")
 
 
 def _check_resample_id(resample_id: Any) -> None:

--- a/skordinal/experiments/_base.py
+++ b/skordinal/experiments/_base.py
@@ -70,6 +70,40 @@ def _check_metric_names(metrics: Any, *, param: str) -> list[str]:
     return metrics
 
 
+def _check_input_preprocessing(input_preprocessing: Any) -> None:
+    """Reject an input_preprocessing that is not a clonable transformer."""
+    if input_preprocessing is None:
+        return
+    # A class answers every hasattr an instance would, and clone needs get_params
+    if not isinstance(input_preprocessing, type) and all(
+        hasattr(input_preprocessing, name)
+        for name in ("fit", "transform", "get_params", "set_params")
+    ):
+        return
+    got = (
+        f"the {input_preprocessing.__name__} class"
+        if isinstance(input_preprocessing, type)
+        else type(input_preprocessing).__name__
+    )
+    raise TypeError(
+        f"'input_preprocessing' must be None or a transformer instance "
+        f"implementing fit, transform and get_params; got {got}."
+    )
+
+
 def _check_tuning_metric(tuning_metric: Any) -> None:
     """Resolve the tuning metric, which a search-free run never would."""
     get_ordinal_scorer(tuning_metric)
+
+
+def _set_nested_random_state(estimator: Any, random_state: int | None) -> None:
+    """Forward the seed to every nested random_state parameter of a clone."""
+    if random_state is None:
+        return
+    estimator.set_params(
+        **{
+            key: random_state
+            for key in estimator.get_params(deep=True)
+            if key == "random_state" or key.endswith("__random_state")
+        }
+    )

--- a/skordinal/experiments/_base.py
+++ b/skordinal/experiments/_base.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import numpy as np
 
+from skordinal.metrics import get_ordinal_scorer
+from skordinal.metrics._metrics import _resolve_label_metric
+
 
 def _check_path_component(name: Any, what: str) -> None:
     """Reject a path component that cannot safely name one directory."""
@@ -34,3 +37,39 @@ def _check_split(split: str, *, allow_both: bool) -> None:
     valid = {"test", "train", "both"} if allow_both else {"test", "train"}
     if split not in valid:
         raise ValueError(f"split must be one of {sorted(valid)!r}, got {split!r}.")
+
+
+def _check_metric_names(metrics: Any, *, param: str) -> list[str]:
+    """Check an iterable of metric names, returning them stripped and unique."""
+    if isinstance(metrics, str):
+        raise TypeError(
+            f"'{param}' must be an iterable of metric name strings, not a "
+            f"bare string; pass [{metrics!r}] to use a single metric."
+        )
+    # An iterator is always truthy, and a name array has no single truth value
+    try:
+        metrics = list(metrics)
+    except TypeError:
+        raise TypeError(
+            f"'{param}' must be an iterable of metric name strings; got "
+            f"{type(metrics).__name__}."
+        ) from None
+    if not metrics:
+        raise ValueError(f"'{param}' must be a non-empty list; got an empty sequence.")
+    for name in metrics:
+        if not isinstance(name, str):
+            raise TypeError(
+                f"'{param}' must contain only metric name strings; got "
+                f"{type(name).__name__!r}."
+            )
+    # A repeat would compute the metric twice and duplicate evaluate's column
+    metrics = list(dict.fromkeys(name.strip() for name in metrics))
+    # Resolve now: a typo otherwise costs a full grid search
+    for name in metrics:
+        _resolve_label_metric(name)
+    return metrics
+
+
+def _check_tuning_metric(tuning_metric: Any) -> None:
+    """Resolve the tuning metric, which a search-free run never would."""
+    get_ordinal_scorer(tuning_metric)

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -7,11 +7,13 @@ from numbers import Integral
 from pathlib import Path
 
 import pandas as pd
+from sklearn.base import BaseEstimator
 from sklearn.utils import check_random_state
 
 from skordinal.datasets import load_partitions
 
 from ._base import (
+    _check_input_preprocessing,
     _check_metric_names,
     _check_path_component,
     _check_tuning_metric,
@@ -84,21 +86,20 @@ class Benchmark:
     n_jobs : int, default=1
         Number of parallel jobs forwarded to ``GridSearchCV``.
 
-    input_preprocessing : {"std", "norm"} or None, default=None
-        Optional feature preprocessing applied to every resample before
-        fitting: ``"norm"`` applies min-max normalisation and ``"std"`` applies
-        z-score standardisation. Both scalers are fitted on the training split
-        only, then applied to both train and test splits. ``None`` means no
+    input_preprocessing : transformer or None, default=None
+        Optional preprocessing applied before fitting: a transformer
+        instance, e.g. a scaler or a ``Pipeline``, cloned and seeded with
+        ``random_state`` for each resample. Fitted on the training split
+        only, then applied to both splits. ``None`` means no
         preprocessing.
 
     random_state : int or None, default=0
-        Seed used for two sources of randomness: the base estimator and the
-        cross-validation splitter (``StratifiedKFold``) used during
-        hyper-parameter search. Also forwarded to ``load_partitions`` when a
-        fallback split is generated. A non-integer value (including ``None``)
-        is resolved to one concrete integer at construction, so every
-        ``load_partitions`` call in ``run`` shares the same partitioning
-        scheme.
+        Seed forwarded to the base estimator, to the ``StratifiedKFold``
+        splitter of a hyper-parameter search, to the ``input_preprocessing``
+        clone, and to ``load_partitions`` when it generates the splits. A
+        non-integer value (including ``None``) is resolved to one concrete
+        integer at construction, so every ``load_partitions`` call in ``run``
+        shares the same partitioning scheme.
 
     overwrite : bool, default=False
         If ``False``, resamples already saved are skipped, making runs
@@ -112,8 +113,10 @@ class Benchmark:
     TypeError
         If ``models`` is not a dict or any of its values is not a
         ``ModelConfig``, if a model label or dataset name is not a str, if
-        ``datasets`` or ``eval_metrics`` is a bare string, or if
-        ``eval_metrics`` is not iterable or holds a non-string name.
+        ``datasets`` or ``eval_metrics`` is a bare string, if
+        ``eval_metrics`` is not iterable or holds a non-string name, or if
+        ``input_preprocessing`` is neither ``None`` nor a transformer
+        instance.
 
     ValueError
         If ``models``, ``datasets`` or ``eval_metrics`` is empty, if a model
@@ -155,7 +158,7 @@ class Benchmark:
         tuning_metric: str | Callable[..., float] | None = "neg_mean_absolute_error",
         cv: int = 3,
         n_jobs: int = 1,
-        input_preprocessing: str | None = None,
+        input_preprocessing: BaseEstimator | None = None,
         random_state: int | None = 0,
         overwrite: bool = False,
         verbose: bool = True,
@@ -190,16 +193,7 @@ class Benchmark:
             _check_path_component(name, "dataset name")
         eval_metrics = _check_metric_names(eval_metrics, param="eval_metrics")
         _check_tuning_metric(tuning_metric)
-
-        _allowed_preproc = {"std", "norm"}
-        if input_preprocessing is not None:
-            _normalized = str(input_preprocessing).strip().lower()
-            if _normalized not in _allowed_preproc:
-                raise ValueError(
-                    f"'input_preprocessing' must be one of {None, 'std', 'norm'}; "
-                    f"got '{input_preprocessing}'."
-                )
-            input_preprocessing = _normalized
+        _check_input_preprocessing(input_preprocessing)
 
         self.models: dict[str, ModelConfig] = dict(models)
         self.data_home: str | Path | None = data_home

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from numbers import Integral
 from pathlib import Path
 
+import pandas as pd
 from sklearn.utils import check_random_state
 
 from skordinal.datasets import load_partitions
 
+from ._base import _check_path_component
 from ._evaluation import save_summary
 from ._experiment import Experiment
 from ._model_config import ModelConfig
@@ -39,7 +41,9 @@ class Benchmark:
 
     datasets : list of str
         Names of the datasets to load, resolved via the dataset-loading layer.
-        Each name is passed directly to ``load_partitions``.
+        Each name is checked at construction: it also names the per-dataset
+        results folder, so it must be a plain name or filename without path
+        separators.
 
     eval_metrics : list of str
         Metric names to compute for every resample (e.g.
@@ -95,6 +99,17 @@ class Benchmark:
     verbose : bool, default=True
         If ``True``, progress messages are printed to stdout.
 
+    Raises
+    ------
+    TypeError
+        If ``models`` is not a dict or any of its values is not a
+        ``ModelConfig``, if a model label or dataset name is not a str, or
+        if ``datasets`` is a bare string.
+
+    ValueError
+        If ``models``, ``datasets`` or ``eval_metrics`` is empty, or if a
+        model label or dataset name is empty or holds a path separator.
+
     Attributes
     ----------
     _results : Results
@@ -134,6 +149,11 @@ class Benchmark:
         overwrite: bool = False,
         verbose: bool = True,
     ) -> None:
+        if not isinstance(models, dict):
+            raise TypeError(
+                f"'models' must be a dict of label to ModelConfig; got "
+                f"{type(models).__name__}."
+            )
         if not models:
             raise ValueError("'models' must be a non-empty dict; got an empty mapping.")
         _bad = [k for k, v in models.items() if not isinstance(v, ModelConfig)]
@@ -142,10 +162,20 @@ class Benchmark:
                 f"All values in 'models' must be ModelConfig instances; "
                 f"got non-ModelConfig value(s) for key(s): {_bad}."
             )
+        if isinstance(datasets, str):
+            raise TypeError(
+                f"'datasets' must be an iterable of dataset names, not a bare "
+                f"string; pass [{datasets!r}] to use a single dataset."
+            )
         if not datasets:
             raise ValueError(
                 "'datasets' must be a non-empty list; got an empty sequence."
             )
+        # Both name a directory in the results tree
+        for label in models:
+            _check_path_component(label, "model label")
+        for name in datasets:
+            _check_path_component(name, "dataset name")
         if not eval_metrics:
             raise ValueError(
                 "'eval_metrics' must be a non-empty list; got an empty sequence."
@@ -218,10 +248,12 @@ class Benchmark:
             If the recipe file does not define a top-level ``RECIPE`` dict.
 
         TypeError
-            If the recipe fails structural type validation.
+            If the recipe fails structural type validation, or if the
+            resulting configuration fails ``Benchmark.__init__``'s validation.
 
         ValueError
-            If the recipe fails structural constraint validation.
+            If the recipe fails structural constraint validation, or if the
+            resulting configuration fails ``Benchmark.__init__``'s validation.
         """
         recipe = dict(load_recipe(recipe_path))
         recipe.update(overrides)
@@ -312,8 +344,10 @@ class Benchmark:
         for split in ("train", "test"):
             try:
                 save_summary(self.results_path, split=split)
-            except ValueError:
-                # No stored metrics to summarise for this split: either nothing
-                # has been run yet, or no pair produced a report
+            except (pd.errors.EmptyDataError, pd.errors.ParserError):
+                # A corrupt report.csv is data loss, never "nothing to do"
+                raise
+            except (FileNotFoundError, ValueError):
+                # Nothing run yet (the folder may not exist), or no pair reported
                 if self.verbose:
                     print("  No metrics to summarise for the", split, "split")

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from numbers import Integral
 from pathlib import Path
 
@@ -10,7 +11,11 @@ from sklearn.utils import check_random_state
 
 from skordinal.datasets import load_partitions
 
-from ._base import _check_path_component
+from ._base import (
+    _check_metric_names,
+    _check_path_component,
+    _check_tuning_metric,
+)
 from ._evaluation import save_summary
 from ._experiment import Experiment
 from ._model_config import ModelConfig
@@ -41,15 +46,17 @@ class Benchmark:
 
     datasets : list of str
         Names of the datasets to load, resolved via the dataset-loading layer.
-        Each name is checked at construction: it also names the per-dataset
-        results folder, so it must be a plain name or filename without path
-        separators.
+        Each name is stripped and checked at construction: it also names the
+        per-dataset results folder, so it must be a plain name or filename
+        without path separators.
 
     eval_metrics : list of str
         Metric names to compute for every resample (e.g.
         ``["mean_absolute_error", "average_mean_absolute_error"]``). Names
         must match a ``skordinal.metrics`` metric that scores predicted
-        labels, which excludes ``ranked_probability_score``.
+        labels, which excludes ``ranked_probability_score``. Each name is
+        stripped and resolved at construction, so a typo fails before any
+        fitting starts.
 
     results_path : str or Path
         Directory where result files are written. Expanded and resolved to
@@ -64,11 +71,12 @@ class Benchmark:
         Fraction of samples held out for testing when ``load_partitions``
         generates the splits; ignored when a masks file supplies them.
 
-    tuning_metric : str, default="neg_mean_absolute_error"
-        Metric used as the cross-validation scoring criterion when selecting the
-        best hyper-parameter combination. Must be recognised by
-        ``skordinal.metrics.get_ordinal_scorer``; validation is deferred to
-        runtime.
+    tuning_metric : str, callable or None, default="neg_mean_absolute_error"
+        Cross-validation scoring criterion used to select the best
+        hyper-parameter combination. A string is resolved at construction
+        with ``skordinal.metrics.get_ordinal_scorer``; a callable is passed
+        to ``GridSearchCV`` verbatim, and ``None`` falls back to the
+        estimator's own ``score``.
 
     cv : int, default=3
         Number of folds used in hyper-parameter cross-validation.
@@ -103,12 +111,15 @@ class Benchmark:
     ------
     TypeError
         If ``models`` is not a dict or any of its values is not a
-        ``ModelConfig``, if a model label or dataset name is not a str, or
-        if ``datasets`` is a bare string.
+        ``ModelConfig``, if a model label or dataset name is not a str, if
+        ``datasets`` or ``eval_metrics`` is a bare string, or if
+        ``eval_metrics`` is not iterable or holds a non-string name.
 
     ValueError
-        If ``models``, ``datasets`` or ``eval_metrics`` is empty, or if a
-        model label or dataset name is empty or holds a path separator.
+        If ``models``, ``datasets`` or ``eval_metrics`` is empty, if a model
+        label or dataset name is not a usable path component, if a name in
+        ``eval_metrics`` is not a registered label metric, or if a string
+        ``tuning_metric`` is not a registered scorer name.
 
     Attributes
     ----------
@@ -141,7 +152,7 @@ class Benchmark:
         results_path: str | Path,
         resamples: int | list[int] = 30,
         test_size: float = 0.3,
-        tuning_metric: str = "neg_mean_absolute_error",
+        tuning_metric: str | Callable[..., float] | None = "neg_mean_absolute_error",
         cv: int = 3,
         n_jobs: int = 1,
         input_preprocessing: str | None = None,
@@ -174,12 +185,11 @@ class Benchmark:
         # Both name a directory in the results tree
         for label in models:
             _check_path_component(label, "model label")
+        datasets = [x.strip() if isinstance(x, str) else x for x in datasets]
         for name in datasets:
             _check_path_component(name, "dataset name")
-        if not eval_metrics:
-            raise ValueError(
-                "'eval_metrics' must be a non-empty list; got an empty sequence."
-            )
+        eval_metrics = _check_metric_names(eval_metrics, param="eval_metrics")
+        _check_tuning_metric(tuning_metric)
 
         _allowed_preproc = {"std", "norm"}
         if input_preprocessing is not None:
@@ -194,7 +204,7 @@ class Benchmark:
         self.models: dict[str, ModelConfig] = dict(models)
         self.data_home: str | Path | None = data_home
         self.datasets: list[str] = list(datasets)
-        self.eval_metrics: list[str] = list(eval_metrics)
+        self.eval_metrics: list[str] = eval_metrics
         self._results = Results(results_path)
         # Reuse the resolved root so a later chdir cannot split write from read
         self.results_path = self._results.path
@@ -283,9 +293,7 @@ class Benchmark:
             print("###############################")
 
         # Iterate over datasets
-        for x in self.datasets:
-            dataset_name = x.strip()
-
+        for dataset_name in self.datasets:
             if self.verbose:
                 print("\nRunning", dataset_name, "dataset")
                 print("--------------------------")

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import logging
+import math
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from numbers import Integral
 from pathlib import Path
 
@@ -23,6 +27,13 @@ from ._experiment import Experiment
 from ._model_config import ModelConfig
 from ._recipes import load_recipe
 from ._results import Results
+
+_logger = logging.getLogger("skordinal.experiments")
+
+try:  # Soft dependency: progress bars appear only when tqdm is installed
+    from tqdm.auto import tqdm
+except ImportError:  # pragma: no cover - the dev extra always installs tqdm
+    tqdm = None
 
 
 class Benchmark:
@@ -58,7 +69,8 @@ class Benchmark:
         must match a ``skordinal.metrics`` metric that scores predicted
         labels, which excludes ``ranked_probability_score``. Each name is
         stripped and resolved at construction, so a typo fails before any
-        fitting starts.
+        fitting starts. The first name is the one surfaced in progress
+        output.
 
     results_path : str or Path
         Directory where result files are written. Expanded and resolved to
@@ -106,7 +118,11 @@ class Benchmark:
         resumable. ``True`` recomputes every resample.
 
     verbose : bool, default=True
-        If ``True``, progress messages are printed to stdout.
+        If ``True``, progress is reported at INFO on the
+        ``"skordinal.experiments"`` logger, with a stdout handler attached
+        for the call unless the application configured its own, plus a tqdm
+        bar per pair when tqdm is installed and stderr is a terminal. If
+        ``False``, the records are still emitted but no handler is attached.
 
     Raises
     ------
@@ -281,75 +297,146 @@ class Benchmark:
             If a dataset name cannot be resolved by the dataset-loading layer
             (no matching path and not present in the bundled collection).
         """
-        if self.verbose:
-            print("\n###############################")
-            print("\tRunning Benchmark")
-            print("###############################")
+        with self._stdout_logging():
+            _logger.info(
+                "Running benchmark: %d model(s) x %d dataset(s)",
+                len(self.models),
+                len(self.datasets),
+            )
+            for dataset_name in self.datasets:
+                _logger.info("Running the %s dataset", dataset_name)
 
-        # Iterate over datasets
-        for dataset_name in self.datasets:
-            if self.verbose:
-                print("\nRunning", dataset_name, "dataset")
-                print("--------------------------")
-
-            # Iterate over configurations
-            for label, model in self.models.items():
-                if self.verbose:
-                    print("Running", label, "...")
-
-                experiment = Experiment(
-                    model,
-                    eval_metrics=self.eval_metrics,
-                    tuning_metric=self.tuning_metric,
-                    cv=self.cv,
-                    n_jobs=self.n_jobs,
-                    input_preprocessing=self.input_preprocessing,
-                    random_state=self.random_state,
-                )
-
-                # Iterate over resamples via the dataset-loading layer
-                for b in load_partitions(
-                    dataset_name,
-                    data_home=self.data_home,
-                    resamples=self.resamples,
-                    test_size=self.test_size,
-                    random_state=self.random_state,
-                ):
-                    if not self.overwrite and self._results.exists(
-                        label, dataset_name, b.resample_id
-                    ):
-                        if self.verbose:
-                            print("  Skipping resample", b.resample_id)
-                        continue
-
-                    if self.verbose:
-                        print("  Running resample", b.resample_id)
-
-                    result = experiment.run(
-                        b.data_train,
-                        b.target_train,
-                        b.data_test,
-                        b.target_test,
-                        dataset_name=dataset_name,
-                        classifier_name=label,
-                        resample_id=b.resample_id,
-                        train_index=b.train_index,
-                        test_index=b.test_index,
+                for label, model in self.models.items():
+                    experiment = Experiment(
+                        model,
+                        eval_metrics=self.eval_metrics,
+                        tuning_metric=self.tuning_metric,
+                        cv=self.cv,
+                        n_jobs=self.n_jobs,
+                        input_preprocessing=self.input_preprocessing,
+                        random_state=self.random_state,
                     )
-                    self._results.save(result)
+
+                    partitions = load_partitions(
+                        dataset_name,
+                        data_home=self.data_home,
+                        resamples=self.resamples,
+                        test_size=self.test_size,
+                        random_state=self.random_state,
+                    )
+                    bar = None
+                    if self.verbose and tqdm is not None:
+                        total = (
+                            len(self.resamples)
+                            if isinstance(self.resamples, list)
+                            else int(self.resamples)
+                        )
+                        partitions = bar = tqdm(
+                            partitions,
+                            desc=f"  {label}",
+                            unit="resample",
+                            total=total,
+                            leave=False,
+                            disable=None,
+                        )
+
+                    # A live bar names the model and counts resamples itself
+                    progress_level = (
+                        logging.DEBUG
+                        if bar is not None and not getattr(bar, "disable", False)
+                        else logging.INFO
+                    )
+                    _logger.log(progress_level, "  Running %s", label)
+                    metric = self.eval_metrics[0]
+                    ran, skipped, scores = 0, 0, []
+                    for b in partitions:
+                        if not self.overwrite and self._results.exists(
+                            label, dataset_name, b.resample_id
+                        ):
+                            _logger.log(
+                                progress_level,
+                                "    Skipping resample %s",
+                                b.resample_id,
+                            )
+                            skipped += 1
+                            continue
+
+                        _logger.log(
+                            progress_level, "    Running resample %s", b.resample_id
+                        )
+                        result = experiment.run(
+                            b.data_train,
+                            b.target_train,
+                            b.data_test,
+                            b.target_test,
+                            dataset_name=dataset_name,
+                            classifier_name=label,
+                            resample_id=b.resample_id,
+                            train_index=b.train_index,
+                            test_index=b.test_index,
+                        )
+                        self._results.save(result)
+                        ran += 1
+                        # NaN means a train-only run, which the mean leaves out
+                        score = result.test_metrics[f"{metric}_test"]
+                        if not math.isnan(score):
+                            scores.append(score)
+                            if bar is not None:
+                                # Refreshing now would redraw a stale counter
+                                bar.set_postfix(
+                                    {f"{metric}_test": f"{score:.4f}"}, refresh=False
+                                )
+
+                    summary = f"  {label}: {ran} resample(s) run, {skipped} skipped"
+                    if scores and not skipped:
+                        summary += (
+                            f", mean {metric}_test={sum(scores) / len(scores):.4f}"
+                        )
+                    _logger.info(summary)
 
     def summarize(self) -> None:
         """Write the train and test summaries to the results folder."""
-        if self.verbose:
-            print("\nSaving summary...")
+        with self._stdout_logging():
+            _logger.info("Saving summary")
+            for split in ("train", "test"):
+                try:
+                    save_summary(self.results_path, split=split)
+                except (pd.errors.EmptyDataError, pd.errors.ParserError):
+                    # A corrupt report.csv is data loss, never "nothing to do"
+                    raise
+                except (FileNotFoundError, ValueError):
+                    # Nothing run yet (the folder may not exist), or no pair reported
+                    _logger.info("No metrics to summarise for the %s split", split)
 
-        for split in ("train", "test"):
-            try:
-                save_summary(self.results_path, split=split)
-            except (pd.errors.EmptyDataError, pd.errors.ParserError):
-                # A corrupt report.csv is data loss, never "nothing to do"
-                raise
-            except (FileNotFoundError, ValueError):
-                # Nothing run yet (the folder may not exist), or no pair reported
-                if self.verbose:
-                    print("  No metrics to summarise for the", split, "split")
+    @contextmanager
+    def _stdout_logging(self) -> Iterator[None]:
+        """Show INFO progress while verbose, unless the app configured logging."""
+        if not self.verbose:
+            yield
+            return
+        previous_level = _logger.level
+        if _logger.getEffectiveLevel() > logging.INFO:
+            _logger.setLevel(logging.INFO)
+        handler = None
+        if not self._has_real_handler(_logger):
+            handler = logging.StreamHandler(sys.stdout)
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            _logger.addHandler(handler)
+        try:
+            yield
+        finally:
+            if handler is not None:
+                _logger.removeHandler(handler)
+            _logger.setLevel(previous_level)
+
+    @staticmethod
+    def _has_real_handler(logger: logging.Logger) -> bool:
+        """Report whether a non-NullHandler is reachable from logger."""
+        current: logging.Logger | None = logger
+        while current is not None:
+            if any(not isinstance(h, logging.NullHandler) for h in current.handlers):
+                return True
+            if not current.propagate:
+                return False
+            current = current.parent  # type: ignore[assignment]
+        return False

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -39,11 +39,11 @@ except ImportError:  # pragma: no cover - the dev extra always installs tqdm
 class Benchmark:
     """Run a benchmark of M configurations across N datasets and their resamples.
 
-    Each configuration pairs a classifier method with one or more hyper-parameter
-    values. Calling ``run`` performs cross-validation for every resample of each
-    dataset-configuration pair, fits the selected model, predicts the test
-    labels, and stores all metrics in a ``Results`` object. ``summarize``
-    then writes the aggregated train and test summaries.
+    Each configuration pairs a classifier method with one or more
+    hyper-parameter values. ``run`` fits and scores every resample of each
+    dataset-configuration pair, cross-validating the grid when it holds more
+    than one candidate, and stores the metrics in a ``Results`` object.
+    ``summarize`` then writes the aggregated train and test summaries.
 
     Parameters
     ----------
@@ -142,8 +142,8 @@ class Benchmark:
 
     Attributes
     ----------
-    _results : Results
-        Manages and stores all information obtained during the experiment run.
+    results_path : Path
+        Absolute results root, resolved once at construction.
 
     Examples
     --------
@@ -256,8 +256,7 @@ class Benchmark:
         Returns
         -------
         benchmark : Benchmark
-            A fully configured ``Benchmark`` instance ready to call
-            ``run`` on.
+            A configured ``Benchmark``, ready to ``run``.
 
         Raises
         ------
@@ -283,13 +282,11 @@ class Benchmark:
     def run(self) -> None:
         """Run the benchmark over every dataset, configuration and resample.
 
-        Loads all datasets via the dataset-loading layer, one resample at a
-        time. Builds a model per resample, using cross-validation to find the
-        optimal values among the hyper-parameters to compare from.
-
-        Uses the built model to get train and test metrics, storing all the
-        information into a Results object. Resamples already saved are
-        skipped unless ``overwrite`` is ``True``.
+        Streams each dataset's resamples from the dataset-loading layer and
+        runs every configuration on each of them, cross-validating the grid
+        when that configuration needs a search. Every result is stored in the
+        ``Results`` object, and resamples already saved are skipped unless
+        ``overwrite`` is ``True``.
 
         Raises
         ------

--- a/skordinal/experiments/_benchmark.py
+++ b/skordinal/experiments/_benchmark.py
@@ -34,8 +34,8 @@ class Benchmark:
 
     data_home : str, Path, or None, default=None
         Optional base directory used to locate dataset files. When ``None``,
-        dataset names are resolved against a direct path or the bundled
-        collection via the dataset-loading layer.
+        dataset names are resolved against the bundled collection via the
+        dataset-loading layer.
 
     datasets : list of str
         Names of the datasets to load, resolved via the dataset-loading layer.
@@ -52,9 +52,9 @@ class Benchmark:
         an absolute path at construction, so a later working-directory
         change does not affect where results are written or read.
 
-    resamples : int, default=30
-        Number of resamples (train/test splits) to load per dataset. Forwarded
-        to ``load_partitions``.
+    resamples : int or list of int, default=30
+        Resamples (train/test splits) to load per dataset, forwarded verbatim
+        to ``load_partitions``: a count, or the list of resample ids to use.
 
     test_size : float, default=0.3
         Fraction of samples held out for testing when ``load_partitions``
@@ -124,7 +124,7 @@ class Benchmark:
         datasets: list[str],
         eval_metrics: list[str],
         results_path: str | Path,
-        resamples: int = 30,
+        resamples: int | list[int] = 30,
         test_size: float = 0.3,
         tuning_metric: str = "neg_mean_absolute_error",
         cv: int = 3,
@@ -168,7 +168,7 @@ class Benchmark:
         self._results = Results(results_path)
         # Reuse the resolved root so a later chdir cannot split write from read
         self.results_path = self._results.path
-        self.resamples: int = resamples
+        self.resamples: int | list[int] = resamples
         self.test_size: float = test_size
         self.tuning_metric = tuning_metric
         self.cv = cv

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -282,7 +282,6 @@ def tabulate_results(results_path, *, metric="mean_absolute_error", split="test"
     rows = []
 
     for clf, ds, df in _iter_reports(results):
-        # Format as "mean +/- std", or "n/a" when metric is absent or all-NaN
         if col not in df.columns or df[col].isna().all():
             cell = "n/a"
         else:

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -77,9 +77,8 @@ def evaluate(
     ValueError
         If ``split`` is not ``"test"`` or ``"train"``, if ``metrics`` is
         empty or holds an unregistered name, if ``classifier_name`` or
-        ``dataset_name`` is empty, a dot segment, or contains a path
-        separator, or if a predictions file lacks the ``Target`` or
-        ``Prediction`` column.
+        ``dataset_name`` is not a usable path component, or if a predictions
+        file lacks the ``Target`` or ``Prediction`` column.
 
     TypeError
         If ``classifier_name`` or ``dataset_name`` is not a string, or if

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -6,7 +6,8 @@ import pandas as pd
 
 from skordinal.metrics._metrics import _resolve_label_metric
 
-from ._io import _atomic_write, _check_split
+from ._base import _check_split
+from ._io import _atomic_write
 from ._results import Results
 
 

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -2,12 +2,11 @@
 
 import math
 
+import numpy as np
 import pandas as pd
 
-from skordinal.metrics._metrics import _resolve_label_metric
-
-from ._base import _check_metric_names, _check_split
-from ._io import _atomic_write
+from ._base import _check_metric_names, _check_split, _compute_metric
+from ._io import _atomic_write, _read_confusion_matrix_size
 from ._results import Results
 
 
@@ -101,7 +100,8 @@ def evaluate(
     ``best_model.classes_``, so metrics are recomputed in rank space, where
     adjacent categories are always distance 1. ``report.csv``'s own values are
     computed on the raw labels, so the two agree only while the label set is
-    contiguous.
+    contiguous. The scale spans the pair's saved confusion matrix, so a tree
+    written without one is scored on the ranks its predictions contain.
 
     Examples
     --------
@@ -129,8 +129,13 @@ def evaluate(
             )
         y_true = df["Target"].to_numpy()
         y_pred = df["Prediction"].to_numpy()
+        # The saved confusion matrix is the only artefact that still carries K
+        size = _read_confusion_matrix_size(
+            path.parent / f"{split}_confusion_matrix.txt"
+        )
+        labels = np.arange(size) if size else None
         rows[resample_id] = {
-            name: float(_resolve_label_metric(name)(y_true, y_pred))
+            name: _compute_metric(name, y_true, y_pred, labels=labels)
             for name in metric_names
         }
 
@@ -202,7 +207,6 @@ def summarize(results_path, *, classifiers=None, split="test"):
         if classifier_set is not None and clf not in classifier_set:
             continue
 
-        # Select columns for the requested split
         if split == "test":
             metric_cols = [c for c in df.columns if c.endswith("_test")]
         elif split == "train":
@@ -210,7 +214,6 @@ def summarize(results_path, *, classifiers=None, split="test"):
         else:
             metric_cols = [c for c in df.columns if c.endswith(("_test", "_train"))]
 
-        # Compute mean and std for each metric column
         row = {"classifier": clf, "dataset": ds}
         for col in metric_cols:
             series = df[col].dropna()
@@ -227,7 +230,6 @@ def summarize(results_path, *, classifiers=None, split="test"):
     if not rows:
         return pd.DataFrame()
 
-    # Build MultiIndex DataFrame from accumulated rows
     summary = pd.DataFrame(rows).set_index(["classifier", "dataset"])
     summary.columns = pd.MultiIndex.from_tuples(list(summary.columns))
     return summary
@@ -297,7 +299,6 @@ def tabulate_results(results_path, *, metric="mean_absolute_error", split="test"
     if not rows:
         return pd.DataFrame()
 
-    # Pivot into a classifiers x datasets table
     return (
         pd.DataFrame(rows)
         .pivot(index="classifier", columns="dataset", values="value")

--- a/skordinal/experiments/_evaluation.py
+++ b/skordinal/experiments/_evaluation.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from skordinal.metrics._metrics import _resolve_label_metric
 
-from ._base import _check_split
+from ._base import _check_metric_names, _check_split
 from ._io import _atomic_write
 from ._results import Results
 
@@ -110,28 +110,10 @@ def evaluate(
     """
     _check_split(split, allow_both=False)
 
-    if isinstance(metrics, str):
-        raise TypeError(
-            "metrics must be an iterable of metric name strings, not a bare string; "
-            f"pass [{metrics!r}] to compute a single metric."
-        )
-    metric_names = (
-        tuple(metrics)
-        if metrics is not None
-        else ("mean_absolute_error", "accuracy_score")
-    )
-    if not metric_names:
-        raise ValueError("'metrics' must be non-empty; got an empty sequence.")
-    for name in metric_names:
-        if not isinstance(name, str):
-            raise TypeError(
-                "metrics must contain only metric name strings; got "
-                f"{type(name).__name__!r}."
-            )
-    # Key the columns by the stripped name, like Experiment's report.csv
-    metric_names = tuple(name.strip() for name in metric_names)
-    # Resolve up front so an unknown name raises before any file is read
-    resolved = {name: _resolve_label_metric(name) for name in metric_names}
+    if metrics is None:
+        metrics = ("mean_absolute_error", "accuracy_score")
+    # Stripped names key the columns, like Experiment's report.csv
+    metric_names = tuple(_check_metric_names(metrics, param="metrics"))
 
     results = _existing_results(results_path)
     rows = {}
@@ -148,7 +130,8 @@ def evaluate(
         y_true = df["Target"].to_numpy()
         y_pred = df["Prediction"].to_numpy()
         rows[resample_id] = {
-            name: float(metric(y_true, y_pred)) for name, metric in resolved.items()
+            name: float(_resolve_label_metric(name)(y_true, y_pred))
+            for name in metric_names
         }
 
     return pd.DataFrame.from_dict(

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -24,21 +24,6 @@ def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) ->
     return _resolve_label_metric(metric_name.strip())(y_true, y_pred)
 
 
-def _predict_proba_or_none(estimator: Any, inputs: np.ndarray) -> np.ndarray | None:
-    """Return class probabilities, or ``None`` when the estimator cannot."""
-    if not hasattr(estimator, "predict_proba"):
-        return None
-    try:
-        return estimator.predict_proba(inputs)
-    except AttributeError as exc:
-        warnings.warn(
-            f"predict_proba raised AttributeError; probabilities are omitted: {exc}",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return None
-
-
 class Experiment:
     """Run a single classifier configuration on one train/test partition.
 
@@ -141,6 +126,21 @@ class Experiment:
         self.n_jobs = n_jobs
         self.input_preprocessing = input_preprocessing
         self.random_state = random_state
+
+    @staticmethod
+    def _predict_proba_or_none(estimator: Any, inputs: np.ndarray) -> np.ndarray | None:
+        """Return class probabilities, or ``None`` when the estimator cannot."""
+        if not hasattr(estimator, "predict_proba"):
+            return None
+        try:
+            return estimator.predict_proba(inputs)
+        except AttributeError as exc:
+            warnings.warn(
+                f"predict_proba raised AttributeError; probabilities are omitted: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return None
 
     def run(
         self,
@@ -289,11 +289,11 @@ class Experiment:
         test_metrics["time_test"] = elapsed
 
         # Compute class probabilities on each split when supported
-        train_y_proba = _predict_proba_or_none(best_estimator, train_inputs)
+        train_y_proba = self._predict_proba_or_none(best_estimator, train_inputs)
         y_proba = None
         if y_test is not None:
             assert test_inputs is not None
-            y_proba = _predict_proba_or_none(best_estimator, test_inputs)
+            y_proba = self._predict_proba_or_none(best_estimator, test_inputs)
 
         # Build and return the ExperimentResult; no persistence here.
         return ExperimentResult(

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections import OrderedDict
+from collections.abc import Callable
 from time import perf_counter
 from typing import Any
 
@@ -15,6 +16,7 @@ from sklearn.model_selection import GridSearchCV, StratifiedKFold
 from skordinal.metrics import get_ordinal_scorer
 from skordinal.metrics._metrics import _resolve_label_metric
 
+from ._base import _check_metric_names, _check_tuning_metric
 from ._model_config import ModelConfig
 from ._results import ExperimentResult
 
@@ -46,13 +48,16 @@ class Experiment:
         Metric names to compute for every partition (e.g.
         ``["mean_absolute_error", "average_mean_absolute_error"]``). Names
         must match a ``skordinal.metrics`` metric that scores predicted
-        labels, which excludes ``ranked_probability_score``.
+        labels, which excludes ``ranked_probability_score``. Each name is
+        stripped and resolved at construction, so a typo fails before any
+        fitting starts.
 
-    tuning_metric : str, default="neg_mean_absolute_error"
-        Metric used as the cross-validation scoring criterion when selecting
-        the best hyper-parameter combination. Must be recognised by
-        ``skordinal.metrics.get_ordinal_scorer``; validation is deferred to
-        runtime.
+    tuning_metric : str, callable or None, default="neg_mean_absolute_error"
+        Cross-validation scoring criterion used to select the best
+        hyper-parameter combination. A string is resolved at construction
+        with ``skordinal.metrics.get_ordinal_scorer``; a callable is passed
+        to ``GridSearchCV`` verbatim, and ``None`` falls back to the
+        estimator's own ``score``.
 
     cv : int, default=3
         Number of folds used in hyper-parameter cross-validation.
@@ -72,6 +77,16 @@ class Experiment:
         cross-validation splitter (``StratifiedKFold``) used during
         hyper-parameter search. When ``None``, both use their own default
         random behaviour.
+
+    Raises
+    ------
+    TypeError
+        If ``model`` is not a ``ModelConfig``, or if ``eval_metrics`` is a
+        bare string, not iterable, or holds a non-string name.
+
+    ValueError
+        If ``eval_metrics`` is empty or holds an unregistered label-metric
+        name, or if a string ``tuning_metric`` is not a registered scorer name.
 
     Examples
     --------
@@ -94,7 +109,7 @@ class Experiment:
         model: ModelConfig,
         *,
         eval_metrics: list[str],
-        tuning_metric: str = "neg_mean_absolute_error",
+        tuning_metric: str | Callable[..., float] | None = "neg_mean_absolute_error",
         cv: int = 3,
         n_jobs: int = 1,
         input_preprocessing: str | None = None,
@@ -104,10 +119,8 @@ class Experiment:
             raise TypeError(
                 f"'model' must be a ModelConfig instance; got {type(model).__name__!r}."
             )
-        if not eval_metrics:
-            raise ValueError(
-                "'eval_metrics' must be a non-empty list; got an empty sequence."
-            )
+        eval_metrics = _check_metric_names(eval_metrics, param="eval_metrics")
+        _check_tuning_metric(tuning_metric)
 
         _allowed_preproc = {"std", "norm"}
         if input_preprocessing is not None:
@@ -120,7 +133,7 @@ class Experiment:
             input_preprocessing = _normalized
 
         self.model = model
-        self.eval_metrics: list[str] = list(eval_metrics)
+        self.eval_metrics: list[str] = eval_metrics
         self.tuning_metric = tuning_metric
         self.cv = cv
         self.n_jobs = n_jobs
@@ -282,13 +295,13 @@ class Experiment:
                 y_train,
                 train_predicted_y,
             )
-            train_metrics[metric_name.strip() + "_train"] = train_score
+            train_metrics[metric_name + "_train"] = train_score
 
-            test_metrics[metric_name.strip() + "_test"] = np.nan
+            test_metrics[metric_name + "_test"] = np.nan
             if y_test is not None:
                 assert test_predicted_y is not None
                 test_score = _compute_metric(metric_name, y_test, test_predicted_y)
-                test_metrics[metric_name.strip() + "_test"] = test_score
+                test_metrics[metric_name + "_test"] = test_score
 
         # Assemble timing keys, the cv_* pair stays NaN unless a search ran
         train_metrics["cv_time_train"] = cv_time_train

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -29,11 +29,8 @@ class Experiment:
     """Run a single classifier configuration on one train/test partition.
 
     Wraps one ``ModelConfig`` together with the cross-validation and
-    preprocessing settings shared across partitions. Calling ``run`` applies
-    optional preprocessing, selects and fits the best estimator, predicts on
-    the train and (when present) test splits, computes all evaluation metrics
-    and timing keys, and returns an ``ExperimentResult``. Nothing is written
-    to disk.
+    preprocessing settings shared across partitions. ``run`` does the work
+    for one partition and writes nothing to disk.
 
     Parameters
     ----------
@@ -192,30 +189,27 @@ class Experiment:
             Test labels. When ``None`` no test metrics are computed.
 
         dataset_name : str
-            Name of the dataset, forwarded to the returned
-            ``ExperimentResult``.
+            Name of the dataset, recorded on the result.
 
         classifier_name : str
-            Configuration label, used as ``classifier_name`` in the returned
-            ``ExperimentResult``.
+            Configuration label, recorded on the result.
 
         resample_id : int
-            Partition index, forwarded to the returned ``ExperimentResult``.
+            Partition index, recorded on the result.
 
         train_index : ndarray of shape (n_train_samples,) or None, default=None
             Zero-based positions of the training samples in the original
-            dataset array; forwarded to the returned ``ExperimentResult`` and
-            used as the ``Pattern ID`` column.
+            dataset array, recorded on the result as its ``Pattern ID``
+            column.
 
         test_index : ndarray of shape (n_test_samples,) or None, default=None
             Zero-based positions of the test samples in the original dataset
-            array; forwarded to the returned ``ExperimentResult`` and used as
-            the ``Pattern ID`` column.
+            array, recorded on the result as its ``Pattern ID`` column.
 
         Returns
         -------
         ExperimentResult
-            Fully populated result for this partition. No side effects.
+            Fully populated result for this partition.
 
         Raises
         ------
@@ -232,7 +226,6 @@ class Experiment:
 
         if scaler is not None:
             train_inputs = scaler.fit(train_inputs).transform(train_inputs)
-            # A train-only run has no test split to transform
             if X_test is not None:
                 test_inputs = scaler.transform(X_test)
 
@@ -296,7 +289,7 @@ class Experiment:
                 )
                 test_metrics[metric_name + "_test"] = test_score
 
-        # Assemble timing keys, the cv_* pair stays NaN unless a search ran
+        # The cv_* pair stays NaN unless a search ran
         train_metrics["cv_time_train"] = cv_time_train
         test_metrics["cv_time_test"] = cv_time_test
         train_metrics["time_train"] = refit_time

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -13,21 +13,16 @@ from sklearn.base import BaseEstimator, clone
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import get_ordinal_scorer
-from skordinal.metrics._metrics import _resolve_label_metric
 
 from ._base import (
     _check_input_preprocessing,
     _check_metric_names,
     _check_tuning_metric,
+    _compute_metric,
     _set_nested_random_state,
 )
 from ._model_config import ModelConfig
 from ._results import ExperimentResult
-
-
-def _compute_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
-    """Compute a single ordinal metric by name."""
-    return _resolve_label_metric(metric_name.strip())(y_true, y_pred)
 
 
 class Experiment:
@@ -230,7 +225,7 @@ class Experiment:
         if y_test is not None and X_test is None:
             raise ValueError("'y_test' was given without 'X_test'.")
 
-        # Apply preprocessing on local copies so the caller's arrays are not mutated.
+        # Preprocess into locals so the caller's arrays are never mutated
         train_inputs: np.ndarray = X_train
         test_inputs: np.ndarray | None = X_test
         scaler = self._build_scaler()
@@ -241,8 +236,7 @@ class Experiment:
             if X_test is not None:
                 test_inputs = scaler.transform(X_test)
 
-        # Select and fit the best estimator, keeping the refit metadata in
-        # locals so nothing is ever injected onto the estimator itself
+        # Keep the refit metadata in locals, never on the estimator itself
         base = self.model.build(self.random_state)
         if self.model.needs_search:
             scorer = get_ordinal_scorer(self.tuning_metric)
@@ -274,10 +268,8 @@ class Experiment:
             cv_time_train = np.nan
             cv_time_test = np.nan
 
-        # Predict on the training split.
         train_predicted_y = best_estimator.predict(train_inputs)
 
-        # Predict on the test split when it is present.
         test_predicted_y = None
         elapsed = np.nan
         if y_test is not None:
@@ -286,21 +278,22 @@ class Experiment:
             test_predicted_y = np.asarray(best_estimator.predict(test_inputs))
             elapsed = perf_counter() - start
 
-        # Compute evaluation metrics for both splits.
+        # The fitted scale, so a split missing a class keeps its real gaps
+        classes = getattr(best_estimator, "classes_", None)
         train_metrics: OrderedDict[str, Any] = OrderedDict()
         test_metrics: OrderedDict[str, Any] = OrderedDict()
         for metric_name in self.eval_metrics:
             train_score = _compute_metric(
-                metric_name,
-                y_train,
-                train_predicted_y,
+                metric_name, y_train, train_predicted_y, labels=classes
             )
             train_metrics[metric_name + "_train"] = train_score
 
             test_metrics[metric_name + "_test"] = np.nan
             if y_test is not None:
                 assert test_predicted_y is not None
-                test_score = _compute_metric(metric_name, y_test, test_predicted_y)
+                test_score = _compute_metric(
+                    metric_name, y_test, test_predicted_y, labels=classes
+                )
                 test_metrics[metric_name + "_test"] = test_score
 
         # Assemble timing keys, the cv_* pair stays NaN unless a search ran
@@ -309,14 +302,12 @@ class Experiment:
         train_metrics["time_train"] = refit_time
         test_metrics["time_test"] = elapsed
 
-        # Compute class probabilities on each split when supported
         train_y_proba = self._predict_proba_or_none(best_estimator, train_inputs)
         y_proba = None
         if y_test is not None:
             assert test_inputs is not None
             y_proba = self._predict_proba_or_none(best_estimator, test_inputs)
 
-        # Build and return the ExperimentResult; no persistence here.
         return ExperimentResult(
             dataset_name=dataset_name,
             classifier_name=classifier_name,

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -9,14 +9,18 @@ from time import perf_counter
 from typing import Any
 
 import numpy as np
-from sklearn import preprocessing
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, clone
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
 
 from skordinal.metrics import get_ordinal_scorer
 from skordinal.metrics._metrics import _resolve_label_metric
 
-from ._base import _check_metric_names, _check_tuning_metric
+from ._base import (
+    _check_input_preprocessing,
+    _check_metric_names,
+    _check_tuning_metric,
+    _set_nested_random_state,
+)
 from ._model_config import ModelConfig
 from ._results import ExperimentResult
 
@@ -65,24 +69,26 @@ class Experiment:
     n_jobs : int, default=1
         Number of parallel jobs forwarded to ``GridSearchCV``.
 
-    input_preprocessing : {"std", "norm"} or None, default=None
-        Optional feature preprocessing applied to every partition before
-        fitting: ``"norm"`` applies min-max normalisation and ``"std"`` applies
-        z-score standardisation. Both scalers are fitted on the training split
+    input_preprocessing : transformer or None, default=None
+        Optional preprocessing applied before fitting: a transformer
+        instance, e.g. a scaler or a ``Pipeline``, cloned and seeded with
+        ``random_state`` for each partition. Fitted on the training split
         only, then applied to the train split and, when present, the test
         split. ``None`` means no preprocessing.
 
     random_state : int or None, default=None
-        Seed used for two sources of randomness: the base estimator and the
-        cross-validation splitter (``StratifiedKFold``) used during
-        hyper-parameter search. When ``None``, both use their own default
-        random behaviour.
+        Seed forwarded to the base estimator, to the ``StratifiedKFold``
+        splitter of a hyper-parameter search, and to the
+        ``input_preprocessing`` clone. When ``None``, each keeps its own
+        default random behaviour.
 
     Raises
     ------
     TypeError
-        If ``model`` is not a ``ModelConfig``, or if ``eval_metrics`` is a
-        bare string, not iterable, or holds a non-string name.
+        If ``model`` is not a ``ModelConfig``, if ``eval_metrics`` is a
+        bare string, not iterable, or holds a non-string name, or if
+        ``input_preprocessing`` is neither ``None`` nor a transformer
+        instance.
 
     ValueError
         If ``eval_metrics`` is empty or holds an unregistered label-metric
@@ -112,7 +118,7 @@ class Experiment:
         tuning_metric: str | Callable[..., float] | None = "neg_mean_absolute_error",
         cv: int = 3,
         n_jobs: int = 1,
-        input_preprocessing: str | None = None,
+        input_preprocessing: BaseEstimator | None = None,
         random_state: int | None = None,
     ) -> None:
         if not isinstance(model, ModelConfig):
@@ -121,16 +127,7 @@ class Experiment:
             )
         eval_metrics = _check_metric_names(eval_metrics, param="eval_metrics")
         _check_tuning_metric(tuning_metric)
-
-        _allowed_preproc = {"std", "norm"}
-        if input_preprocessing is not None:
-            _normalized = str(input_preprocessing).strip().lower()
-            if _normalized not in _allowed_preproc:
-                raise ValueError(
-                    f"'input_preprocessing' must be one of {None, 'std', 'norm'}; "
-                    f"got '{input_preprocessing}'."
-                )
-            input_preprocessing = _normalized
+        _check_input_preprocessing(input_preprocessing)
 
         self.model = model
         self.eval_metrics: list[str] = eval_metrics
@@ -139,6 +136,15 @@ class Experiment:
         self.n_jobs = n_jobs
         self.input_preprocessing = input_preprocessing
         self.random_state = random_state
+
+    def _build_scaler(self) -> BaseEstimator | None:
+        """Return a fresh, seeded scaler for one partition, or None."""
+        if self.input_preprocessing is None:
+            return None
+        # Never fit the caller's instance, and seed it like the estimator
+        scaler = clone(self.input_preprocessing)
+        _set_nested_random_state(scaler, self.random_state)
+        return scaler
 
     @staticmethod
     def _predict_proba_or_none(estimator: Any, inputs: np.ndarray) -> np.ndarray | None:
@@ -227,16 +233,10 @@ class Experiment:
         # Apply preprocessing on local copies so the caller's arrays are not mutated.
         train_inputs: np.ndarray = X_train
         test_inputs: np.ndarray | None = X_test
-        scaler: BaseEstimator | None = None
+        scaler = self._build_scaler()
 
-        if self.input_preprocessing in {"norm", "std"}:
-            scaler_cls = (
-                preprocessing.MinMaxScaler
-                if self.input_preprocessing == "norm"
-                else preprocessing.StandardScaler
-            )
-            scaler = scaler_cls().fit(train_inputs)
-            train_inputs = scaler.transform(train_inputs)
+        if scaler is not None:
+            train_inputs = scaler.fit(train_inputs).transform(train_inputs)
             # A train-only run has no test split to transform
             if X_test is not None:
                 test_inputs = scaler.transform(X_test)

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -251,7 +251,7 @@ class Experiment:
             )
             search = GridSearchCV(
                 base,
-                param_grid=self.model.param_grid,
+                param_grid=self.model.search_grid(),
                 scoring=scorer,
                 n_jobs=self.n_jobs,
                 cv=splitter,

--- a/skordinal/experiments/_experiment.py
+++ b/skordinal/experiments/_experiment.py
@@ -202,7 +202,15 @@ class Experiment:
         -------
         ExperimentResult
             Fully populated result for this partition. No side effects.
+
+        Raises
+        ------
+        ValueError
+            If ``y_test`` is given without ``X_test``.
         """
+        if y_test is not None and X_test is None:
+            raise ValueError("'y_test' was given without 'X_test'.")
+
         # Apply preprocessing on local copies so the caller's arrays are not mutated.
         train_inputs: np.ndarray = X_train
         test_inputs: np.ndarray | None = X_test

--- a/skordinal/experiments/_io.py
+++ b/skordinal/experiments/_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import sys
 import tempfile
@@ -126,3 +127,15 @@ def _write_split_files(
         seed_dir / f"{split}_confusion_matrix.txt",
         f"Seed {resample_id}\n{'=' * 21}\n{body}\n",
     )
+
+
+def _read_confusion_matrix_size(path: Path) -> int | None:
+    """Return K from a saved K x K confusion matrix, or None if unreadable."""
+    try:
+        body = path.read_text(encoding="utf-8").split("\n", 2)[2]
+        matrix = ast.literal_eval(body.strip())
+    except (OSError, IndexError, ValueError, SyntaxError):
+        return None
+    if not matrix or any(len(row) != len(matrix) for row in matrix):
+        return None
+    return len(matrix)

--- a/skordinal/experiments/_io.py
+++ b/skordinal/experiments/_io.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path
@@ -10,32 +11,10 @@ from typing import Any
 
 import joblib
 import numpy as np
+import pandas as pd
+from sklearn.metrics import confusion_matrix
 
 _TEMP_PREFIX = ".skordinal-tmp-"
-
-
-def _check_path_component(name: Any, what: str) -> None:
-    """Reject a path component that is empty, dotted or holds a separator."""
-    if not isinstance(name, str):
-        raise TypeError(f"{what} must be a str; got {type(name).__name__}.")
-    if name in ("", ".", ".."):
-        raise ValueError(f"{what} must not be empty or a dot segment; got {name!r}.")
-    if any(sep in name for sep in (os.sep, "/", os.altsep) if sep):
-        raise ValueError(f"{what} must not contain a path separator; got {name!r}.")
-
-
-def _check_resample_id(resample_id: Any) -> None:
-    """Reject a resample id that is neither int-like nor a plain path component."""
-    if isinstance(resample_id, (int, np.integer)):
-        return
-    _check_path_component(str(resample_id), "resample_id")
-
-
-def _check_split(split: str, *, allow_both: bool) -> None:
-    """Raise ValueError when split is not a recognised value."""
-    valid = {"test", "train", "both"} if allow_both else {"test", "train"}
-    if split not in valid:
-        raise ValueError(f"split must be one of {sorted(valid)!r}, got {split!r}.")
 
 
 def _ensure_parent(path: Path) -> None:
@@ -98,3 +77,52 @@ def _format_proba_column(proba: np.ndarray) -> list[str]:
 def _parse_proba_column(series: Iterable[str]) -> np.ndarray:
     """Expand stringified ``"[p0, p1, ...]"`` cells into an (n, q) array."""
     return np.vstack([np.fromstring(x.strip("[]"), sep=",") for x in series])
+
+
+def _write_split_files(
+    seed_dir: Path,
+    split: str,
+    *,
+    index: np.ndarray | None,
+    true_y: np.ndarray,
+    predicted_y: np.ndarray,
+    proba: np.ndarray | None,
+    classes: np.ndarray,
+    resample_id: int,
+) -> None:
+    """Encode one split's labels and write its per-seed output files."""
+    if not np.isin(true_y, classes).all():
+        raise ValueError(
+            f"'{split}' true labels contain classes unknown to the fitted model."
+        )
+    pattern_id = index if index is not None else np.arange(predicted_y.shape[0])
+    target = np.searchsorted(classes, true_y)
+    if not np.isin(predicted_y, classes).all():
+        raise ValueError(
+            f"'{split}' predicted labels contain classes unknown to the fitted model."
+        )
+    # Record the estimator's actual decision, never a proba argmax substitute
+    prediction = np.searchsorted(classes, predicted_y)
+
+    columns: dict[str, object] = {"Pattern ID": pattern_id, "Target": target}
+    if proba is not None:
+        if proba.shape != (true_y.shape[0], classes.size):
+            raise ValueError(
+                f"'{split}' probabilities have shape {proba.shape}; expected "
+                f"({true_y.shape[0]}, {classes.size})."
+            )
+        columns["Prediction probabilities"] = _format_proba_column(proba)
+    columns["Prediction"] = prediction
+    _atomic_write(
+        seed_dir / f"{split}_predictions.csv",
+        pd.DataFrame(columns).to_csv(index=False),
+    )
+
+    cm = confusion_matrix(target, prediction, labels=np.arange(classes.size))
+    body = np.array2string(
+        cm, separator=", ", threshold=cm.size, max_line_width=sys.maxsize
+    )
+    _atomic_write(
+        seed_dir / f"{split}_confusion_matrix.txt",
+        f"Seed {resample_id}\n{'=' * 21}\n{body}\n",
+    )

--- a/skordinal/experiments/_model_config.py
+++ b/skordinal/experiments/_model_config.py
@@ -16,9 +16,8 @@ from ._base import _set_nested_random_state
 class ModelConfig:
     """Bind a sklearn estimator to an optional hyper-parameter grid.
 
-    ``ModelConfig`` is a pure, immutable description of what to run.
-    It carries no evaluation protocol (cv folds, metric, seed) — those
-    live on the orchestrator that consumes it.
+    An immutable description of what to run, carrying no evaluation
+    protocol (cv folds, metric, seed): those live on the orchestrator.
 
     Parameters
     ----------
@@ -127,18 +126,15 @@ class ModelConfig:
     def build(self, random_state: int | None = None) -> BaseEstimator:
         """Return a fresh clone of the estimator, optionally seeded.
 
-        Creates a clone via ``sklearn.base.clone`` so ``self.estimator``
-        is never mutated.  When ``random_state`` is not ``None``, the
-        seed is forwarded to every parameter named ``random_state`` or
-        ending in ``__random_state``, including those of nested
-        estimators and Pipeline steps.  When the estimator exposes no
-        such parameter, the seed is ignored.
+        Clones via ``sklearn.base.clone``, so ``self.estimator`` is never
+        mutated, then forwards a non-``None`` seed to every parameter named
+        ``random_state`` or ending in ``__random_state``, including those of
+        nested estimators and Pipeline steps.
 
         Parameters
         ----------
         random_state : int or None, default=None
-            Seed to forward to the cloned estimator.  Passing ``None``
-            leaves the estimator's own default unchanged.
+            Seed to forward to the cloned estimator.
 
         Returns
         -------

--- a/skordinal/experiments/_model_config.py
+++ b/skordinal/experiments/_model_config.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from sklearn.base import BaseEstimator, clone
 
+from ._base import _set_nested_random_state
+
 
 @dataclass(frozen=True)
 class ModelConfig:
@@ -124,12 +126,5 @@ class ModelConfig:
             An unfitted clone ready for ``fit``.
         """
         est = clone(self.estimator)
-        if random_state is not None:
-            est.set_params(
-                **{
-                    key: random_state
-                    for key in est.get_params(deep=True)
-                    if key == "random_state" or key.endswith("__random_state")
-                }
-            )
+        _set_nested_random_state(est, random_state)
         return est

--- a/skordinal/experiments/_model_config.py
+++ b/skordinal/experiments/_model_config.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+import numpy as np
 from sklearn.base import BaseEstimator, clone
 
 from ._base import _set_nested_random_state
@@ -24,8 +26,9 @@ class ModelConfig:
         Untrained sklearn-compatible estimator instance.
 
     param_grid : dict[str, Any] or None, keyword-only, default=None
-        Hyper-parameter grid mapping parameter names to a value or list
-        of values.  ``None`` means the estimator is fitted as-is.
+        Hyper-parameter grid mapping parameter names to a value or a
+        sequence of candidate values (list, tuple or array).  ``None``
+        means the estimator is fitted as-is.
 
     Raises
     ------
@@ -58,51 +61,68 @@ class ModelConfig:
         if self.param_grid is not None and not isinstance(self.param_grid, dict):
             raise TypeError("param_grid must be a dict or None.")
 
+    @staticmethod
+    def _is_search_sequence(value: Any) -> bool:
+        """Report whether a grid value enumerates candidates, as ParameterGrid does."""
+        if isinstance(value, np.ndarray):
+            # A 0-d array holds one value, and has no len() to enumerate
+            return value.ndim > 0
+        return isinstance(value, Sequence) and not isinstance(value, str)
+
     @property
     def needs_search(self) -> bool:
         """Return ``True`` iff the grid has at least one multi-value entry.
 
-        A multi-value entry is a list or tuple with more than one element.
-        When ``param_grid`` is ``None`` or empty, or every value is a scalar
-        or singleton list/tuple, returns ``False``.
-
         Returns
         -------
         needs_search : bool
-            ``True`` when at least one grid value is a list or tuple
-            with more than one element; ``False`` otherwise.
+            ``True`` when a grid value is a non-string sequence (list, tuple
+            or array) holding more than one element; ``False`` otherwise,
+            which includes a ``None`` or empty grid.
         """
         if not self.param_grid:
             return False
         return any(
-            isinstance(v, (list, tuple)) and len(v) > 1
-            for v in self.param_grid.values()
+            self._is_search_sequence(v) and len(v) > 1 for v in self.param_grid.values()
         )
 
     def fixed_params(self) -> dict[str, Any]:
-        """Return a flat parameter dict, unwrapping singleton lists/tuples.
-
-        Singleton list or tuple values (``len == 1``) are unwrapped to their
-        scalar element.  Empty list/tuple values are skipped.  Scalar values
-        are passed through unchanged.  When ``param_grid`` is ``None``,
-        an empty dict is returned.
+        """Return a flat parameter dict, unwrapping singleton sequences.
 
         Returns
         -------
         params : dict[str, Any]
-            Flat parameter dict ready to pass to ``set_params``.
+            Flat parameter dict ready to pass to ``set_params``: a singleton
+            sequence unwrapped to its element, an empty one skipped, a scalar
+            unchanged.  Empty when ``param_grid`` is ``None``.
         """
         if self.param_grid is None:
             return {}
         out: dict[str, Any] = {}
         for key, value in self.param_grid.items():
-            if isinstance(value, (list, tuple)):
+            if self._is_search_sequence(value):
                 if len(value) == 0:
                     continue
                 out[key] = value[0]
             else:
                 out[key] = value
         return out
+
+    def search_grid(self) -> dict[str, Any]:
+        """Return the grid with scalar values wrapped for ``GridSearchCV``.
+
+        Returns
+        -------
+        grid : dict[str, Any]
+            Parameter grid ready to pass to ``GridSearchCV``: sequences pass
+            through, and a fixed scalar becomes the singleton list it requires.
+        """
+        if self.param_grid is None:
+            return {}
+        return {
+            key: value if self._is_search_sequence(value) else [value]
+            for key, value in self.param_grid.items()
+        }
 
     def build(self, random_state: int | None = None) -> BaseEstimator:
         """Return a fresh clone of the estimator, optionally seeded.

--- a/skordinal/experiments/_recipes.py
+++ b/skordinal/experiments/_recipes.py
@@ -33,11 +33,11 @@ def validate_recipe(recipe: dict) -> None:
     """Structurally validate a recipe dict.
 
     Checks that ``recipe`` is a dict containing the required keys
-    ``models`` and ``datasets``, that ``models`` is a non-empty dict
-    mapping string labels to ``ModelConfig`` instances, and that
-    ``datasets`` is a non-empty sequence.  All further value validation
-    (scorer names, numeric ranges, estimator types) is deferred to
-    ``Benchmark.__init__``.
+    ``models`` and ``datasets``, that ``models`` is a non-empty dict of
+    ``ModelConfig`` values, and that ``datasets`` is a non-empty,
+    non-string sequence.  This is a structural check only: label and
+    dataset names, metric names and estimator types are all left to
+    ``Benchmark.__init__``, which every recipe passes through.
 
     Parameters
     ----------
@@ -50,8 +50,9 @@ def validate_recipe(recipe: dict) -> None:
     Raises
     ------
     TypeError
-        If ``recipe`` is not a dict, or if any value in ``models`` is
-        not a ``ModelConfig`` instance.
+        If ``recipe`` is not a dict, if ``models`` is not a dict or any of
+        its values is not a ``ModelConfig`` instance, or if ``datasets`` is
+        a bare string.
 
     ValueError
         If required keys are missing, unknown keys are present,
@@ -80,7 +81,13 @@ def validate_recipe(recipe: dict) -> None:
         raise ValueError(f"recipe missing required keys: {sorted(missing)}.")
 
     models = recipe["models"]
-    if not isinstance(models, dict) or not models:
+    # Same messages as Benchmark.__init__, which validates this again
+    if not isinstance(models, dict):
+        raise TypeError(
+            f"'models' must be a dict of label to ModelConfig; got "
+            f"{type(models).__name__}."
+        )
+    if not models:
         raise ValueError(f"'models' must be a non-empty dict; got {type(models)!r}.")
     bad = [k for k, v in models.items() if not isinstance(v, ModelConfig)]
     if bad:
@@ -90,6 +97,11 @@ def validate_recipe(recipe: dict) -> None:
         )
 
     datasets = recipe["datasets"]
+    if isinstance(datasets, str):
+        raise TypeError(
+            f"'datasets' must be an iterable of dataset names, not a bare "
+            f"string; pass [{datasets!r}] to use a single dataset."
+        )
     if not datasets:
         raise ValueError("'datasets' must be a non-empty list; got an empty sequence.")
 

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -164,9 +164,9 @@ class Results:
     ``hyperparameter_configuration.csv`` records the best parameters per
     seed with the ``clf__`` pipeline prefix stripped; its ``Seed`` column
     always holds the resample identifier. ``report.csv`` is indexed by
-    ``resample_id``, in numeric order. The root-level ``train_summary.csv``
-    and ``test_summary.csv`` files are written by ``save_summary`` and are
-    absent until it is called.
+    ``resample_id``, in numeric order when the ids are integers. The
+    root-level ``train_summary.csv`` and ``test_summary.csv`` files are
+    written by ``save_summary`` and are absent until it is called.
     """
 
     def __init__(self, path: str | Path) -> None:
@@ -237,8 +237,7 @@ class Results:
         seed_dir, model_path = self._resample_paths(base_dir, result.resample_id)
         # Clear any temp file left by a prior crash before writing new ones
         _sweep_orphaned_temp_files(base_dir)
-        # Drop this resample's committed row so a crash mid-write cannot
-        # leave a report row describing predictions no longer on disk
+        # Uncommit first, so a crash cannot leave a row without its files
         self._uncommit_report_row(base_dir, result.resample_id)
         # Must run before the writes below recreate what it deletes
         self._remove_stale_artefacts(base_dir, result.resample_id)
@@ -394,17 +393,13 @@ class Results:
     ) -> list[tuple[int | str, Path]]:
         """Return sorted ``(resample_id, path)`` pairs of one split's readable seeds.
 
-        Where a ``report.csv`` exists it is the commit marker, so a seed
-        directory with no row in it was left behind by a crashed save and is
-        skipped, and a row that does carry ``{split}`` metrics but has no
-        predictions file is corruption, not a train-only run, and warns.
-
-        Where the pair has none there is no marker to consult, so every seed
-        holding the split's predictions file is read on the strength of that
-        file, which ``_atomic_write`` leaves either complete or absent. A save
-        that crashed before writing any report row falls here too.
-
-        Ids sort like ``report.csv``'s index.
+        With a ``report.csv`` it is the commit marker: a seed missing from it
+        was left behind by a crashed save and is skipped, while a committed row
+        carrying ``{split}`` metrics but no predictions file is corruption, not
+        a train-only run, and warns. Without one there is no marker, so every
+        seed holding the file is read on the strength of that file, which
+        ``_atomic_write`` leaves either complete or absent. Ids sort like
+        ``report.csv``'s index.
         """
         seeds_dir = (
             self._pair_dir(classifier_name, dataset_name) / "predictions_by_seed"
@@ -717,11 +712,9 @@ class Results:
 
         A pair qualifies on a ``report.csv``, the commit marker, or failing
         that on a ``predictions_by_seed`` directory, which is how a tree
-        written by another tool is discovered. Read a yielded pair with
-        ``report``, ``hyperparameters``, ``predictions`` or ``model``; each
-        raises ``FileNotFoundError`` when its own file is absent, so only
-        ``report`` is guaranteed to fail for a pair carrying no
-        ``report.csv``.
+        written by another tool is discovered. A yielded pair need not carry
+        every file: ``report``, ``hyperparameters``, ``predictions`` and
+        ``model`` each raise ``FileNotFoundError`` when their own is absent.
 
         Yields
         ------

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import shutil
-import sys
 import warnings
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -14,18 +13,15 @@ import joblib
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
-from sklearn.metrics import confusion_matrix
 from sklearn.pipeline import Pipeline
 
+from ._base import _check_path_component, _check_resample_id, _check_split
 from ._io import (
     _atomic_dump,
     _atomic_write,
-    _check_path_component,
-    _check_resample_id,
-    _check_split,
-    _format_proba_column,
     _parse_proba_column,
     _sweep_orphaned_temp_files,
+    _write_split_files,
 )
 
 
@@ -116,55 +112,6 @@ class ExperimentResult:
     test_index: np.ndarray | None = None
     train_y_proba: np.ndarray | None = None
     scaler: BaseEstimator | None = None
-
-
-def _write_split_files(
-    seed_dir: Path,
-    split: str,
-    *,
-    index: np.ndarray | None,
-    true_y: np.ndarray,
-    predicted_y: np.ndarray,
-    proba: np.ndarray | None,
-    classes: np.ndarray,
-    resample_id: int,
-) -> None:
-    """Encode one split's labels and write its per-seed output files."""
-    if not np.isin(true_y, classes).all():
-        raise ValueError(
-            f"'{split}' true labels contain classes unknown to the fitted model."
-        )
-    pattern_id = index if index is not None else np.arange(predicted_y.shape[0])
-    target = np.searchsorted(classes, true_y)
-    if not np.isin(predicted_y, classes).all():
-        raise ValueError(
-            f"'{split}' predicted labels contain classes unknown to the fitted model."
-        )
-    # Record the estimator's actual decision, never a proba argmax substitute
-    prediction = np.searchsorted(classes, predicted_y)
-
-    columns: dict[str, object] = {"Pattern ID": pattern_id, "Target": target}
-    if proba is not None:
-        if proba.shape != (true_y.shape[0], classes.size):
-            raise ValueError(
-                f"'{split}' probabilities have shape {proba.shape}; expected "
-                f"({true_y.shape[0]}, {classes.size})."
-            )
-        columns["Prediction probabilities"] = _format_proba_column(proba)
-    columns["Prediction"] = prediction
-    _atomic_write(
-        seed_dir / f"{split}_predictions.csv",
-        pd.DataFrame(columns).to_csv(index=False),
-    )
-
-    cm = confusion_matrix(target, prediction, labels=np.arange(classes.size))
-    body = np.array2string(
-        cm, separator=", ", threshold=cm.size, max_line_width=sys.maxsize
-    )
-    _atomic_write(
-        seed_dir / f"{split}_confusion_matrix.txt",
-        f"Seed {resample_id}\n{'=' * 21}\n{body}\n",
-    )
 
 
 class Results:

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -699,8 +699,9 @@ class Results:
         csv_path = self._pair_dir(classifier_name, dataset_name) / "report.csv"
         if not csv_path.is_file():
             return False
-        df = pd.read_csv(csv_path, index_col=0)
-        return str(resample_id) in df.index.astype(str)
+        # Only the index decides, and a resumed run reads it once per resample
+        index = pd.read_csv(csv_path, index_col=0, usecols=[0]).index
+        return str(resample_id) in index.astype(str)
 
     def iter_experiments(self) -> Iterator[tuple[str, str]]:
         """Yield every readable pair as ``(classifier_name, dataset_name)``.

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -202,14 +202,14 @@ class Results:
 
         ValueError
             If ``result.classifier_name``, ``result.dataset_name`` or a
-            non-int ``result.resample_id`` is empty, a dot segment, or
-            contains a path separator, if ``result`` lacks the true labels
-            required for the ``Target`` column (``train_true_y``, or
-            ``test_true_y`` when test predictions are present), if a true
-            or predicted label is not one of ``best_model.classes_``, or if
-            a probability matrix does not hold one row per sample and one
-            column per class. Files already written for a preceding split
-            are left in place; nothing else is recorded for the partition.
+            non-int ``result.resample_id`` is not a usable path component,
+            if ``result`` lacks the true labels required for the ``Target``
+            column (``train_true_y``, or ``test_true_y`` when test
+            predictions are present), if a true or predicted label is not one
+            of ``best_model.classes_``, or if a probability matrix does not
+            hold one row per sample and one column per class. Files already
+            written for a preceding split are left in place; nothing else is
+            recorded for the partition.
 
         OSError
             If a stale artefact cannot be removed or the folder cannot be
@@ -472,8 +472,8 @@ class Results:
             If ``classifier_name`` or ``dataset_name`` is not a string.
 
         ValueError
-            If ``classifier_name`` or ``dataset_name`` is empty, a dot
-            segment, or contains a path separator.
+            If ``classifier_name`` or ``dataset_name`` is not a usable
+            path component.
 
         FileNotFoundError
             If the pair has no ``report.csv``.
@@ -512,8 +512,8 @@ class Results:
             If ``classifier_name`` or ``dataset_name`` is not a string.
 
         ValueError
-            If ``classifier_name`` or ``dataset_name`` is empty, a dot
-            segment, or contains a path separator.
+            If ``classifier_name`` or ``dataset_name`` is not a usable
+            path component.
 
         FileNotFoundError
             If the pair has no ``hyperparameter_configuration.csv``.
@@ -574,8 +574,8 @@ class Results:
 
         ValueError
             If ``classifier_name``, ``dataset_name`` or a non-int
-            ``resample_id`` is empty, a dot segment, or contains a path
-            separator, or if ``split`` is not ``"test"`` or ``"train"``.
+            ``resample_id`` is not a usable path component, or if ``split``
+            is not ``"test"`` or ``"train"``.
 
         FileNotFoundError
             If the resample has no predictions file for ``split``.
@@ -634,8 +634,7 @@ class Results:
 
         ValueError
             If ``classifier_name``, ``dataset_name`` or a non-int
-            ``resample_id`` is empty, a dot segment, or contains a path
-            separator.
+            ``resample_id`` is not a usable path component.
 
         FileNotFoundError
             If the resample was saved with ``save_model=False`` or its
@@ -687,8 +686,7 @@ class Results:
 
         ValueError
             If ``classifier_name``, ``dataset_name`` or a non-int
-            ``resample_id`` is empty, a dot segment, or contains a path
-            separator.
+            ``resample_id`` is not a usable path component.
 
         Examples
         --------

--- a/skordinal/experiments/_results.py
+++ b/skordinal/experiments/_results.py
@@ -346,15 +346,24 @@ class Results:
 
         csv_path = base_dir / "hyperparameter_configuration.csv"
         df = pd.DataFrame([row])
+        # Note which columns hold integers before the union can upcast them
+        integral = {c for c in df.columns if pd.api.types.is_integer_dtype(df[c])}
         if csv_path.is_file():
             existing = pd.read_csv(csv_path, float_precision="round_trip")
+            integral |= {
+                c
+                for c in existing.columns
+                if pd.api.types.is_integer_dtype(existing[c])
+            }
             existing = existing[existing["Seed"] != result.resample_id]
             df = pd.concat([existing, df], ignore_index=True)
 
         columns = ["Seed"] + sorted(c for c in df.columns if c != "Seed")
         df = df[columns].sort_values("Seed").reset_index(drop=True)
-        # Restore integer dtypes upcast to float by the NaN column union
-        _atomic_write(csv_path, df.convert_dtypes().to_csv(index=False))
+        # Restore only those, so a searched float like 10.0 is not written as 10
+        for col in integral & set(df.columns):
+            df[col] = df[col].convert_dtypes()
+        _atomic_write(csv_path, df.to_csv(index=False))
 
     @classmethod
     def load(cls, path: str | Path) -> Results:

--- a/skordinal/experiments/tests/test_base.py
+++ b/skordinal/experiments/tests/test_base.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from skordinal.experiments._base import (
+    _check_metric_names,
     _check_path_component,
     _check_resample_id,
 )
@@ -52,3 +53,38 @@ def test_check_resample_id_rejects_traversal(bad):
     """_check_resample_id rejects a non-int id that fails path validation."""
     with pytest.raises(ValueError, match="resample_id"):
         _check_resample_id(bad)
+
+
+@pytest.mark.parametrize(
+    "bad, exc_type, match",
+    [
+        pytest.param(
+            iter([]),
+            ValueError,
+            "non-empty",
+            id="empty-one-shot-iterable",
+        ),
+        pytest.param("", TypeError, "not a bare string", id="empty-string"),
+        pytest.param(None, TypeError, "got NoneType", id="none"),
+    ],
+)
+def test_check_metric_names_rejects_degenerate_input(bad, exc_type, match):
+    """Emptiness is judged after materialising, so lazy iterables cannot hide."""
+    with pytest.raises(exc_type, match=match):
+        _check_metric_names(bad, param="eval_metrics")
+
+
+def test_check_metric_names_drops_an_exact_duplicate():
+    """A repeat would compute the metric twice and duplicate evaluate's column."""
+    names = _check_metric_names(
+        ["mean_absolute_error", " mean_absolute_error ", "accuracy_score"], param="m"
+    )
+    assert names == ["mean_absolute_error", "accuracy_score"]
+
+
+def test_check_metric_names_accepts_array_likes():
+    """A numpy array of names materialises instead of raising ambiguous truth."""
+    names = _check_metric_names(
+        np.array(["mean_absolute_error", " accuracy_score "]), param="metrics"
+    )
+    assert names == ["mean_absolute_error", "accuracy_score"]

--- a/skordinal/experiments/tests/test_base.py
+++ b/skordinal/experiments/tests/test_base.py
@@ -1,0 +1,38 @@
+"""Tests for the experiments shared validation helpers."""
+
+import os
+
+import numpy as np
+import pytest
+
+from skordinal.experiments._base import (
+    _check_path_component,
+    _check_resample_id,
+)
+
+
+@pytest.mark.parametrize("bad", ["", ".", "..", "a/b", f"a{os.sep}b"])
+def test_check_path_component_rejects_bad_strings(bad):
+    """_check_path_component rejects empty, dotted or separator names."""
+    with pytest.raises(ValueError):
+        _check_path_component(bad, "classifier_name")
+
+
+@pytest.mark.parametrize("bad", [3, None, ("x",)])
+def test_check_path_component_rejects_non_str(bad):
+    """_check_path_component rejects a non-string component."""
+    with pytest.raises(TypeError):
+        _check_path_component(bad, "classifier_name")
+
+
+@pytest.mark.parametrize("good", [0, -1, np.int64(3), "0"])
+def test_check_resample_id_accepts_int_like(good):
+    """_check_resample_id passes through ints, numpy ints and int-like strings."""
+    _check_resample_id(good)
+
+
+@pytest.mark.parametrize("bad", ["../../../../tmp/evil", "..", "", "a/b"])
+def test_check_resample_id_rejects_traversal(bad):
+    """_check_resample_id rejects a non-int id that fails path validation."""
+    with pytest.raises(ValueError, match="resample_id"):
+        _check_resample_id(bad)

--- a/skordinal/experiments/tests/test_base.py
+++ b/skordinal/experiments/tests/test_base.py
@@ -13,6 +13,7 @@ from skordinal.experiments._base import (
     _check_metric_names,
     _check_path_component,
     _check_resample_id,
+    _compute_metric,
 )
 
 
@@ -108,3 +109,19 @@ def test_check_input_preprocessing_rejects_a_non_transformer(bad):
     """A non-transformer, a removed token or a class (forgotten parens) raises."""
     with pytest.raises(TypeError, match="'input_preprocessing' must be None"):
         _check_input_preprocessing(bad)
+
+
+def test_compute_metric_names_the_scale_only_where_accepted():
+    """labels= reaches the metrics that take it and is dropped for the rest."""
+    y_true = np.array([0, 0, 2, 2])
+    y_pred = np.array([0, 2, 0, 2])
+    scale = np.array([0, 1, 2])
+    # With the middle class named, the extremes stay two apart, not adjacent
+    assert _compute_metric("accuracy_off1_score", y_true, y_pred) == 1.0
+    assert _compute_metric(
+        "accuracy_off1_score", y_true, y_pred, labels=scale
+    ) == pytest.approx(0.5)
+    # accuracy_score takes no labels, so passing them must not raise
+    assert _compute_metric(
+        "accuracy_score", y_true, y_pred, labels=scale
+    ) == pytest.approx(0.5)

--- a/skordinal/experiments/tests/test_base.py
+++ b/skordinal/experiments/tests/test_base.py
@@ -5,8 +5,11 @@ from pathlib import PureWindowsPath
 
 import numpy as np
 import pytest
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVC
 
 from skordinal.experiments._base import (
+    _check_input_preprocessing,
     _check_metric_names,
     _check_path_component,
     _check_resample_id,
@@ -88,3 +91,20 @@ def test_check_metric_names_accepts_array_likes():
         np.array(["mean_absolute_error", " accuracy_score "]), param="metrics"
     )
     assert names == ["mean_absolute_error", "accuracy_score"]
+
+
+def test_check_input_preprocessing_accepts_a_transformer():
+    """A transformer instance and None both pass the check."""
+    _check_input_preprocessing(StandardScaler())
+    _check_input_preprocessing(None)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [SVC(), "std", StandardScaler],
+    ids=["no-transform", "old-token", "class-not-instance"],
+)
+def test_check_input_preprocessing_rejects_a_non_transformer(bad):
+    """A non-transformer, a removed token or a class (forgotten parens) raises."""
+    with pytest.raises(TypeError, match="'input_preprocessing' must be None"):
+        _check_input_preprocessing(bad)

--- a/skordinal/experiments/tests/test_base.py
+++ b/skordinal/experiments/tests/test_base.py
@@ -1,6 +1,7 @@
 """Tests for the experiments shared validation helpers."""
 
 import os
+from pathlib import PureWindowsPath
 
 import numpy as np
 import pytest
@@ -23,6 +24,21 @@ def test_check_path_component_rejects_non_str(bad):
     """_check_path_component rejects a non-string component."""
     with pytest.raises(TypeError):
         _check_path_component(bad, "classifier_name")
+
+
+def test_check_path_component_rejects_a_windows_drive():
+    """A drive-qualified name would resolve outside the results root."""
+    # No Windows runner needed: PureWindowsPath shows the escape anywhere
+    assert PureWindowsPath("C:/runs/exp") / "D:" / "ds" == PureWindowsPath("D:ds")
+    with pytest.raises(ValueError, match="must not contain a colon"):
+        _check_path_component("D:", "model label")
+
+
+@pytest.mark.parametrize("bad", ["x\\y", "..\\esc"], ids=["nested", "traversal"])
+def test_check_path_component_rejects_a_backslash(bad):
+    """os.altsep is None on POSIX, so a backslash must be rejected outright."""
+    with pytest.raises(ValueError, match="must not contain a path separator"):
+        _check_path_component(bad, "model label")
 
 
 @pytest.mark.parametrize("good", [0, -1, np.int64(3), "0"])

--- a/skordinal/experiments/tests/test_base.py
+++ b/skordinal/experiments/tests/test_base.py
@@ -1,7 +1,6 @@
 """Tests for the experiments shared validation helpers."""
 
 import os
-from pathlib import PureWindowsPath
 
 import numpy as np
 import pytest
@@ -17,44 +16,39 @@ from skordinal.experiments._base import (
 )
 
 
-@pytest.mark.parametrize("bad", ["", ".", "..", "a/b", f"a{os.sep}b"])
-def test_check_path_component_rejects_bad_strings(bad):
-    """_check_path_component rejects empty, dotted or separator names."""
-    with pytest.raises(ValueError):
-        _check_path_component(bad, "classifier_name")
-
-
-@pytest.mark.parametrize("bad", [3, None, ("x",)])
-def test_check_path_component_rejects_non_str(bad):
-    """_check_path_component rejects a non-string component."""
-    with pytest.raises(TypeError):
-        _check_path_component(bad, "classifier_name")
-
-
-def test_check_path_component_rejects_a_windows_drive():
-    """A drive-qualified name would resolve outside the results root."""
-    # No Windows runner needed: PureWindowsPath shows the escape anywhere
-    assert PureWindowsPath("C:/runs/exp") / "D:" / "ds" == PureWindowsPath("D:ds")
-    with pytest.raises(ValueError, match="must not contain a colon"):
-        _check_path_component("D:", "model label")
-
-
-@pytest.mark.parametrize("bad", ["x\\y", "..\\esc"], ids=["nested", "traversal"])
-def test_check_path_component_rejects_a_backslash(bad):
-    """os.altsep is None on POSIX, so a backslash must be rejected outright."""
-    with pytest.raises(ValueError, match="must not contain a path separator"):
+@pytest.mark.parametrize(
+    "bad, exc_type, match",
+    [
+        pytest.param("", ValueError, "empty or a dot segment", id="empty"),
+        pytest.param(".", ValueError, "empty or a dot segment", id="dot"),
+        pytest.param("..", ValueError, "empty or a dot segment", id="dot-dot"),
+        pytest.param("a/b", ValueError, "path separator", id="slash"),
+        pytest.param(f"a{os.sep}b", ValueError, "path separator", id="os-sep"),
+        # os.altsep is None on POSIX, so a backslash must be rejected outright
+        pytest.param("x\\y", ValueError, "path separator", id="backslash"),
+        pytest.param("..\\esc", ValueError, "path separator", id="backslash-up"),
+        # "D:" would resolve outside the results root once read on Windows
+        pytest.param("D:", ValueError, "colon", id="drive"),
+        pytest.param(3, TypeError, "must be a str", id="int"),
+        pytest.param(None, TypeError, "must be a str", id="none"),
+        pytest.param(("x",), TypeError, "must be a str", id="tuple"),
+    ],
+)
+def test_path_component_rejects_unsafe_names(bad, exc_type, match):
+    """Every name that cannot safely name one directory raises."""
+    with pytest.raises(exc_type, match=match):
         _check_path_component(bad, "model label")
 
 
 @pytest.mark.parametrize("good", [0, -1, np.int64(3), "0"])
-def test_check_resample_id_accepts_int_like(good):
-    """_check_resample_id passes through ints, numpy ints and int-like strings."""
+def test_resample_id_accepts_int_like(good):
+    """Ints, numpy ints and int-like strings pass through."""
     _check_resample_id(good)
 
 
 @pytest.mark.parametrize("bad", ["../../../../tmp/evil", "..", "", "a/b"])
-def test_check_resample_id_rejects_traversal(bad):
-    """_check_resample_id rejects a non-int id that fails path validation."""
+def test_resample_id_rejects_traversal(bad):
+    """A non-int id that fails path validation raises."""
     with pytest.raises(ValueError, match="resample_id"):
         _check_resample_id(bad)
 
@@ -62,39 +56,33 @@ def test_check_resample_id_rejects_traversal(bad):
 @pytest.mark.parametrize(
     "bad, exc_type, match",
     [
-        pytest.param(
-            iter([]),
-            ValueError,
-            "non-empty",
-            id="empty-one-shot-iterable",
-        ),
-        pytest.param("", TypeError, "not a bare string", id="empty-string"),
-        pytest.param(None, TypeError, "got NoneType", id="none"),
+        pytest.param(iter([]), ValueError, "non-empty", id="empty-one-shot-iterable"),
+        pytest.param("", TypeError, "not a bare string", id="bare-string"),
+        pytest.param(None, TypeError, "got NoneType", id="not-iterable"),
+        pytest.param([3], TypeError, "only metric name strings", id="non-str-element"),
     ],
 )
-def test_check_metric_names_rejects_degenerate_input(bad, exc_type, match):
+def test_metric_names_rejects_degenerate_input(bad, exc_type, match):
     """Emptiness is judged after materialising, so lazy iterables cannot hide."""
     with pytest.raises(exc_type, match=match):
         _check_metric_names(bad, param="eval_metrics")
 
 
-def test_check_metric_names_drops_an_exact_duplicate():
-    """A repeat would compute the metric twice and duplicate evaluate's column."""
-    names = _check_metric_names(
-        ["mean_absolute_error", " mean_absolute_error ", "accuracy_score"], param="m"
-    )
-    assert names == ["mean_absolute_error", "accuracy_score"]
+@pytest.mark.parametrize(
+    "metrics",
+    [
+        ["mean_absolute_error", " mean_absolute_error ", "accuracy_score"],
+        np.array(["mean_absolute_error", " accuracy_score "]),
+    ],
+    ids=["repeated-name", "array-like"],
+)
+def test_metric_names_stripped_and_deduplicated(metrics):
+    """Names come back stripped and unique, whatever iterable carried them."""
+    expected = ["mean_absolute_error", "accuracy_score"]
+    assert _check_metric_names(metrics, param="m") == expected
 
 
-def test_check_metric_names_accepts_array_likes():
-    """A numpy array of names materialises instead of raising ambiguous truth."""
-    names = _check_metric_names(
-        np.array(["mean_absolute_error", " accuracy_score "]), param="metrics"
-    )
-    assert names == ["mean_absolute_error", "accuracy_score"]
-
-
-def test_check_input_preprocessing_accepts_a_transformer():
+def test_input_preprocessing_accepts_a_transformer():
     """A transformer instance and None both pass the check."""
     _check_input_preprocessing(StandardScaler())
     _check_input_preprocessing(None)
@@ -105,13 +93,13 @@ def test_check_input_preprocessing_accepts_a_transformer():
     [SVC(), "std", StandardScaler],
     ids=["no-transform", "old-token", "class-not-instance"],
 )
-def test_check_input_preprocessing_rejects_a_non_transformer(bad):
+def test_input_preprocessing_rejects_a_non_transformer(bad):
     """A non-transformer, a removed token or a class (forgotten parens) raises."""
     with pytest.raises(TypeError, match="'input_preprocessing' must be None"):
         _check_input_preprocessing(bad)
 
 
-def test_compute_metric_names_the_scale_only_where_accepted():
+def test_compute_metric_forwards_labels_where_accepted():
     """labels= reaches the metrics that take it and is dropped for the rest."""
     y_true = np.array([0, 0, 2, 2])
     y_pred = np.array([0, 2, 0, 2])

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -22,18 +22,6 @@ _INVALID_CONSTRUCTOR_CASES = [
     pytest.param(
         {"eval_metrics": []}, ValueError, "non-empty", id="empty-eval-metrics"
     ),
-    pytest.param(
-        {"eval_metrics": "accuracy_score"},
-        TypeError,
-        r"not a bare string; pass \['accuracy_score'\]",
-        id="bare-string-eval-metrics",
-    ),
-    pytest.param(
-        {"eval_metrics": [3]},
-        TypeError,
-        r"must contain only metric name strings; got 'int'",
-        id="non-str-eval-metric",
-    ),
     # Eval metrics use the label registry, where a loss keeps its plain name
     pytest.param(
         {"eval_metrics": ["neg_mean_absolute_error"]},
@@ -95,6 +83,22 @@ _INVALID_CONSTRUCTOR_CASES = [
 ]
 
 
+def _make_benchmark(results_path, **overrides):
+    """Build a small, quiet, seeded Benchmark on the bundled dataset."""
+    kwargs = dict(
+        models=_SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=results_path,
+        resamples=2,
+        cv=2,
+        random_state=0,
+        verbose=False,
+    )
+    kwargs.update(overrides)
+    return Benchmark(**kwargs)
+
+
 @pytest.fixture
 def unconfigured_logging(monkeypatch):
     """Pretend no logging is configured; pytest's capture handlers would hide it."""
@@ -122,7 +126,7 @@ def csv_ds_dir(tmp_path):
 
 
 @pytest.mark.parametrize("overrides, exc_type, match", _INVALID_CONSTRUCTOR_CASES)
-def test_benchmark_constructor_validation(tmp_path, overrides, exc_type, match):
+def test_constructor_validation(tmp_path, overrides, exc_type, match):
     """Each invalid constructor argument raises at construction."""
     kwargs = {
         "models": _MINIMAL_CONF,
@@ -137,66 +141,31 @@ def test_benchmark_constructor_validation(tmp_path, overrides, exc_type, match):
 
 def test_names_stored_stripped(tmp_path):
     """Metric and dataset names are stripped; a one-shot iterable is kept."""
-    b = Benchmark(
-        _MINIMAL_CONF,
+    b = _make_benchmark(
+        tmp_path,
         datasets=[f" {_BUNDLED_DS} "],
         eval_metrics=(m for m in [" mean_absolute_error "]),
-        results_path=tmp_path,
     )
     assert b.eval_metrics == ["mean_absolute_error"]
     assert b.datasets == [_BUNDLED_DS]
 
 
-def test_data_home_str_stays_str(tmp_path):
-    """A str data_home is stored verbatim, not converted to Path."""
-    b = Benchmark(
-        _MINIMAL_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path,
-        data_home=str(tmp_path),
-    )
-    assert isinstance(b.data_home, str)
-    assert b.data_home == str(tmp_path)
-
-
-def test_data_home_none_stays_none(tmp_path):
-    """data_home=None is stored as None."""
-    b = Benchmark(
-        _MINIMAL_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path,
-    )
-    assert b.data_home is None
-
-
-def test_resamples_stored_verbatim(tmp_path):
-    """resamples is stored as-is (int, not coerced)."""
-    b = Benchmark(
-        _MINIMAL_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path,
-        resamples=7,
-    )
-    assert b.resamples == 7
-
-
 def test_protocol_attrs_stored(tmp_path):
-    """cv, tuning_metric, eval_metrics, random_state, n_jobs, verbose are stored."""
-    b = Benchmark(
-        _MINIMAL_CONF,
-        datasets=[_BUNDLED_DS],
+    """Every protocol argument is stored verbatim on the instance."""
+    b = _make_benchmark(
+        tmp_path,
         eval_metrics=["mean_absolute_error", "accuracy_score"],
-        results_path=tmp_path,
-        resamples=3,
+        data_home=str(tmp_path),
+        resamples=7,
         cv=4,
         tuning_metric="accuracy_score",
         n_jobs=2,
         random_state=99,
         verbose=False,
     )
+    assert b.data_home == str(tmp_path)
+    assert isinstance(b.data_home, str)
+    assert b.resamples == 7
     assert b.cv == 4
     assert b.tuning_metric == "accuracy_score"
     assert b.eval_metrics == ["mean_absolute_error", "accuracy_score"]
@@ -205,20 +174,27 @@ def test_protocol_attrs_stored(tmp_path):
     assert b.verbose is False
 
 
-def test_run_default_seed_reproducible_across_constructions(tmp_path):
-    """Two separately-constructed runs with the default random_state match."""
+def test_protocol_defaults(tmp_path):
+    """The documented defaults land unchanged on the instance."""
+    b = Benchmark(
+        _MINIMAL_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path,
+    )
+    assert b.data_home is None
+    assert b.resamples == 30
+    assert b.tuning_metric == "neg_mean_absolute_error"
+    assert b.random_state == 0
+    assert b.overwrite is False
+    assert b.verbose is True
+
+
+def test_run_default_seed_is_reproducible(tmp_path):
+    """Two separately-constructed runs with the same seed match exactly."""
 
     def _run(results_dir):
-        b = Benchmark(
-            _SVC_CONF,
-            datasets=[_BUNDLED_DS],
-            eval_metrics=["mean_absolute_error"],
-            results_path=results_dir,
-            resamples=3,
-            cv=2,
-            verbose=False,
-        )
-        b.run()
+        _make_benchmark(results_dir, resamples=3).run()
         df = pd.read_csv(results_dir / "SVM" / _BUNDLED_DS / "report.csv", index_col=0)
         return df.drop(columns=[c for c in df.columns if c.startswith("time_")])
 
@@ -227,23 +203,14 @@ def test_run_default_seed_reproducible_across_constructions(tmp_path):
     pd.testing.assert_frame_equal(df_a, df_b)
 
 
-def test_run_all_models_see_identical_partitions_with_random_state_none(tmp_path):
+def test_run_random_state_none_shares_partitions(tmp_path):
     """random_state=None resolves once, so every model sees identical partitions."""
     configs = {
         "SVM1": ModelConfig(SVC(), param_grid={"C": [1]}),
         "SVM2": ModelConfig(SVC(), param_grid={"C": [1]}),
     }
     results_dir = tmp_path / "out"
-    b = Benchmark(
-        configs,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=results_dir,
-        resamples=3,
-        cv=2,
-        verbose=False,
-        random_state=None,
-    )
+    b = _make_benchmark(results_dir, models=configs, resamples=3, random_state=None)
     assert isinstance(b.random_state, int)
     b.run()
 
@@ -254,20 +221,11 @@ def test_run_all_models_see_identical_partitions_with_random_state_none(tmp_path
     np.testing.assert_array_equal(_pattern_ids("SVM1"), _pattern_ids("SVM2"))
 
 
-def test_run_and_summarize_bundled_dataset(tmp_path):
+def test_run_and_summarize_layout(tmp_path):
     """run() + summarize() over a bundled dataset write the expected on-disk layout."""
     results_dir = tmp_path / "runs"
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=results_dir,
-        resamples=3,
-        cv=2,
-        verbose=False,
-        random_state=0,
-    )
-    b.run()
+    b = _make_benchmark(results_dir, resamples=3)
+    assert b.run() is None
     b.summarize()
 
     pair_dir = results_dir / "SVM" / _BUNDLED_DS
@@ -276,6 +234,8 @@ def test_run_and_summarize_bundled_dataset(tmp_path):
     # report.csv uses resample_id as its index; one row per resample
     df = pd.read_csv(pair_dir / "report.csv", index_col=0)
     assert df.shape[0] == 3
+    assert "mean_absolute_error_train" in df.columns
+    assert "mean_absolute_error_test" in df.columns
 
     assert (pair_dir / "hyperparameter_configuration.csv").is_file()
     assert not (pair_dir / "params.json").exists()
@@ -285,19 +245,10 @@ def test_run_and_summarize_bundled_dataset(tmp_path):
     test_preds = sorted(pred_dir.glob("seed_*/test_predictions.csv"))
     assert len(train_preds) == 3
     assert len(test_preds) == 3
-
-    # Check per-seed directory names carry the resample_id (0, 1, 2)
     ids_from_dirs = sorted(int(f.parent.name.split("_")[1]) for f in train_preds)
     assert ids_from_dirs == [0, 1, 2]
 
-    # report.csv must contain one <metric>_train and one <metric>_test column
-    assert "mean_absolute_error_train" in df.columns
-    assert "mean_absolute_error_test" in df.columns
-
     assert (results_dir / "train_summary.csv").is_file()
-    assert (results_dir / "test_summary.csv").is_file()
-
-    # test_summary.csv must be well-formed with the expected aggregated columns
     summary = pd.read_csv(results_dir / "test_summary.csv")
     assert "SVM" in summary["classifier"].values
     assert "mean_absolute_error_test_mean" in summary.columns
@@ -307,18 +258,8 @@ def test_run_and_summarize_bundled_dataset(tmp_path):
 @pytest.mark.parametrize("overwrite, reruns", [(False, 0), (True, 3)])
 def test_run_overwrite_controls_rerun(tmp_path, monkeypatch, overwrite, reruns):
     """A rerun recomputes already-saved resamples only when overwrite is True."""
-    kwargs = dict(
-        models=_SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path / "runs",
-        resamples=3,
-        cv=2,
-        verbose=False,
-        random_state=0,
-        overwrite=overwrite,
-    )
-    Benchmark(**kwargs).run()
+    kwargs = dict(results_path=tmp_path / "runs", resamples=3, overwrite=overwrite)
+    _make_benchmark(**kwargs).run()
 
     calls = []
     original = Experiment.run
@@ -328,90 +269,30 @@ def test_run_overwrite_controls_rerun(tmp_path, monkeypatch, overwrite, reruns):
         return original(self, *args, **kw)
 
     monkeypatch.setattr(Experiment, "run", _counting_run)
-    Benchmark(**kwargs).run()
+    _make_benchmark(**kwargs).run()
     assert len(calls) == reruns
 
 
-@pytest.mark.parametrize("resamples", [1, 4], ids=["one", "several"])
-def test_run_resamples_count_matches_requested(tmp_path, resamples):
-    """run() with resamples=N produces exactly N rows in report.csv."""
-    results_dir = tmp_path / "out"
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=results_dir,
-        resamples=resamples,
-        cv=2,
-        verbose=False,
-        random_state=1,
-    )
-    b.run()
-
-    df = pd.read_csv(results_dir / "SVM" / _BUNDLED_DS / "report.csv", index_col=0)
-    assert df.shape[0] == resamples
-
-
-def test_run_mask_path_correct_partition_count(tmp_path, csv_ds_dir):
-    """run() with a masks file consumes exactly the mask-defined number of partitions."""
+def test_run_with_a_masks_file(tmp_path, csv_ds_dir):
+    """A masks file defines the partition count, sizes and Pattern IDs."""
     results_dir = tmp_path / "mask_runs"
-    b = Benchmark(
-        _SVC_CONF,
-        data_home=csv_ds_dir,
-        datasets=["smallds"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=results_dir,
-        resamples=2,
-        cv=2,
-        verbose=False,
-        random_state=0,
-    )
+    b = _make_benchmark(results_dir, data_home=csv_ds_dir, datasets=["smallds"])
     b.run()
 
     df = pd.read_csv(results_dir / "SVM" / "smallds" / "report.csv", index_col=0)
     assert df.shape[0] == 2
 
-
-def test_run_mask_path_train_test_sizes_match_masks(tmp_path, csv_ds_dir):
-    """Prediction file row counts match the mask-defined train/test sizes."""
-    results_dir = tmp_path / "mask_runs2"
-    b = Benchmark(
-        _SVC_CONF,
-        data_home=csv_ds_dir,
-        datasets=["smallds"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=results_dir,
-        resamples=2,
-        cv=2,
-        verbose=False,
-        random_state=0,
-    )
-    b.run()
-
     seed_dir = results_dir / "SVM" / "smallds" / "predictions_by_seed" / "seed_0"
-    # Each mask splits n=60 half-and-half: 30 train / 30 test
+    # Mask 0 splits n=60 half-and-half: 30 train / 30 test, in file order
     train_0 = pd.read_csv(seed_dir / "train_predictions.csv")
     test_0 = pd.read_csv(seed_dir / "test_predictions.csv")
-    assert len(train_0) == 30
-    assert len(test_0) == 30
-
-    # Check Pattern ID carries the original row positions defined by mask 0
     np.testing.assert_array_equal(train_0["Pattern ID"].values, np.arange(30))
     np.testing.assert_array_equal(test_0["Pattern ID"].values, np.arange(30, 60))
 
 
 def test_run_forwards_test_size(tmp_path):
     """test_size reaches load_partitions: balance_scale at 0.5 tests 313 rows."""
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path,
-        resamples=1,
-        test_size=0.5,
-        cv=2,
-        verbose=False,
-    )
+    b = _make_benchmark(tmp_path, resamples=1, test_size=0.5)
     b.run()
 
     seed_dir = tmp_path / "SVM" / _BUNDLED_DS / "predictions_by_seed" / "seed_0"
@@ -420,64 +301,17 @@ def test_run_forwards_test_size(tmp_path):
 
 def test_run_unresolvable_dataset_raises(tmp_path):
     """run() propagates FileNotFoundError for an unknown dataset name."""
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=["this_dataset_does_not_exist_xyz"],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path,
-        resamples=3,
-        cv=2,
-        verbose=False,
-    )
+    b = _make_benchmark(tmp_path, datasets=["this_dataset_does_not_exist_xyz"])
     with pytest.raises(FileNotFoundError):
         b.run()
 
 
-def test_run_returns_none(tmp_path):
-    """run() returns None."""
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path / "out",
-        resamples=2,
-        cv=2,
-        verbose=False,
-        random_state=0,
-    )
-    assert b.run() is None
-
-
-def test_verbose_false_no_stdout(tmp_path, capsys):
-    """verbose=False produces no stdout output during run()."""
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path / "out",
-        resamples=2,
-        cv=2,
-        verbose=False,
-        random_state=0,
-    )
-    b.run()
-    captured = capsys.readouterr()
-    assert captured.out == ""
-
-
-def test_run_emits_log_records_when_not_verbose(tmp_path, caplog):
-    """Progress reaches the skordinal.experiments logger even with verbose=False."""
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path / "out",
-        resamples=1,
-        cv=2,
-        verbose=False,
-    )
+def test_run_not_verbose_logs_without_stdout(tmp_path, capsys, caplog):
+    """verbose=False writes nothing to stdout but still emits the log records."""
+    b = _make_benchmark(tmp_path / "out")
     with caplog.at_level("INFO", logger="skordinal.experiments"):
         b.run()
+    assert capsys.readouterr().out == ""
     assert any("Running the" in m for m in caplog.messages)
 
 
@@ -486,15 +320,7 @@ def test_run_verbose_without_tqdm_logs_to_stdout(
 ):
     """With verbose=True and no tqdm, progress falls back to stdout messages."""
     monkeypatch.setattr("skordinal.experiments._benchmark.tqdm", None)
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path / "out",
-        resamples=1,
-        cv=2,
-        verbose=True,
-    )
+    b = _make_benchmark(tmp_path / "out", resamples=1, verbose=True)
     b.run()
     out = capsys.readouterr().out
     assert f"Running the {_BUNDLED_DS} dataset" in out
@@ -517,16 +343,7 @@ def test_run_verbose_with_configured_logging_emits_once(tmp_path, capsys):
     handler = Recorder()
     logger.addHandler(handler)
     try:
-        b = Benchmark(
-            _SVC_CONF,
-            datasets=[_BUNDLED_DS],
-            eval_metrics=["mean_absolute_error"],
-            results_path=tmp_path / "out",
-            resamples=1,
-            cv=2,
-            verbose=True,
-        )
-        b.run()
+        _make_benchmark(tmp_path / "out", resamples=1, verbose=True).run()
     finally:
         logger.removeHandler(handler)
     assert capsys.readouterr().out == ""
@@ -551,15 +368,7 @@ def test_run_wraps_resamples_in_a_progress_bar(tmp_path, monkeypatch, caplog):
             calls["refresh"] = refresh
 
     monkeypatch.setattr("skordinal.experiments._benchmark.tqdm", FakeBar)
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path / "out",
-        resamples=[0, 2],
-        cv=2,
-        verbose=True,
-    )
+    b = _make_benchmark(tmp_path / "out", resamples=[0, 2], verbose=True)
     with caplog.at_level(logging.INFO, logger="skordinal.experiments"):
         b.run()
     assert calls["kwargs"]["total"] == 2
@@ -573,6 +382,23 @@ def test_run_wraps_resamples_in_a_progress_bar(tmp_path, monkeypatch, caplog):
     assert any("resample(s) run" in m for m in caplog.messages)
 
 
+def test_run_leaves_nan_scores_out_of_the_summary(tmp_path, monkeypatch, caplog):
+    """A NaN test score is not averaged into the per-model summary line."""
+    original = Experiment.run
+
+    def _nan_run(self, *args, **kwargs):
+        result = original(self, *args, **kwargs)
+        result.test_metrics["mean_absolute_error_test"] = float("nan")
+        return result
+
+    monkeypatch.setattr(Experiment, "run", _nan_run)
+    b = _make_benchmark(tmp_path / "out", resamples=1)
+    with caplog.at_level(logging.INFO, logger="skordinal.experiments"):
+        b.run()
+    line = next(m for m in caplog.messages if "resample(s) run" in m)
+    assert "mean" not in line
+
+
 def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
     """A relative results_path is anchored at construction, not at run."""
     work_a = tmp_path / "a"
@@ -580,16 +406,7 @@ def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
     work_a.mkdir()
     work_b.mkdir()
     monkeypatch.chdir(work_a)
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path="runs",
-        resamples=3,
-        cv=2,
-        verbose=False,
-        random_state=0,
-    )
+    b = _make_benchmark("runs", resamples=3)
     # results_path is now absolute and anchored under work_a
     assert Path(b.results_path).is_absolute()
     assert Path(b.results_path) == (work_a / "runs").resolve()
@@ -600,20 +417,13 @@ def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
     assert not (work_b / "runs").exists()
 
 
-def test_summarize_reraises_a_corrupt_report(tmp_path, unconfigured_logging):
+def test_summarize_reraises_a_corrupt_report(tmp_path):
     """An unreadable report.csv is data loss, so it must not read as 'nothing'."""
-    pair = tmp_path / "out" / "cfg" / _BUNDLED_DS
+    pair = tmp_path / "out" / "SVM" / _BUNDLED_DS
     pair.mkdir(parents=True)
     (pair / "report.csv").write_text("", encoding="utf-8")
-    b = Benchmark(
-        _MINIMAL_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path / "out",
-        verbose=True,
-    )
     with pytest.raises(pd.errors.EmptyDataError):
-        b.summarize()
+        _make_benchmark(tmp_path / "out").summarize()
 
 
 def test_has_real_handler_walks_the_logger_chain():
@@ -630,22 +440,13 @@ def test_has_real_handler_walks_the_logger_chain():
 
 
 @pytest.mark.parametrize("make_dir", [True, False], ids=["empty-dir", "missing-dir"])
-def test_summarize_without_results_reports_instead_of_raising(
+def test_summarize_reports_when_nothing_to_do(
     tmp_path, capsys, unconfigured_logging, make_dir
 ):
     """summarize() over an empty or never-created folder warns, never raises."""
     results_path = tmp_path / "out"
     if make_dir:
         results_path.mkdir()
-    b = Benchmark(
-        _SVC_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=results_path,
-        resamples=2,
-        cv=2,
-        verbose=True,
-        random_state=0,
-    )
+    b = _make_benchmark(results_path, verbose=True)
     b.summarize()
     assert "No metrics to summarise" in capsys.readouterr().out

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -47,6 +47,12 @@ _INVALID_CONSTRUCTOR_CASES = [
         r"a loss is only registered as 'neg_mean_absolute_error'",
         id="bare-loss-as-tuning-metric",
     ),
+    pytest.param(
+        {"input_preprocessing": "std"},
+        TypeError,
+        "'input_preprocessing' must be None",
+        id="string-input-preprocessing",
+    ),
     # Both name a directory in the results tree, so they fail eagerly
     pytest.param(
         {"datasets": ["dir/era"]},
@@ -130,41 +136,6 @@ def test_names_stored_stripped(tmp_path):
     )
     assert b.eval_metrics == ["mean_absolute_error"]
     assert b.datasets == [_BUNDLED_DS]
-
-
-@pytest.mark.parametrize("bad_value", ["minmax", ""])
-def test_input_preprocessing_invalid_raises(tmp_path, bad_value):
-    """Unrecognised input_preprocessing values raise ValueError."""
-    with pytest.raises(ValueError, match="'input_preprocessing' must be one of"):
-        Benchmark(
-            _MINIMAL_CONF,
-            datasets=[_BUNDLED_DS],
-            eval_metrics=["mean_absolute_error"],
-            results_path=tmp_path,
-            input_preprocessing=bad_value,
-        )
-
-
-@pytest.mark.parametrize(
-    "raw, expected",
-    [
-        (None, None),
-        ("std", "std"),
-        ("norm", "norm"),
-        (" STD ", "std"),
-        ("NORM", "norm"),
-    ],
-)
-def test_input_preprocessing_accepted_and_normalised(tmp_path, raw, expected):
-    """Valid input_preprocessing values are accepted and lower-stripped."""
-    b = Benchmark(
-        _MINIMAL_CONF,
-        datasets=[_BUNDLED_DS],
-        eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path,
-        input_preprocessing=raw,
-    )
-    assert b.input_preprocessing == expected
 
 
 def test_data_home_str_stays_str(tmp_path):

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -16,26 +16,42 @@ _MINIMAL_CONF: dict[str, ModelConfig] = {"cfg": ModelConfig(SVC())}
 _BUNDLED_DS = "balance_scale"
 
 _INVALID_CONSTRUCTOR_CASES = [
+    pytest.param({"models": {}}, ValueError, "non-empty", id="empty-configurations"),
+    pytest.param({"datasets": []}, ValueError, "non-empty", id="empty-datasets"),
     pytest.param(
-        {},
-        [_BUNDLED_DS],
-        ["mean_absolute_error"],
-        "non-empty",
-        id="empty-configurations",
+        {"eval_metrics": []}, ValueError, "non-empty", id="empty-eval-metrics"
+    ),
+    # Both name a directory in the results tree, so they fail eagerly
+    pytest.param(
+        {"datasets": ["dir/era"]},
+        ValueError,
+        "dataset name must not contain a path separator",
+        id="path-dataset-name",
     ),
     pytest.param(
-        _MINIMAL_CONF,
-        [],
-        ["mean_absolute_error"],
-        "non-empty",
-        id="empty-datasets",
+        {"models": {"a/b": ModelConfig(SVC())}},
+        ValueError,
+        "model label must not contain a path separator",
+        id="path-model-label",
     ),
     pytest.param(
-        _MINIMAL_CONF,
-        [_BUNDLED_DS],
-        [],
-        "non-empty",
-        id="empty-eval-metrics",
+        {"models": {"cfg": SVC()}},
+        TypeError,
+        "must be ModelConfig instances",
+        id="non-modelconfig-value",
+    ),
+    pytest.param(
+        {"models": [ModelConfig(SVC())]},
+        TypeError,
+        "'models' must be a dict",
+        id="models-not-a-dict",
+    ),
+    # A bare string would otherwise become one dataset per character
+    pytest.param(
+        {"datasets": _BUNDLED_DS},
+        TypeError,
+        r"not a bare string; pass \['balance_scale'\]",
+        id="bare-string-datasets",
     ),
 ]
 
@@ -58,21 +74,18 @@ def csv_ds_dir(tmp_path):
     return tmp_path
 
 
-@pytest.mark.parametrize(
-    "configurations, datasets, eval_metrics, match",
-    _INVALID_CONSTRUCTOR_CASES,
-)
-def test_benchmark_constructor_validation(
-    tmp_path, configurations, datasets, eval_metrics, match
-):
-    """Constructor raises ValueError for each category of invalid argument."""
-    with pytest.raises(ValueError, match=match):
-        Benchmark(
-            configurations,
-            datasets=datasets,
-            eval_metrics=eval_metrics,
-            results_path=tmp_path,
-        )
+@pytest.mark.parametrize("overrides, exc_type, match", _INVALID_CONSTRUCTOR_CASES)
+def test_benchmark_constructor_validation(tmp_path, overrides, exc_type, match):
+    """Each invalid constructor argument raises at construction."""
+    kwargs = {
+        "models": _MINIMAL_CONF,
+        "datasets": [_BUNDLED_DS],
+        "eval_metrics": ["mean_absolute_error"],
+        "results_path": tmp_path,
+        **overrides,
+    }
+    with pytest.raises(exc_type, match=match):
+        Benchmark(**kwargs)
 
 
 @pytest.mark.parametrize("bad_value", ["minmax", ""])
@@ -455,13 +468,35 @@ def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
     assert not (work_b / "runs").exists()
 
 
-def test_summarize_without_results_reports_instead_of_raising(tmp_path, capsys):
-    """summarize() over a folder with no stored metrics warns instead of raising."""
+def test_summarize_reraises_a_corrupt_report(tmp_path):
+    """An unreadable report.csv is data loss, so it must not read as 'nothing'."""
+    pair = tmp_path / "out" / "cfg" / _BUNDLED_DS
+    pair.mkdir(parents=True)
+    (pair / "report.csv").write_text("", encoding="utf-8")
+    b = Benchmark(
+        _MINIMAL_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path / "out",
+        verbose=True,
+    )
+    with pytest.raises(pd.errors.EmptyDataError):
+        b.summarize()
+
+
+@pytest.mark.parametrize("make_dir", [True, False], ids=["empty-dir", "missing-dir"])
+def test_summarize_without_results_reports_instead_of_raising(
+    tmp_path, capsys, make_dir
+):
+    """summarize() over an empty or never-created folder warns, never raises."""
+    results_path = tmp_path / "out"
+    if make_dir:
+        results_path.mkdir()
     b = Benchmark(
         _SVC_CONF,
         datasets=[_BUNDLED_DS],
         eval_metrics=["mean_absolute_error"],
-        results_path=tmp_path,
+        results_path=results_path,
         resamples=2,
         cv=2,
         verbose=True,

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -21,6 +21,32 @@ _INVALID_CONSTRUCTOR_CASES = [
     pytest.param(
         {"eval_metrics": []}, ValueError, "non-empty", id="empty-eval-metrics"
     ),
+    pytest.param(
+        {"eval_metrics": "accuracy_score"},
+        TypeError,
+        r"not a bare string; pass \['accuracy_score'\]",
+        id="bare-string-eval-metrics",
+    ),
+    pytest.param(
+        {"eval_metrics": [3]},
+        TypeError,
+        r"must contain only metric name strings; got 'int'",
+        id="non-str-eval-metric",
+    ),
+    # Eval metrics use the label registry, where a loss keeps its plain name
+    pytest.param(
+        {"eval_metrics": ["neg_mean_absolute_error"]},
+        ValueError,
+        r"Unknown metric name: 'neg_mean_absolute_error'\.",
+        id="scorer-name-as-eval-metric",
+    ),
+    # Tuning metrics use the scorer registry, where a loss exists only as neg_
+    pytest.param(
+        {"tuning_metric": "mean_absolute_error"},
+        ValueError,
+        r"a loss is only registered as 'neg_mean_absolute_error'",
+        id="bare-loss-as-tuning-metric",
+    ),
     # Both name a directory in the results tree, so they fail eagerly
     pytest.param(
         {"datasets": ["dir/era"]},
@@ -33,6 +59,12 @@ _INVALID_CONSTRUCTOR_CASES = [
         ValueError,
         "model label must not contain a path separator",
         id="path-model-label",
+    ),
+    pytest.param(
+        {"tuning_metric": 5},
+        TypeError,
+        "scoring",
+        id="non-string-tuning-metric",
     ),
     pytest.param(
         {"models": {"cfg": SVC()}},
@@ -86,6 +118,18 @@ def test_benchmark_constructor_validation(tmp_path, overrides, exc_type, match):
     }
     with pytest.raises(exc_type, match=match):
         Benchmark(**kwargs)
+
+
+def test_names_stored_stripped(tmp_path):
+    """Metric and dataset names are stripped; a one-shot iterable is kept."""
+    b = Benchmark(
+        _MINIMAL_CONF,
+        datasets=[f" {_BUNDLED_DS} "],
+        eval_metrics=(m for m in [" mean_absolute_error "]),
+        results_path=tmp_path,
+    )
+    assert b.eval_metrics == ["mean_absolute_error"]
+    assert b.datasets == [_BUNDLED_DS]
 
 
 @pytest.mark.parametrize("bad_value", ["minmax", ""])

--- a/skordinal/experiments/tests/test_benchmark.py
+++ b/skordinal/experiments/tests/test_benchmark.py
@@ -1,6 +1,7 @@
 """Tests for the benchmark runner module."""
 
 import json
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -92,6 +93,14 @@ _INVALID_CONSTRUCTOR_CASES = [
         id="bare-string-datasets",
     ),
 ]
+
+
+@pytest.fixture
+def unconfigured_logging(monkeypatch):
+    """Pretend no logging is configured; pytest's capture handlers would hide it."""
+    monkeypatch.setattr(
+        Benchmark, "_has_real_handler", staticmethod(lambda logger: False)
+    )
 
 
 @pytest.fixture
@@ -456,6 +465,114 @@ def test_verbose_false_no_stdout(tmp_path, capsys):
     assert captured.out == ""
 
 
+def test_run_emits_log_records_when_not_verbose(tmp_path, caplog):
+    """Progress reaches the skordinal.experiments logger even with verbose=False."""
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path / "out",
+        resamples=1,
+        cv=2,
+        verbose=False,
+    )
+    with caplog.at_level("INFO", logger="skordinal.experiments"):
+        b.run()
+    assert any("Running the" in m for m in caplog.messages)
+
+
+def test_run_verbose_without_tqdm_logs_to_stdout(
+    tmp_path, capsys, monkeypatch, unconfigured_logging
+):
+    """With verbose=True and no tqdm, progress falls back to stdout messages."""
+    monkeypatch.setattr("skordinal.experiments._benchmark.tqdm", None)
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path / "out",
+        resamples=1,
+        cv=2,
+        verbose=True,
+    )
+    b.run()
+    out = capsys.readouterr().out
+    assert f"Running the {_BUNDLED_DS} dataset" in out
+    # The label line attributes the resample lines that follow it
+    assert "Running SVM" in out
+    # Without a live bar the per-resample lines surface at INFO, as on stdout
+    assert "Running resample 0" in out
+    assert "1 resample(s) run, 0 skipped" in out
+
+
+def test_run_verbose_with_configured_logging_emits_once(tmp_path, capsys):
+    """An app-configured handler wins: no stdout duplicate is attached."""
+    records = []
+
+    class Recorder(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    logger = logging.getLogger("skordinal.experiments")
+    handler = Recorder()
+    logger.addHandler(handler)
+    try:
+        b = Benchmark(
+            _SVC_CONF,
+            datasets=[_BUNDLED_DS],
+            eval_metrics=["mean_absolute_error"],
+            results_path=tmp_path / "out",
+            resamples=1,
+            cv=2,
+            verbose=True,
+        )
+        b.run()
+    finally:
+        logger.removeHandler(handler)
+    assert capsys.readouterr().out == ""
+    assert any("resample(s) run" in m for m in records)
+
+
+def test_run_wraps_resamples_in_a_progress_bar(tmp_path, monkeypatch, caplog):
+    """The bar gets the total and latest score, and supersedes the INFO lines."""
+    calls = {"postfixes": []}
+
+    class FakeBar:
+        def __init__(self, iterable, **kwargs):
+            calls["kwargs"] = kwargs
+            self._iterable = iterable
+            self.disable = False
+
+        def __iter__(self):
+            return iter(self._iterable)
+
+        def set_postfix(self, postfix, refresh=True):
+            calls["postfixes"].append(postfix)
+            calls["refresh"] = refresh
+
+    monkeypatch.setattr("skordinal.experiments._benchmark.tqdm", FakeBar)
+    b = Benchmark(
+        _SVC_CONF,
+        datasets=[_BUNDLED_DS],
+        eval_metrics=["mean_absolute_error"],
+        results_path=tmp_path / "out",
+        resamples=[0, 2],
+        cv=2,
+        verbose=True,
+    )
+    with caplog.at_level(logging.INFO, logger="skordinal.experiments"):
+        b.run()
+    assert calls["kwargs"]["total"] == 2
+    assert calls["kwargs"]["desc"] == "  SVM"
+    assert "mean_absolute_error_test" in calls["postfixes"][-1]
+    # Refreshing on the spot would redraw the counter before it advances
+    assert calls["refresh"] is False
+    # The bar already names the model and counts resamples: no INFO duplicates
+    assert not [m for m in caplog.messages if "Running SVM" in m]
+    assert not [m for m in caplog.messages if "Running resample" in m]
+    assert any("resample(s) run" in m for m in caplog.messages)
+
+
 def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
     """A relative results_path is anchored at construction, not at run."""
     work_a = tmp_path / "a"
@@ -483,7 +600,7 @@ def test_results_path_resolved_once_across_chdir(tmp_path, monkeypatch):
     assert not (work_b / "runs").exists()
 
 
-def test_summarize_reraises_a_corrupt_report(tmp_path):
+def test_summarize_reraises_a_corrupt_report(tmp_path, unconfigured_logging):
     """An unreadable report.csv is data loss, so it must not read as 'nothing'."""
     pair = tmp_path / "out" / "cfg" / _BUNDLED_DS
     pair.mkdir(parents=True)
@@ -499,9 +616,22 @@ def test_summarize_reraises_a_corrupt_report(tmp_path):
         b.summarize()
 
 
+def test_has_real_handler_walks_the_logger_chain():
+    """The walk stops at a non-propagating logger and at the end of the chain."""
+    orphan = logging.Logger("orphan-with-no-parent")
+    assert Benchmark._has_real_handler(orphan) is False
+
+    blocked = logging.getLogger("skordinal.experiments.tests.non-propagating")
+    blocked.propagate = False
+    try:
+        assert Benchmark._has_real_handler(blocked) is False
+    finally:
+        blocked.propagate = True
+
+
 @pytest.mark.parametrize("make_dir", [True, False], ids=["empty-dir", "missing-dir"])
 def test_summarize_without_results_reports_instead_of_raising(
-    tmp_path, capsys, make_dir
+    tmp_path, capsys, unconfigured_logging, make_dir
 ):
     """summarize() over an empty or never-created folder warns, never raises."""
     results_path = tmp_path / "out"

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -110,12 +110,6 @@ def test_evaluate_recomputes_metrics_per_seed(seed_folder):
     assert list(df["accuracy_score"]) == pytest.approx([0.75, 0.5])
 
 
-def test_evaluate_ignores_a_repeated_metric_name(seed_folder):
-    """A repeated name must not become two identical columns."""
-    df = evaluate(seed_folder, "A", "d1", metrics=["mean_absolute_error"] * 2)
-    assert list(df.columns) == ["mean_absolute_error"]
-
-
 def test_evaluate_reads_the_requested_split(seed_folder):
     """evaluate scores the train files when split='train'."""
     df = evaluate(seed_folder, "A", "d1", split="train")
@@ -147,7 +141,7 @@ def test_evaluate_skips_uncommitted_seed(seed_folder):
     assert list(df.index) == [2, 10]
 
 
-def test_evaluate_skips_entries_that_are_not_seed_directories(tmp_path, recwarn):
+def test_evaluate_skips_non_seed_entries(tmp_path, recwarn):
     """Only a directory named ``seed_<id>`` counts, even when the id is committed."""
     _write_report(
         tmp_path,
@@ -171,7 +165,7 @@ def test_evaluate_skips_entries_that_are_not_seed_directories(tmp_path, recwarn)
     assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
 
 
-def test_evaluate_warns_when_a_committed_predictions_file_is_missing(tmp_path):
+def test_evaluate_warns_on_a_missing_committed_file(tmp_path):
     """A committed row with metrics for the split but no file is corruption."""
     _write_report(tmp_path, "A", "d1", {3: {"mean_absolute_error_test": 0.5}})
     _write_seed(tmp_path, "A", "d1", 3, "test")
@@ -251,11 +245,7 @@ def test_summarize_and_tabulate_skip_a_pair_without_a_report(tmp_path):
     ],
 )
 def test_evaluate_rejects_invalid_arguments(tmp_path, args, kwargs, exception, match):
-    """Each guard reports its own error before any results file is read.
-
-    ``tmp_path`` holds no tree, so a guard that fails to fire surfaces
-    ``FileNotFoundError`` instead of the pinned message.
-    """
+    """Each guard fires before any read: tmp_path holds no tree to fall back on."""
     with pytest.raises(exception, match=match):
         evaluate(tmp_path, *args, **kwargs)
 
@@ -267,8 +257,8 @@ def test_evaluate_missing_predictions_directory_raises(tmp_path):
 
 
 def test_evaluate_computes_exactly_the_requested_metrics(seed_folder):
-    """Only the requested metrics become columns, keyed by their stripped name."""
-    df = evaluate(seed_folder, "A", "d1", metrics=[" accuracy_score "])
+    """Requested names become columns once each, stripped and deduplicated."""
+    df = evaluate(seed_folder, "A", "d1", metrics=[" accuracy_score "] * 2)
     assert list(df.columns) == ["accuracy_score"]
     assert list(df["accuracy_score"]) == pytest.approx([0.75, 0.5])
 
@@ -393,21 +383,18 @@ def test_summarize_skips_non_pair_entries(tmp_path):
     assert {(clf, ds) for clf, ds in df.index} == {("clf", "ds")}
 
 
-def test_summarize_empty_folder_returns_empty(tmp_path):
-    """summarize returns an empty frame when no pairs are present."""
-    assert summarize(tmp_path).empty
-
-
-def test_summarize_rejects_string_classifiers(two_pair_folder):
-    """summarize raises TypeError when classifiers is a bare string."""
-    with pytest.raises(TypeError, match="iterable"):
-        summarize(two_pair_folder, classifiers="A")
-
-
-def test_summarize_rejects_unknown_split(two_pair_folder):
-    """summarize raises ValueError on an unrecognised split."""
-    with pytest.raises(ValueError, match="split must be"):
-        summarize(two_pair_folder, split="bad")
+@pytest.mark.parametrize(
+    "kwargs, exc_type, match",
+    [
+        ({"classifiers": "A"}, TypeError, "iterable"),
+        ({"split": "bad"}, ValueError, "split must be"),
+    ],
+    ids=["bare-string-classifiers", "unknown-split"],
+)
+def test_summarize_rejects_invalid_arguments(two_pair_folder, kwargs, exc_type, match):
+    """A bare-string classifiers filter and an unknown split both raise."""
+    with pytest.raises(exc_type, match=match):
+        summarize(two_pair_folder, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -426,26 +413,20 @@ def test_tabulate_results_pivots_formatted_cells(two_pair_folder, split, expecte
 
 
 @pytest.mark.parametrize(
-    "rows,metric",
+    "rows, metric, expected",
     [
-        ([{"mae_test": 0.3}], "nonexistent"),
-        ([{"mae_test": float("nan")}], "mae"),
-        ([{"mae_test": float("inf")}], "mae"),
+        ([{"mae_test": 0.25}], "mae", "0.2500 +/- 0.0000"),
+        ([{"mae_test": 0.3}], "nonexistent", "n/a"),
+        ([{"mae_test": float("nan")}], "mae", "n/a"),
+        ([{"mae_test": float("inf")}], "mae", "n/a"),
     ],
-    ids=["absent", "all-nan", "non-finite"],
+    ids=["single-resample", "absent", "all-nan", "non-finite"],
 )
-def test_tabulate_results_renders_na(tmp_path, rows, metric):
-    """tabulate_results shows n/a for absent or non-finite metrics."""
+def test_tabulate_results_cell_rule(tmp_path, rows, metric, expected):
+    """A single resample gets zero std; absent or non-finite metrics get n/a."""
     _make_pair_csv(tmp_path, "clf", "ds", rows)
     df = tabulate_results(tmp_path, metric=metric, split="test")
-    assert df.loc["clf", "ds"] == "n/a"
-
-
-def test_tabulate_results_single_resample_zero_std(tmp_path):
-    """tabulate_results reports zero std for a single resample."""
-    _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": 0.25}])
-    df = tabulate_results(tmp_path, metric="mae", split="test")
-    assert df.loc["clf", "ds"] == "0.2500 +/- 0.0000"
+    assert df.loc["clf", "ds"] == expected
 
 
 def test_tabulate_results_fills_missing_pairs_with_na(tmp_path):
@@ -464,8 +445,9 @@ def test_tabulate_results_rejects_both_split(two_pair_folder):
         tabulate_results(two_pair_folder, split="both")
 
 
-def test_tabulate_results_empty_folder_returns_empty(tmp_path):
-    """tabulate_results returns an empty frame when no pairs are present."""
+def test_aggregators_return_empty_for_an_empty_folder(tmp_path):
+    """An existing root with no pairs yields an empty frame, not an error."""
+    assert summarize(tmp_path).empty
     assert tabulate_results(tmp_path).empty
 
 

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -547,3 +547,19 @@ def test_summarize_round_trip_precision(tmp_path):
     _make_pair_csv(tmp_path, "clf", "ds", [{"mae_test": value}])
     df = summarize(tmp_path, split="test")
     assert df.loc[("clf", "ds"), ("mae_test", "mean")] == value
+
+
+def test_evaluate_recovers_the_scale_from_the_confusion_matrix(tmp_path):
+    """K comes from the stored K x K matrix, so a missing class keeps its gap."""
+    _write_report(tmp_path, "A", "d1", {0: {"accuracy_off1_score_test": 2 / 3}})
+    seed = _write_seed(
+        tmp_path, "A", "d1", 0, "test", [0, 0, 2, 2, 0, 2], [0, 2, 0, 2, 0, 2]
+    )
+    (seed / "test_confusion_matrix.txt").write_text(
+        "Seed 0\n=====\n[[3, 0, 0],\n [0, 0, 0],\n [0, 0, 3]]\n"
+    )
+
+    scored = evaluate(tmp_path, "A", "d1", metrics=["accuracy_off1_score"])
+
+    # Ranks 0 and 2 are two apart on the recovered scale, not adjacent
+    assert scored.loc[0, "accuracy_off1_score"] == pytest.approx(2 / 3)

--- a/skordinal/experiments/tests/test_evaluation.py
+++ b/skordinal/experiments/tests/test_evaluation.py
@@ -110,6 +110,12 @@ def test_evaluate_recomputes_metrics_per_seed(seed_folder):
     assert list(df["accuracy_score"]) == pytest.approx([0.75, 0.5])
 
 
+def test_evaluate_ignores_a_repeated_metric_name(seed_folder):
+    """A repeated name must not become two identical columns."""
+    df = evaluate(seed_folder, "A", "d1", metrics=["mean_absolute_error"] * 2)
+    assert list(df.columns) == ["mean_absolute_error"]
+
+
 def test_evaluate_reads_the_requested_split(seed_folder):
     """evaluate scores the train files when split='train'."""
     df = evaluate(seed_folder, "A", "d1", split="train")

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -253,12 +253,16 @@ def test_run_metric_keys_for_each_eval_metric(split_with_test):
         assert result.test_metrics[name + "_test"] >= 0
 
 
-def test_run_rejects_unknown_eval_metric(split_with_test):
-    """An unknown eval_metric name raises ValueError naming the metric."""
-    X_train, y_train, X_test, y_test = split_with_test
-    exp = _make_experiment(eval_metrics=["ranked_probability_score"])
+def test_rejects_unknown_eval_metric_at_construction():
+    """An unknown eval_metric name raises before anything is fitted."""
     with pytest.raises(ValueError, match="ranked_probability_score"):
-        _call_run(exp, X_train, y_train, X_test, y_test)
+        _make_experiment(eval_metrics=["ranked_probability_score"])
+
+
+def test_rejects_bare_loss_tuning_metric_at_construction():
+    """A bare-loss tuning metric raises even when the model needs no search."""
+    with pytest.raises(ValueError, match="only registered as 'neg_"):
+        _make_experiment(tuning_metric="mean_absolute_error")
 
 
 def test_run_proba_absent_without_predict_proba(split_with_test):

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -61,6 +61,12 @@ def test_empty_eval_metrics_raises():
         Experiment(ModelConfig(SVC()), eval_metrics=[])
 
 
+def test_rejects_a_non_model_config():
+    """A bare estimator instead of a ModelConfig raises TypeError."""
+    with pytest.raises(TypeError, match="'model' must be a ModelConfig instance"):
+        Experiment(SVC(), eval_metrics=["mean_absolute_error"])
+
+
 @pytest.mark.parametrize(
     "raw, expected",
     [
@@ -203,6 +209,13 @@ def test_run_preprocessing_train_only_does_not_raise(
 
     assert result.test_predicted_y is None
     assert math.isnan(result.test_metrics["mean_absolute_error_test"])
+
+
+def test_run_rejects_y_test_without_x_test(split_train_only):
+    """y_test without X_test raises ValueError, not a bare assert."""
+    X_train, y_train, _, _ = split_train_only
+    with pytest.raises(ValueError, match="'y_test' was given without 'X_test'"):
+        _call_run(_make_experiment(), X_train, y_train, None, y_train)
 
 
 def test_run_best_model_carries_no_refit_metadata(split_with_test):

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -5,6 +5,8 @@ import math
 import numpy as np
 import numpy.testing as npt
 import pytest
+from sklearn.decomposition import PCA
+from sklearn.dummy import DummyClassifier
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
@@ -55,26 +57,50 @@ def _call_run(experiment, X_train, y_train, X_test, y_test):
     )
 
 
-def test_empty_eval_metrics_raises():
-    """An empty eval_metrics list raises ValueError."""
-    with pytest.raises(ValueError, match="'eval_metrics' must be a non-empty list"):
-        Experiment(ModelConfig(SVC()), eval_metrics=[])
-
-
-def test_rejects_a_non_model_config():
-    """A bare estimator instead of a ModelConfig raises TypeError."""
-    with pytest.raises(TypeError, match="'model' must be a ModelConfig instance"):
-        Experiment(SVC(), eval_metrics=["mean_absolute_error"])
-
-
-def test_input_preprocessing_rejects_a_string():
-    """The removed "std"/"norm" tokens raise TypeError at construction."""
-    with pytest.raises(TypeError, match="'input_preprocessing' must be None"):
-        Experiment(
-            _MINIMAL_CONF,
-            eval_metrics=["mean_absolute_error"],
-            input_preprocessing="std",
-        )
+@pytest.mark.parametrize(
+    "overrides, exc_type, match",
+    [
+        pytest.param(
+            {"model": SVC()},
+            TypeError,
+            "'model' must be a ModelConfig instance",
+            id="bare-estimator",
+        ),
+        pytest.param(
+            {"eval_metrics": []},
+            ValueError,
+            "'eval_metrics' must be a non-empty list",
+            id="empty-eval-metrics",
+        ),
+        pytest.param(
+            {"eval_metrics": ["ranked_probability_score"]},
+            ValueError,
+            "ranked_probability_score",
+            id="proba-only-eval-metric",
+        ),
+        pytest.param(
+            {"tuning_metric": "mean_absolute_error"},
+            ValueError,
+            "only registered as 'neg_",
+            id="bare-loss-tuning-metric",
+        ),
+        pytest.param(
+            {"input_preprocessing": "std"},
+            TypeError,
+            "'input_preprocessing' must be None",
+            id="string-input-preprocessing",
+        ),
+    ],
+)
+def test_constructor_rejects_invalid_arguments(overrides, exc_type, match):
+    """Each invalid argument raises at construction, before anything is fitted."""
+    kwargs = {
+        "model": _MINIMAL_CONF,
+        "eval_metrics": ["mean_absolute_error"],
+        **overrides,
+    }
+    with pytest.raises(exc_type, match=match):
+        Experiment(kwargs.pop("model"), **kwargs)
 
 
 @pytest.mark.parametrize("kwargs, expected", [({}, None), ({"random_state": 42}, 42)])
@@ -84,18 +110,13 @@ def test_random_state_stored(kwargs, expected):
     assert exp.random_state == expected
 
 
-def test_run_returns_experiment_result(split_with_test):
-    """run returns a populated ExperimentResult."""
+@pytest.mark.parametrize("with_indices", [True, False], ids=["indices", "defaults"])
+def test_run_forwards_identity_and_indices(split_with_test, with_indices):
+    """The result echoes the identity kwargs; indices verbatim or None."""
     X_train, y_train, X_test, y_test = split_with_test
-    result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
+    train_index = np.arange(X_train.shape[0]) if with_indices else None
+    test_index = np.arange(X_test.shape[0]) if with_indices else None
 
-    assert isinstance(result, ExperimentResult)
-    assert result.train_predicted_y.shape == (30,)
-
-
-def test_run_identity_passthrough(split_with_test):
-    """dataset_name, classifier_name, and resample_id are forwarded verbatim."""
-    X_train, y_train, X_test, y_test = split_with_test
     result = _make_experiment().run(
         X_train,
         y_train,
@@ -104,36 +125,21 @@ def test_run_identity_passthrough(split_with_test):
         dataset_name="my_dataset",
         classifier_name="my_conf",
         resample_id=42,
-    )
-
-    assert result.dataset_name == "my_dataset"
-    assert result.classifier_name == "my_conf"
-    assert result.resample_id == 42
-
-
-def test_run_forwards_partition_indices(split_with_test):
-    """train_index/test_index round-trip onto the result; default None."""
-    X_train, y_train, X_test, y_test = split_with_test
-    train_index = np.arange(X_train.shape[0])
-    test_index = np.arange(X_test.shape[0])
-
-    result = _make_experiment().run(
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        dataset_name="ds",
-        classifier_name="cfg",
-        resample_id=0,
         train_index=train_index,
         test_index=test_index,
     )
-    npt.assert_array_equal(result.train_index, train_index)
-    npt.assert_array_equal(result.test_index, test_index)
 
-    default_result = _call_run(_make_experiment(), X_train, y_train, X_test, y_test)
-    assert default_result.train_index is None
-    assert default_result.test_index is None
+    assert isinstance(result, ExperimentResult)
+    assert result.train_predicted_y.shape == (30,)
+    assert result.dataset_name == "my_dataset"
+    assert result.classifier_name == "my_conf"
+    assert result.resample_id == 42
+    if with_indices:
+        npt.assert_array_equal(result.train_index, train_index)
+        npt.assert_array_equal(result.test_index, test_index)
+    else:
+        assert result.train_index is None
+        assert result.test_index is None
 
 
 @pytest.mark.parametrize("has_test", [True, False])
@@ -246,18 +252,6 @@ def test_run_metric_keys_for_each_eval_metric(split_with_test):
         assert result.test_metrics[name + "_test"] >= 0
 
 
-def test_rejects_unknown_eval_metric_at_construction():
-    """An unknown eval_metric name raises before anything is fitted."""
-    with pytest.raises(ValueError, match="ranked_probability_score"):
-        _make_experiment(eval_metrics=["ranked_probability_score"])
-
-
-def test_rejects_bare_loss_tuning_metric_at_construction():
-    """A bare-loss tuning metric raises even when the model needs no search."""
-    with pytest.raises(ValueError, match="only registered as 'neg_"):
-        _make_experiment(tuning_metric="mean_absolute_error")
-
-
 def test_run_proba_absent_without_predict_proba(split_with_test):
     """Both proba fields are None when the estimator has no predict_proba."""
     X_train, y_train, X_test, y_test = split_with_test
@@ -333,8 +327,6 @@ def test_run_records_the_fitted_scaler(
 
 def test_transformer_instance_is_cloned_and_seeded(split_with_test):
     """The caller's transformer is never fitted; its clone gets the run seed."""
-    from sklearn.decomposition import PCA
-
     X_train, y_train, X_test, y_test = split_with_test
     transformer = PCA(n_components=2)
     exp = _make_experiment(input_preprocessing=transformer, random_state=7)
@@ -348,9 +340,8 @@ def test_transformer_instance_is_cloned_and_seeded(split_with_test):
     assert result.best_model.n_features_in_ == 2
 
 
-def test_run_scores_on_the_fitted_scale_not_the_split(split_with_test):
+def test_run_scores_on_the_fitted_scale(split_with_test):
     """A split missing an intermediate class keeps the gaps the model was fitted on."""
-    from sklearn.dummy import DummyClassifier
 
     class Extremes(DummyClassifier):
         """Predicts only the two extreme classes, never the middle one."""

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -346,3 +346,29 @@ def test_transformer_instance_is_cloned_and_seeded(split_with_test):
     assert transformer.random_state is None
     # The estimator saw the reduced features, so both splits were transformed
     assert result.best_model.n_features_in_ == 2
+
+
+def test_run_scores_on_the_fitted_scale_not_the_split(split_with_test):
+    """A split missing an intermediate class keeps the gaps the model was fitted on."""
+    from sklearn.dummy import DummyClassifier
+
+    class Extremes(DummyClassifier):
+        """Predicts only the two extreme classes, never the middle one."""
+
+        def predict(self, X):
+            return np.resize(np.array([0, 20]), len(X))
+
+    X_train = np.zeros((30, 2))
+    y_train = np.repeat([0, 10, 20], 10)
+    X_test = np.zeros((6, 2))
+    y_test = np.array([0, 0, 20, 20, 0, 20])
+    exp = _make_experiment(
+        ModelConfig(Extremes(strategy="most_frequent")),
+        eval_metrics=["accuracy_off1_score"],
+    )
+
+    result = _call_run(exp, X_train, y_train, X_test, y_test)
+
+    # Without the fitted scale the two extremes look adjacent, scoring 1.0
+    npt.assert_array_equal(result.best_model.classes_, [0, 10, 20])
+    assert result.test_metrics["accuracy_off1_score_test"] == pytest.approx(2 / 3)

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 import numpy.testing as npt
 import pytest
-from sklearn.preprocessing import MinMaxScaler, StandardScaler
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 from skordinal.experiments import Experiment, ExperimentResult, ModelConfig
@@ -67,32 +67,13 @@ def test_rejects_a_non_model_config():
         Experiment(SVC(), eval_metrics=["mean_absolute_error"])
 
 
-@pytest.mark.parametrize(
-    "raw, expected",
-    [
-        (None, None),
-        ("std", "std"),
-        ("norm", "norm"),
-        (" STD ", "std"),
-        ("NORM", "norm"),
-    ],
-)
-def test_input_preprocessing_accepted_and_normalized(raw, expected):
-    """Valid input_preprocessing values are accepted and lower-stripped."""
-    exp = Experiment(
-        _MINIMAL_CONF, eval_metrics=["mean_absolute_error"], input_preprocessing=raw
-    )
-    assert exp.input_preprocessing == expected
-
-
-@pytest.mark.parametrize("bad_value", ["minmax", ""])
-def test_input_preprocessing_invalid_raises(bad_value):
-    """Unrecognised input_preprocessing values raise ValueError."""
-    with pytest.raises(ValueError, match="'input_preprocessing' must be one of"):
+def test_input_preprocessing_rejects_a_string():
+    """The removed "std"/"norm" tokens raise TypeError at construction."""
+    with pytest.raises(TypeError, match="'input_preprocessing' must be None"):
         Experiment(
             _MINIMAL_CONF,
             eval_metrics=["mean_absolute_error"],
-            input_preprocessing=bad_value,
+            input_preprocessing="std",
         )
 
 
@@ -197,12 +178,9 @@ def test_run_timing_with_cv(split_with_test):
     assert result.best_params.get("C") in _CONF_CV.param_grid["C"]
 
 
-@pytest.mark.parametrize("input_preprocessing", ["std", "norm"])
-def test_run_preprocessing_train_only_does_not_raise(
-    split_train_only, input_preprocessing
-):
+def test_run_preprocessing_train_only_does_not_raise(split_train_only):
     """input_preprocessing with X_test=None runs without transforming None."""
-    exp = _make_experiment(input_preprocessing=input_preprocessing)
+    exp = _make_experiment(input_preprocessing=StandardScaler())
     X_train, y_train, X_test, y_test = split_train_only
 
     result = _call_run(exp, X_train, y_train, X_test, y_test)
@@ -229,8 +207,8 @@ def test_run_best_model_carries_no_refit_metadata(split_with_test):
 
 
 def test_run_preprocessing_does_not_mutate_inputs(split_with_test):
-    """input_preprocessing='std' operates on copies; caller's arrays are unchanged."""
-    exp = _make_experiment(input_preprocessing="std")
+    """Preprocessing operates on copies; the caller's arrays are unchanged."""
+    exp = _make_experiment(input_preprocessing=StandardScaler())
     X_train, y_train, X_test, y_test = split_with_test
     train_before = X_train.copy()
     test_before = X_test.copy()
@@ -315,7 +293,8 @@ def test_run_proba_none_when_predict_proba_raises(split_with_test, monkeypatch):
 
 @pytest.mark.parametrize(
     "input_preprocessing,expected_type",
-    [("std", StandardScaler), ("norm", MinMaxScaler), (None, type(None))],
+    [(StandardScaler(), StandardScaler), (None, type(None))],
+    ids=["scaler", "none"],
 )
 def test_run_records_the_fitted_scaler(
     split_with_test, input_preprocessing, expected_type
@@ -335,3 +314,20 @@ def test_run_records_the_fitted_scaler(
             result.scaler.transform(X_train)[0],
             expected_type().fit(X_train).transform(X_train)[0],
         )
+
+
+def test_transformer_instance_is_cloned_and_seeded(split_with_test):
+    """The caller's transformer is never fitted; its clone gets the run seed."""
+    from sklearn.decomposition import PCA
+
+    X_train, y_train, X_test, y_test = split_with_test
+    transformer = PCA(n_components=2)
+    exp = _make_experiment(input_preprocessing=transformer, random_state=7)
+    result = _call_run(exp, X_train, y_train, X_test, y_test)
+
+    assert result.scaler is not transformer
+    assert not hasattr(transformer, "components_")
+    assert result.scaler.random_state == 7
+    assert transformer.random_state is None
+    # The estimator saw the reduced features, so both splits were transformed
+    assert result.best_model.n_features_in_ == 2

--- a/skordinal/experiments/tests/test_experiment.py
+++ b/skordinal/experiments/tests/test_experiment.py
@@ -189,6 +189,21 @@ def test_run_preprocessing_train_only_does_not_raise(split_train_only):
     assert math.isnan(result.test_metrics["mean_absolute_error_test"])
 
 
+def test_run_search_accepts_array_grid_and_scalar_entry(split_with_test):
+    """np.array candidates trigger a search; a scalar entry rides along."""
+    X_train, y_train, X_test, y_test = split_with_test
+    # "linear" is not SVC's default, so dropping the scalar would show up
+    conf = ModelConfig(
+        SVC(), param_grid={"C": np.array([0.1, 1.0]), "kernel": "linear"}
+    )
+    assert conf.needs_search
+
+    result = _call_run(_make_experiment(conf), X_train, y_train, X_test, y_test)
+
+    assert result.best_params["C"] in (0.1, 1.0)
+    assert result.best_model.kernel == "linear"
+
+
 def test_run_rejects_y_test_without_x_test(split_train_only):
     """y_test without X_test raises ValueError, not a bare assert."""
     X_train, y_train, _, _ = split_train_only

--- a/skordinal/experiments/tests/test_io.py
+++ b/skordinal/experiments/tests/test_io.py
@@ -15,6 +15,7 @@ from skordinal.experiments._io import (
     _ensure_parent,
     _format_proba_column,
     _parse_proba_column,
+    _read_confusion_matrix_size,
     _sweep_orphaned_temp_files,
     _write_split_files,
 )
@@ -137,3 +138,15 @@ def test_confusion_matrix_not_elided_for_many_classes(tmp_path):
     assert "..." not in body
     # Check the matrix keeps one physical line per row (no wrapping)
     assert body.count("\n") == 39
+
+
+def test_read_confusion_matrix_size(tmp_path):
+    """K comes from the saved matrix, and an unusable file yields None."""
+    good = tmp_path / "test_confusion_matrix.txt"
+    good.write_text("Seed 0\n=====\n[[1, 0, 0],\n [0, 2, 0],\n [0, 0, 3]]\n")
+    assert _read_confusion_matrix_size(good) == 3
+
+    ragged = tmp_path / "ragged.txt"
+    ragged.write_text("Seed 0\n=====\n[[1, 0], [0]]\n")
+    assert _read_confusion_matrix_size(ragged) is None
+    assert _read_confusion_matrix_size(tmp_path / "absent.txt") is None

--- a/skordinal/experiments/tests/test_io.py
+++ b/skordinal/experiments/tests/test_io.py
@@ -12,12 +12,11 @@ from skordinal.experiments._io import (
     _TEMP_PREFIX,
     _atomic_dump,
     _atomic_write,
-    _check_path_component,
-    _check_resample_id,
     _ensure_parent,
     _format_proba_column,
     _parse_proba_column,
     _sweep_orphaned_temp_files,
+    _write_split_files,
 )
 
 
@@ -110,33 +109,31 @@ def test_atomic_dump_round_trips_no_temp(tmp_path):
     assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
 
 
-@pytest.mark.parametrize("bad", ["", ".", "..", "a/b", f"a{os.sep}b"])
-def test_check_path_component_rejects_bad_strings(bad):
-    """_check_path_component rejects empty, dotted or separator names."""
-    with pytest.raises(ValueError):
-        _check_path_component(bad, "classifier_name")
-
-
-@pytest.mark.parametrize("bad", [3, None, ("x",)])
-def test_check_path_component_rejects_non_str(bad):
-    """_check_path_component rejects a non-string component."""
-    with pytest.raises(TypeError):
-        _check_path_component(bad, "classifier_name")
-
-
-@pytest.mark.parametrize("good", [0, -1, np.int64(3), "0"])
-def test_check_resample_id_accepts_int_like(good):
-    """_check_resample_id passes through ints, numpy ints and int-like strings."""
-    _check_resample_id(good)
-
-
-@pytest.mark.parametrize("bad", ["../../../../tmp/evil", "..", "", "a/b"])
-def test_check_resample_id_rejects_traversal(bad):
-    """_check_resample_id rejects a non-int id that fails path validation."""
-    with pytest.raises(ValueError, match="resample_id"):
-        _check_resample_id(bad)
-
-
 def test_sweep_orphaned_temp_files_ignores_missing_dir(tmp_path):
     """The sweep is a no-op when the base directory does not exist."""
     _sweep_orphaned_temp_files(tmp_path / "absent")
+
+
+def test_confusion_matrix_not_elided_for_many_classes(tmp_path):
+    """A large confusion matrix is written in full, without summarising."""
+    labels = np.arange(40)
+    _write_split_files(
+        tmp_path,
+        "train",
+        index=None,
+        true_y=labels,
+        predicted_y=labels,
+        proba=None,
+        classes=labels,
+        resample_id=0,
+    )
+
+    body = (
+        (tmp_path / "train_confusion_matrix.txt")
+        .read_text()
+        .split("\n", 2)[2]
+        .rstrip("\n")
+    )
+    assert "..." not in body
+    # Check the matrix keeps one physical line per row (no wrapping)
+    assert body.count("\n") == 39

--- a/skordinal/experiments/tests/test_io.py
+++ b/skordinal/experiments/tests/test_io.py
@@ -5,7 +5,6 @@ import os
 import joblib
 import numpy as np
 import numpy.testing as npt
-import pandas as pd
 import pytest
 
 from skordinal.experiments._io import (
@@ -21,39 +20,23 @@ from skordinal.experiments._io import (
 )
 
 
-def test_format_proba_column_cells_round_trip():
-    """Wide probability cells stay single-line and parse back exactly."""
+def test_proba_column_round_trips():
+    """Wide probability rows stay single-line cells and parse back exactly."""
     rng = np.random.default_rng(0)
     raw = rng.random((3, 20))
     proba = raw / raw.sum(axis=1, keepdims=True)
 
-    for cell, row in zip(_format_proba_column(proba), proba):
-        assert "\n" not in cell
-        npt.assert_array_equal(np.fromstring(cell.strip("[]"), sep=","), row)
+    cells = _format_proba_column(proba)
+    assert all("\n" not in cell for cell in cells)
+    npt.assert_array_equal(_parse_proba_column(cells), proba)
 
 
-def test_parse_proba_column_round_trips_formatted_cells():
-    """_parse_proba_column reconstructs the matrix _format_proba_column wrote."""
-    rng = np.random.default_rng(0)
-    raw = rng.random((3, 5))
-    proba = raw / raw.sum(axis=1, keepdims=True)
-    parsed = _parse_proba_column(pd.Series(_format_proba_column(proba)))
-    npt.assert_array_equal(parsed, proba)
-
-
-def test_atomic_write_success_leaves_no_temp(tmp_path):
-    """_atomic_write writes full content and leaves no temp file."""
-    target = tmp_path / "f.csv"
-    _atomic_write(target, "a,b\n1,2\n")
-    assert target.read_text() == "a,b\n1,2\n"
-    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
-
-
-def test_atomic_write_creates_missing_parent(tmp_path):
-    """_atomic_write creates the target's parent directory if absent."""
+def test_atomic_write_round_trips(tmp_path):
+    """Content lands whole under a created parent, with no temp file left."""
     target = tmp_path / "nested" / "f.csv"
     _atomic_write(target, "a,b\n1,2\n")
     assert target.read_text() == "a,b\n1,2\n"
+    assert list(tmp_path.rglob(f"{_TEMP_PREFIX}*")) == []
 
 
 def test_ensure_parent_wraps_mkdir_failure(tmp_path, monkeypatch):
@@ -66,15 +49,23 @@ def test_ensure_parent_wraps_mkdir_failure(tmp_path, monkeypatch):
         _ensure_parent(tmp_path / "nested" / "f.csv")
 
 
-def test_atomic_write_cleans_up_on_failure(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "write",
+    [
+        lambda path: _atomic_write(path, "data"),
+        lambda path: _atomic_dump(path, {"k": 1}),
+    ],
+    ids=["write", "dump"],
+)
+def test_atomic_writers_clean_up_on_failure(tmp_path, monkeypatch, write):
     """A failing os.replace unlinks the temp file and re-raises."""
     monkeypatch.setattr(
         "skordinal.experiments._io.os.replace",
         lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
     )
     with pytest.raises(OSError, match="boom"):
-        _atomic_write(tmp_path / "f.csv", "data")
-    assert not (tmp_path / "f.csv").exists()
+        write(tmp_path / "target")
+    assert not (tmp_path / "target").exists()
     assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
 
 
@@ -90,18 +81,6 @@ def test_atomic_write_fsyncs(tmp_path, monkeypatch):
     assert len(calls) == 1
 
 
-def test_atomic_dump_cleans_up_on_failure(tmp_path, monkeypatch):
-    """A failing os.replace unlinks the dump's temp file and re-raises."""
-    monkeypatch.setattr(
-        "skordinal.experiments._io.os.replace",
-        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")),
-    )
-    with pytest.raises(OSError, match="boom"):
-        _atomic_dump(tmp_path / "m.joblib", {"k": 1})
-    assert not (tmp_path / "m.joblib").exists()
-    assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
-
-
 def test_atomic_dump_round_trips_no_temp(tmp_path):
     """_atomic_dump serialises an object recoverable by joblib.load."""
     target = tmp_path / "m.joblib"
@@ -110,9 +89,18 @@ def test_atomic_dump_round_trips_no_temp(tmp_path):
     assert list(tmp_path.glob(f"{_TEMP_PREFIX}*")) == []
 
 
-def test_sweep_orphaned_temp_files_ignores_missing_dir(tmp_path):
-    """The sweep is a no-op when the base directory does not exist."""
+def test_sweep_removes_only_stray_temp_files(tmp_path):
+    """The sweep unlinks temp files, keeping directories; a missing root is a no-op."""
     _sweep_orphaned_temp_files(tmp_path / "absent")
+
+    stray = tmp_path / "sub" / f"{_TEMP_PREFIX}leftover.tmp"
+    stray.parent.mkdir()
+    stray.write_text("junk")
+    temp_dir = tmp_path / f"{_TEMP_PREFIX}dir"
+    temp_dir.mkdir()
+    _sweep_orphaned_temp_files(tmp_path)
+    assert not stray.exists()
+    assert temp_dir.is_dir()
 
 
 def test_confusion_matrix_not_elided_for_many_classes(tmp_path):

--- a/skordinal/experiments/tests/test_model_config.py
+++ b/skordinal/experiments/tests/test_model_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 from sklearn.ensemble import BaggingClassifier
 from sklearn.linear_model import LogisticRegression
@@ -67,13 +68,44 @@ def test_modelconfig_param_grid_is_keyword_only():
         ({"C": [0.5]}, False),
         ({"C": [0.1, 1.0]}, True),
         ({"C": [0.1, 1.0], "max_iter": 200}, True),
+        ({"C": np.logspace(-2, 0, 3)}, True),
+        ({"solver": "lbfgs"}, False),
     ],
-    ids=["none", "empty", "singleton", "multi_value", "mixed_multi"],
+    ids=[
+        "none",
+        "empty",
+        "singleton",
+        "multi_value",
+        "mixed_multi",
+        "numpy_grid",
+        "string_scalar",
+    ],
 )
 def test_needs_search(param_grid, expected):
-    """Return True iff a grid value is a multi-element list or tuple."""
+    """Return True iff a grid value is a multi-element non-string sequence."""
     cfg = ModelConfig(LogisticRegression(), param_grid=param_grid)
     assert cfg.needs_search is expected
+
+
+@pytest.mark.parametrize(
+    "param_grid, expected",
+    [
+        ({"C": [0.1, 1.0], "solver": "lbfgs"}, {"C": [0.1, 1.0], "solver": ["lbfgs"]}),
+        (None, {}),
+    ],
+    ids=["wraps_scalars", "none"],
+)
+def test_search_grid(param_grid, expected):
+    """Scalar entries are wrapped for GridSearchCV; sequences pass through."""
+    cfg = ModelConfig(LogisticRegression(), param_grid=param_grid)
+    assert cfg.search_grid() == expected
+
+
+def test_zero_d_array_counts_as_a_fixed_value():
+    """A 0-d array holds one value and has no len() to enumerate."""
+    cfg = ModelConfig(LogisticRegression(), param_grid={"C": np.asarray(0.5)})
+    assert cfg.needs_search is False
+    assert cfg.fixed_params()["C"] == 0.5
 
 
 @pytest.mark.parametrize(

--- a/skordinal/experiments/tests/test_model_config.py
+++ b/skordinal/experiments/tests/test_model_config.py
@@ -13,7 +13,7 @@ from sklearn.tree import DecisionTreeClassifier
 from skordinal.experiments import ModelConfig
 
 
-def test_modelconfig_stores_estimator_and_grid():
+def test_stores_estimator_and_grid():
     """Store estimator by identity and param_grid (None default, verbatim)."""
     lr = LogisticRegression(max_iter=200)
     cfg_default = ModelConfig(lr)
@@ -25,7 +25,7 @@ def test_modelconfig_stores_estimator_and_grid():
     assert cfg_with_grid.param_grid is grid
 
 
-def test_modelconfig_fields_are_frozen():
+def test_fields_are_frozen():
     """Assigning to a field of a frozen ``ModelConfig`` raises an error."""
     cfg = ModelConfig(LogisticRegression(), param_grid={"C": [1.0]})
     with pytest.raises((AttributeError, TypeError)):
@@ -37,7 +37,7 @@ def test_modelconfig_fields_are_frozen():
     ["not an estimator", 42, None],
     ids=["string", "int", "none"],
 )
-def test_modelconfig_rejects_non_estimator(bad_estimator):
+def test_rejects_non_estimator(bad_estimator):
     """Reject a non-``BaseEstimator`` with a ``TypeError``."""
     with pytest.raises(TypeError, match="BaseEstimator"):
         ModelConfig(bad_estimator)
@@ -48,13 +48,13 @@ def test_modelconfig_rejects_non_estimator(bad_estimator):
     [[1, 2], "C=0.1", 42],
     ids=["list", "string", "int"],
 )
-def test_modelconfig_rejects_bad_param_grid(bad_grid):
+def test_rejects_bad_param_grid(bad_grid):
     """Reject a non-dict, non-None ``param_grid`` with a ``TypeError``."""
     with pytest.raises(TypeError, match="param_grid"):
         ModelConfig(LogisticRegression(), param_grid=bad_grid)
 
 
-def test_modelconfig_param_grid_is_keyword_only():
+def test_param_grid_is_keyword_only():
     """``param_grid`` as a second positional argument raises ``TypeError``."""
     with pytest.raises(TypeError):
         ModelConfig(LogisticRegression(), {"C": [1]})  # type: ignore[call-arg]
@@ -70,6 +70,8 @@ def test_modelconfig_param_grid_is_keyword_only():
         ({"C": [0.1, 1.0], "max_iter": 200}, True),
         ({"C": np.logspace(-2, 0, 3)}, True),
         ({"solver": "lbfgs"}, False),
+        # A 0-d array holds one value and has no len() to enumerate
+        ({"C": np.asarray(0.5)}, False),
     ],
     ids=[
         "none",
@@ -79,6 +81,7 @@ def test_modelconfig_param_grid_is_keyword_only():
         "mixed_multi",
         "numpy_grid",
         "string_scalar",
+        "zero_d_array",
     ],
 )
 def test_needs_search(param_grid, expected):
@@ -101,13 +104,6 @@ def test_search_grid(param_grid, expected):
     assert cfg.search_grid() == expected
 
 
-def test_zero_d_array_counts_as_a_fixed_value():
-    """A 0-d array holds one value and has no len() to enumerate."""
-    cfg = ModelConfig(LogisticRegression(), param_grid={"C": np.asarray(0.5)})
-    assert cfg.needs_search is False
-    assert cfg.fixed_params()["C"] == 0.5
-
-
 @pytest.mark.parametrize(
     "param_grid, expected",
     [
@@ -115,9 +111,10 @@ def test_zero_d_array_counts_as_a_fixed_value():
         ({}, {}),
         ({"C": [0.5]}, {"C": 0.5}),
         ({"C": 0.5}, {"C": 0.5}),
+        ({"C": np.asarray(0.5)}, {"C": 0.5}),
         ({"C": []}, {}),
     ],
-    ids=["none", "empty", "singleton_list", "scalar", "empty_list"],
+    ids=["none", "empty", "singleton_list", "scalar", "zero_d_array", "empty_list"],
 )
 def test_fixed_params(param_grid, expected):
     """Unwrap singleton lists, pass scalars through, skip empty lists."""

--- a/skordinal/experiments/tests/test_recipes.py
+++ b/skordinal/experiments/tests/test_recipes.py
@@ -106,6 +106,18 @@ def test_validate_recipe_empty_models_raises_value_error():
         validate_recipe({"models": {}, "datasets": ["balance_scale"]})
 
 
+def test_validate_recipe_rejects_a_non_dict_models():
+    """A list of models raises TypeError, as its own docstring promises."""
+    with pytest.raises(TypeError, match="'models' must be a dict"):
+        validate_recipe({"models": [_MINIMAL_MODELS], "datasets": ["balance_scale"]})
+
+
+def test_validate_recipe_rejects_a_bare_string_datasets():
+    """A bare string would silently become one dataset per character."""
+    with pytest.raises(TypeError, match=r"not a bare string; pass \['era'\]"):
+        validate_recipe({"models": _MINIMAL_MODELS, "datasets": "era"})
+
+
 def test_validate_recipe_models_value_not_modelconfig_raises_type_error():
     """A ``models`` value that is not a ``ModelConfig`` raises ``TypeError``."""
     with pytest.raises(TypeError, match="ModelConfig"):

--- a/skordinal/experiments/tests/test_recipes.py
+++ b/skordinal/experiments/tests/test_recipes.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 from skordinal.experiments import Benchmark, ModelConfig, load_recipe, validate_recipe
@@ -66,7 +67,7 @@ def test_validate_recipe_all_optional_keys_accepted():
         "tuning_metric": "neg_mean_absolute_error",
         "cv": 3,
         "n_jobs": 1,
-        "input_preprocessing": "std",
+        "input_preprocessing": StandardScaler(),
         "random_state": 0,
         "overwrite": True,
         "verbose": False,

--- a/skordinal/experiments/tests/test_recipes.py
+++ b/skordinal/experiments/tests/test_recipes.py
@@ -49,116 +49,103 @@ def _write(tmp_path: Path, src: str, name: str = "recipe.py") -> Path:
     return p
 
 
-def test_validate_recipe_minimal_valid_does_not_raise():
-    """A minimal recipe with ``models`` and ``datasets`` passes without error."""
-    validate_recipe(_MINIMAL_RECIPE)
-
-
-def test_validate_recipe_all_optional_keys_accepted():
-    """A recipe with every optional key accepted alongside the required keys."""
-    full: dict = {
-        "models": _MINIMAL_MODELS,
-        "datasets": ["balance_scale"],
-        "data_home": "/data",
-        "eval_metrics": ["mean_absolute_error"],
-        "results_path": "/tmp/out",
-        "resamples": 10,
-        "test_size": 0.25,
-        "tuning_metric": "neg_mean_absolute_error",
-        "cv": 3,
-        "n_jobs": 1,
-        "input_preprocessing": StandardScaler(),
-        "random_state": 0,
-        "overwrite": True,
-        "verbose": False,
-    }
-    validate_recipe(full)
+_FULL_RECIPE: dict = {
+    "models": _MINIMAL_MODELS,
+    "datasets": ["balance_scale"],
+    "data_home": "/data",
+    "eval_metrics": ["mean_absolute_error"],
+    "results_path": "/tmp/out",
+    "resamples": 10,
+    "test_size": 0.25,
+    "tuning_metric": "neg_mean_absolute_error",
+    "cv": 3,
+    "n_jobs": 1,
+    "input_preprocessing": StandardScaler(),
+    "random_state": 0,
+    "overwrite": True,
+    "verbose": False,
+}
 
 
 @pytest.mark.parametrize(
-    "bad_recipe",
+    "recipe", [_MINIMAL_RECIPE, _FULL_RECIPE], ids=["minimal", "every-optional-key"]
+)
+def test_validate_recipe_accepts_valid_recipes(recipe):
+    """The required keys alone and every optional key both pass."""
+    validate_recipe(recipe)
+
+
+@pytest.mark.parametrize(
+    "recipe, exc_type, match",
     [
-        pytest.param(["models", "datasets"], id="list-not-dict"),
-        pytest.param(None, id="none-not-dict"),
+        pytest.param(
+            ["models", "datasets"], TypeError, "recipe must be a dict", id="list"
+        ),
+        pytest.param(None, TypeError, "recipe must be a dict", id="none"),
+        pytest.param(
+            {"datasets": ["balance_scale"]},
+            ValueError,
+            "missing required keys",
+            id="missing-models",
+        ),
+        pytest.param(
+            {"models": _MINIMAL_MODELS},
+            ValueError,
+            "missing required keys",
+            id="missing-datasets",
+        ),
+        pytest.param(
+            {"models": _MINIMAL_MODELS, "datasets": ["era"], "bogus": True},
+            ValueError,
+            "unknown keys",
+            id="unknown-key",
+        ),
+        pytest.param(
+            {"models": {}, "datasets": ["era"]},
+            ValueError,
+            "non-empty dict",
+            id="empty-models",
+        ),
+        pytest.param(
+            {"models": [_MINIMAL_MODELS], "datasets": ["era"]},
+            TypeError,
+            "'models' must be a dict",
+            id="models-not-a-dict",
+        ),
+        pytest.param(
+            {"models": {"svc": SVC()}, "datasets": ["era"]},
+            TypeError,
+            "ModelConfig",
+            id="non-modelconfig-value",
+        ),
+        pytest.param(
+            {"models": _MINIMAL_MODELS, "datasets": "era"},
+            TypeError,
+            r"not a bare string; pass \['era'\]",
+            id="bare-string-datasets",
+        ),
+        pytest.param(
+            {"models": _MINIMAL_MODELS, "datasets": []},
+            ValueError,
+            "non-empty",
+            id="empty-datasets",
+        ),
     ],
 )
-def test_validate_recipe_not_dict_raises_type_error(bad_recipe):
-    """A non-dict recipe raises ``TypeError`` mentioning the type."""
-    with pytest.raises(TypeError, match="recipe must be a dict"):
-        validate_recipe(bad_recipe)
+def test_validate_recipe_rejects_invalid_structures(recipe, exc_type, match):
+    """Each structural defect raises its own error, before Benchmark is built."""
+    with pytest.raises(exc_type, match=match):
+        validate_recipe(recipe)
 
 
-def test_validate_recipe_missing_models_raises_value_error():
-    """A recipe without ``models`` raises ``ValueError`` mentioning the key."""
-    with pytest.raises(ValueError, match="missing required keys"):
-        validate_recipe({"datasets": ["balance_scale"]})
-
-
-def test_validate_recipe_missing_datasets_raises_value_error():
-    """A recipe without ``datasets`` raises ``ValueError`` mentioning the key."""
-    with pytest.raises(ValueError, match="missing required keys"):
-        validate_recipe({"models": _MINIMAL_MODELS})
-
-
-def test_validate_recipe_empty_models_raises_value_error():
-    """An empty ``models`` dict raises ``ValueError``."""
-    with pytest.raises(ValueError, match="non-empty dict"):
-        validate_recipe({"models": {}, "datasets": ["balance_scale"]})
-
-
-def test_validate_recipe_rejects_a_non_dict_models():
-    """A list of models raises TypeError, as its own docstring promises."""
-    with pytest.raises(TypeError, match="'models' must be a dict"):
-        validate_recipe({"models": [_MINIMAL_MODELS], "datasets": ["balance_scale"]})
-
-
-def test_validate_recipe_rejects_a_bare_string_datasets():
-    """A bare string would silently become one dataset per character."""
-    with pytest.raises(TypeError, match=r"not a bare string; pass \['era'\]"):
-        validate_recipe({"models": _MINIMAL_MODELS, "datasets": "era"})
-
-
-def test_validate_recipe_models_value_not_modelconfig_raises_type_error():
-    """A ``models`` value that is not a ``ModelConfig`` raises ``TypeError``."""
-    with pytest.raises(TypeError, match="ModelConfig"):
-        validate_recipe(
-            {
-                "models": {"svc": SVC()},  # raw estimator, not wrapped
-                "datasets": ["balance_scale"],
-            }
-        )
-
-
-def test_validate_recipe_empty_datasets_raises_value_error():
-    """An empty ``datasets`` list raises ``ValueError``."""
-    with pytest.raises(ValueError, match="non-empty"):
-        validate_recipe({"models": _MINIMAL_MODELS, "datasets": []})
-
-
-def test_validate_recipe_unknown_key_raises_value_error():
-    """An unknown top-level key raises ``ValueError`` naming the unknown key."""
-    with pytest.raises(ValueError, match="unknown keys"):
-        validate_recipe(
-            {
-                "models": _MINIMAL_MODELS,
-                "datasets": ["balance_scale"],
-                "this_key_is_not_allowed": True,
-            }
-        )
-
-
-def test_load_recipe_valid_file_returns_dict(tmp_path):
-    """``load_recipe`` on a valid file returns a validated dict with ``ModelConfig`` values."""
-    p = _write(tmp_path, _VALID_RECIPE_SRC)
+def test_load_recipe_returns_the_validated_dict(tmp_path):
+    """The RECIPE dict comes back whole, its ModelConfig values constructed."""
+    p = _write(tmp_path, _RECIPE_WITH_EXTRAS_SRC)
     recipe = load_recipe(p)
 
-    assert isinstance(recipe, dict)
-    assert "models" in recipe
-    assert "datasets" in recipe
-    for name, cfg in recipe["models"].items():
-        assert isinstance(cfg, ModelConfig), (
-            f"models[{name!r}] is {type(cfg)!r}, expected ModelConfig"
-        )
+    assert recipe["datasets"] == ["balance_scale"]
+    assert recipe["resamples"] == 2
+    assert all(isinstance(cfg, ModelConfig) for cfg in recipe["models"].values())
 
 
 def test_load_recipe_missing_attribute_raises_attribute_error(tmp_path):
@@ -168,41 +155,26 @@ def test_load_recipe_missing_attribute_raises_attribute_error(tmp_path):
         load_recipe(p)
 
 
-def test_load_recipe_file_not_found_raises(tmp_path):
-    """A non-existent path raises ``FileNotFoundError``."""
+@pytest.mark.parametrize("exists", [False, True], ids=["missing", "not-python"])
+def test_load_recipe_rejects_an_unloadable_path(tmp_path, exists):
+    """A missing path and a file no import loader accepts both fail loud."""
+    path = tmp_path / "recipe.txt"
+    if exists:
+        path.write_text(_VALID_RECIPE_SRC, encoding="utf-8")
     with pytest.raises(FileNotFoundError):
-        load_recipe(tmp_path / "nonexistent_recipe.py")
+        load_recipe(path)
 
 
-def test_load_recipe_is_repeatable(tmp_path):
-    """Calling ``load_recipe`` twice on the same file returns equal results."""
+def test_load_recipe_is_repeatable_and_leaves_sys_modules_clean(tmp_path):
+    """Repeat loads see fresh state; the synthetic module never lingers."""
+    import sys
+
     p = _write(tmp_path, _VALID_RECIPE_SRC)
     first = load_recipe(p)
     second = load_recipe(p)
 
-    assert set(first.keys()) == set(second.keys())
     assert list(first["datasets"]) == list(second["datasets"])
-
-
-def test_load_recipe_does_not_pollute_sys_modules(tmp_path):
-    """The synthetic module name is removed from ``sys.modules`` after loading."""
-    import sys
-
-    p = _write(tmp_path, _VALID_RECIPE_SRC)
-    module_name = f"_skordinal_recipe_{p.stem}"
-
-    load_recipe(p)
-
-    assert module_name not in sys.modules
-
-
-def test_load_recipe_with_extra_fields_returns_all_keys(tmp_path):
-    """Optional keys declared in the recipe are present in the returned dict."""
-    p = _write(tmp_path, _RECIPE_WITH_EXTRAS_SRC)
-    recipe = load_recipe(p)
-
-    assert "resamples" in recipe
-    assert recipe["resamples"] == 2
+    assert f"_skordinal_recipe_{p.stem}" not in sys.modules
 
 
 _FROM_RECIPE_TMPL = """\

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -546,6 +546,33 @@ def test_hyperparameters_prefix_strip_and_union(tmp_path):
     assert "2.0" not in raw
 
 
+def test_hyperparameters_keep_a_searched_float_a_float(tmp_path):
+    """A float grid value stays 10.0; the int column beside it stays an int."""
+    r = Results(tmp_path)
+    for seed, params in (
+        (0, {"clf__C": 10.0, "clf__degree": 2}),
+        (1, {"clf__C": 1.0, "clf__degree": 3}),
+    ):
+        r.save(
+            _make_result(
+                partition=seed,
+                dataset="ds",
+                configuration="clf",
+                best_params=params,
+                train_metrics={"mae_train": 0.1},
+                test_metrics={"mae_test": 0.1},
+                train_predicted_y=np.array([1]),
+                test_predicted_y=np.array([1]),
+            ),
+            save_model=False,
+        )
+
+    raw = (tmp_path / "clf" / "ds" / "hyperparameter_configuration.csv").read_text()
+    # convert_dtypes() used to rewrite an all-integral float column as ints
+    assert "10.0" in raw
+    assert "3.0" not in raw
+
+
 def test_hyperparameters_empty_params(tmp_path):
     """Empty best_params yields a one-column CSV holding only Seed."""
     Results(tmp_path).save(

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -30,15 +30,18 @@ def _fitted_svc(classes=(1, 2, 3), probability=False):
     return SVC(probability=probability).fit(features, targets)
 
 
+_KEEP = object()
+
+
 def _make_result(
-    partition: int,
-    dataset: str,
-    configuration: str,
-    best_params: dict,
-    train_metrics: dict,
-    test_metrics: dict,
-    train_predicted_y: np.ndarray,
-    test_predicted_y: np.ndarray | None,
+    partition: int = 0,
+    dataset: str = "ds",
+    configuration: str = "clf",
+    best_params: dict | None = None,
+    train_metrics: dict | None = None,
+    test_metrics: dict | None = None,
+    train_predicted_y: np.ndarray | None = None,
+    test_predicted_y=_KEEP,
     estimator=None,
     train_true_y=None,
     test_true_y=None,
@@ -47,6 +50,16 @@ def _make_result(
     y_proba=None,
     scaler=None,
 ) -> ExperimentResult:
+    if best_params is None:
+        best_params = {}
+    if train_metrics is None:
+        train_metrics = {"mae_train": 0.1}
+    if test_metrics is None:
+        test_metrics = {"mae_test": 0.1}
+    if train_predicted_y is None:
+        train_predicted_y = np.array([1])
+    if test_predicted_y is _KEEP:
+        test_predicted_y = np.array([1])
     if estimator is None:
         estimator = _fitted_svc()
     if train_true_y is None:
@@ -88,7 +101,6 @@ def test_save(tmp_path):
     results = Results(tmp_path)
 
     result_0 = _make_result(
-        partition=0,
         dataset="toy",
         configuration="conf_1",
         best_params={"C": 0.1, "gamma": 1},
@@ -153,10 +165,7 @@ def test_save_encodes_labels_zero_based(tmp_path):
     test_true = np.array([1, 2, 3, 1])
     test_pred = np.array([2, 2, 3, 1])
     result = _make_result(
-        partition=0,
         dataset="toy",
-        configuration="clf",
-        best_params={},
         train_metrics={"acc_train": 1.0},
         test_metrics={"acc_test": 1.0},
         train_predicted_y=np.array([2, 2, 3]),
@@ -180,7 +189,6 @@ def test_save_encodes_labels_zero_based(tmp_path):
 def test_save_model_false(tmp_path):
     """save_model=False writes the seed dir but no models/ folder."""
     result = _make_result(
-        partition=0,
         dataset="toy",
         configuration="conf_1",
         best_params={"C": 1},
@@ -331,12 +339,6 @@ def test_save_requires_true_labels(tmp_path):
 def test_save_rejects_unknown_labels(tmp_path, overrides, match):
     """A label absent from classes_ raises instead of mis-encoding."""
     kwargs = dict(
-        partition=0,
-        dataset="toy",
-        configuration="clf",
-        best_params={},
-        train_metrics={"acc_train": 1.0},
-        test_metrics={"acc_test": 1.0},
         train_predicted_y=np.array([1, 2, 3]),
         test_predicted_y=np.array([1, 2, 3]),
         train_true_y=np.array([1, 2, 3]),
@@ -346,7 +348,7 @@ def test_save_rejects_unknown_labels(tmp_path, overrides, match):
     with pytest.raises(ValueError, match=match):
         Results(tmp_path).save(_make_result(**kwargs))
     # Check the failed save left no model behind
-    assert not (tmp_path / "clf" / "toy" / "models" / "0.joblib").exists()
+    assert not (tmp_path / "clf" / "ds" / "models" / "0.joblib").exists()
 
 
 def test_save_rejects_misshaped_proba(tmp_path):
@@ -372,10 +374,7 @@ def test_save_rejects_misshaped_proba(tmp_path):
 def test_save_no_test_partition(tmp_path):
     """When test_predicted_y is None, no test files are written."""
     result = _make_result(
-        partition=0,
         dataset="toy",
-        configuration="clf",
-        best_params={},
         train_metrics={"ccr_train": 0.9},
         test_metrics={},
         train_predicted_y=np.array([1, 2, 3]),
@@ -396,10 +395,7 @@ def test_save_writes_confusion_matrices(tmp_path):
     test_true = np.array([1, 1, 2, 2, 3, 3])
     test_pred = np.array([1, 2, 2, 3, 3, 3])
     result = _make_result(
-        partition=0,
         dataset="toy",
-        configuration="clf",
-        best_params={},
         train_metrics={"acc_train": 1.0},
         test_metrics={"acc_test": 1.0},
         train_predicted_y=np.array([1, 2, 3]),
@@ -435,10 +431,7 @@ def test_save_pattern_id_fallback(tmp_path, with_indices):
     test_index = np.array([40, 41]) if with_indices else None
     Results(tmp_path).save(
         _make_result(
-            partition=0,
             dataset="toy",
-            configuration="clf",
-            best_params={},
             train_metrics={"acc_train": 1.0},
             test_metrics={"acc_test": 1.0},
             train_predicted_y=np.array([1, 2, 3, 1]),
@@ -465,13 +458,8 @@ def test_save_multiple_partitions_and_hyperparameter_upsert(tmp_path):
         r.save(
             _make_result(
                 partition=i,
-                dataset="ds",
-                configuration="clf",
-                best_params={},
                 train_metrics={"mae_train": float(i)},
                 test_metrics={"mae_test": float(i)},
-                train_predicted_y=np.array([1]),
-                test_predicted_y=np.array([1]),
             ),
             save_model=False,
         )
@@ -479,23 +467,12 @@ def test_save_multiple_partitions_and_hyperparameter_upsert(tmp_path):
     df = pd.read_csv(tmp_path / "clf" / "ds" / "report.csv", index_col=0)
     assert df.shape[0] == 3
 
-    base_result = dict(
-        dataset="ds",
-        configuration="clf",
-        train_metrics={"mae_train": 0.1},
-        test_metrics={"mae_test": 0.1},
-        train_predicted_y=np.array([1]),
-        test_predicted_y=np.array([1]),
-    )
-    r.save(
-        _make_result(partition=0, best_params={"C": 0.1}, **base_result),
-        save_model=False,
-    )
-    r.save(
-        _make_result(partition=0, best_params={"C": 1.0}, **base_result),
-        save_model=False,
-    )
+    r.save(_make_result(best_params={"C": 0.1}), save_model=False)
+    r.save(_make_result(best_params={"C": 1.0}), save_model=False)
 
+    # Re-saving seed 0 keeps one report row and one upserted parameter row
+    df = pd.read_csv(tmp_path / "clf" / "ds" / "report.csv", index_col=0)
+    assert df.shape[0] == 3
     hyper = pd.read_csv(tmp_path / "clf" / "ds" / "hyperparameter_configuration.csv")
     seed_0 = hyper[hyper["Seed"] == 0]
     assert len(seed_0) == 1
@@ -508,28 +485,15 @@ def test_hyperparameters_prefix_strip_and_union(tmp_path):
     """The clf__ prefix is stripped and missing params union to NaN."""
     r = Results(tmp_path)
     r.save(
-        _make_result(
-            partition=0,
-            dataset="ds",
-            configuration="clf",
-            best_params={"clf__gamma": 1},
-            train_metrics={"mae_train": 0.1},
-            test_metrics={"mae_test": 0.1},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
-        ),
+        _make_result(best_params={"clf__gamma": 1}),
         save_model=False,
     )
     r.save(
         _make_result(
             partition=1,
-            dataset="ds",
-            configuration="clf",
             best_params={"clf__gamma": 0.3, "clf__alpha": 2},
             train_metrics={"mae_train": 0.2},
             test_metrics={"mae_test": 0.2},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
         ),
         save_model=False,
     )
@@ -554,16 +518,7 @@ def test_hyperparameters_keep_a_searched_float_a_float(tmp_path):
         (1, {"clf__C": 1.0, "clf__degree": 3}),
     ):
         r.save(
-            _make_result(
-                partition=seed,
-                dataset="ds",
-                configuration="clf",
-                best_params=params,
-                train_metrics={"mae_train": 0.1},
-                test_metrics={"mae_test": 0.1},
-                train_predicted_y=np.array([1]),
-                test_predicted_y=np.array([1]),
-            ),
+            _make_result(partition=seed, best_params=params),
             save_model=False,
         )
 
@@ -576,16 +531,7 @@ def test_hyperparameters_keep_a_searched_float_a_float(tmp_path):
 def test_hyperparameters_empty_params(tmp_path):
     """Empty best_params yields a one-column CSV holding only Seed."""
     Results(tmp_path).save(
-        _make_result(
-            partition=0,
-            dataset="ds",
-            configuration="clf",
-            best_params={},
-            train_metrics={"mae_train": 0.1},
-            test_metrics={"mae_test": 0.1},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
-        ),
+        _make_result(),
         save_model=False,
     )
 
@@ -596,16 +542,7 @@ def test_hyperparameters_empty_params(tmp_path):
 def test_hyperparameters_seed_param_cannot_shadow_key(tmp_path):
     """A parameter literally named Seed cannot overwrite the Seed column."""
     Results(tmp_path).save(
-        _make_result(
-            partition=5,
-            dataset="ds",
-            configuration="clf",
-            best_params={"Seed": 999},
-            train_metrics={"mae_train": 0.1},
-            test_metrics={"mae_test": 0.1},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
-        ),
+        _make_result(partition=5, best_params={"Seed": 999}),
         save_model=False,
     )
 
@@ -662,10 +599,8 @@ def test_predictions_reads_the_requested_split(tmp_path):
     results = Results(tmp_path)
     results.save(
         _make_result(
-            partition=0,
             dataset="toy",
             configuration="conf_1",
-            best_params={},
             train_metrics={},
             test_metrics={},
             train_predicted_y=np.array([1, 2, 3, 3]),
@@ -691,10 +626,8 @@ def test_predictions_parse_proba(tmp_path):
     results = Results(tmp_path)
     results.save(
         _make_result(
-            partition=0,
             dataset="toy",
             configuration="conf_1",
-            best_params={},
             train_metrics={},
             test_metrics={},
             train_predicted_y=np.array([1, 2]),
@@ -717,10 +650,8 @@ def test_model_round_trips_the_bare_estimator(tmp_path):
     results = Results(tmp_path)
     results.save(
         _make_result(
-            partition=0,
             dataset="toy",
             configuration="conf_1",
-            best_params={},
             train_metrics={},
             test_metrics={},
             train_predicted_y=np.array([1, 2]),
@@ -818,14 +749,7 @@ def test_exists(tmp_path):
 
     r.save(
         _make_result(
-            partition=0,
-            dataset="toy",
-            configuration="SVC",
-            best_params={},
-            train_metrics={"mae_train": 0.1},
-            test_metrics={"mae_test": 0.2},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
+            dataset="toy", configuration="SVC", test_metrics={"mae_test": 0.2}
         ),
         save_model=False,
     )
@@ -847,22 +771,22 @@ def test_report_csv_index_label_and_numeric_order(tmp_path):
     r = Results(tmp_path)
     for partition in (10, 2, 1):
         r.save(
-            _make_result(
-                partition=partition,
-                dataset="ds",
-                configuration="clf",
-                best_params={},
-                train_metrics={"mae_train": 0.1},
-                test_metrics={"mae_test": 0.1},
-                train_predicted_y=np.array([1]),
-                test_predicted_y=np.array([1]),
-            ),
+            _make_result(partition=partition),
             save_model=False,
         )
     csv_path = tmp_path / "clf" / "ds" / "report.csv"
     assert csv_path.read_text().splitlines()[0].split(",")[0] == "resample_id"
     df = pd.read_csv(csv_path, index_col=0)
     assert list(df.index) == [1, 2, 10]
+
+
+def test_report_rows_fall_back_to_lexicographic_order(tmp_path):
+    """Non-integer resample ids sort as strings instead of failing the save."""
+    r = Results(tmp_path)
+    for partition in ("fold_b", "fold_a"):
+        r.save(_make_result(partition=partition), save_model=False)
+    df = pd.read_csv(tmp_path / "clf" / "ds" / "report.csv", index_col=0)
+    assert list(df.index) == ["fold_a", "fold_b"]
 
 
 def test_report_row_sort_preserves_pre_existing_duplicates(tmp_path):
@@ -882,13 +806,8 @@ def test_report_row_sort_preserves_pre_existing_duplicates(tmp_path):
     Results(tmp_path).save(
         _make_result(
             partition=2,
-            dataset="ds",
-            configuration="clf",
-            best_params={},
             train_metrics={"mae_train": 0.3},
             test_metrics={"mae_test": 0.3},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
         ),
         save_model=False,
     )
@@ -899,16 +818,7 @@ def test_save_removes_stale_artefacts(tmp_path):
     """Re-saving without a test split drops the prior run's test files and model."""
     r = Results(tmp_path)
     r.save(
-        _make_result(
-            partition=0,
-            dataset="ds",
-            configuration="clf",
-            best_params={},
-            train_metrics={"mae_train": 0.1},
-            test_metrics={"mae_test": 0.1},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
-        ),
+        _make_result(),
         save_model=True,
     )
     seed_dir = tmp_path / "clf" / "ds" / "predictions_by_seed" / "seed_0"
@@ -919,14 +829,7 @@ def test_save_removes_stale_artefacts(tmp_path):
 
     r.save(
         _make_result(
-            partition=0,
-            dataset="ds",
-            configuration="clf",
-            best_params={},
-            train_metrics={"mae_train": 0.2},
-            test_metrics={},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=None,
+            train_metrics={"mae_train": 0.2}, test_metrics={}, test_predicted_y=None
         ),
         save_model=False,
     )
@@ -938,6 +841,18 @@ def test_save_removes_stale_artefacts(tmp_path):
     assert df.shape[0] == 1
 
 
+def test_save_wraps_a_failing_stale_artefact_removal(tmp_path, monkeypatch):
+    """An OSError while clearing a prior run is wrapped with the failing dir."""
+    r = Results(tmp_path)
+    r.save(_make_result(), save_model=False)
+    monkeypatch.setattr(
+        "skordinal.experiments._results.shutil.rmtree",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("denied")),
+    )
+    with pytest.raises(OSError, match="Could not remove stale results"):
+        r.save(_make_result(), save_model=False)
+
+
 @pytest.mark.parametrize(
     "overrides, match",
     [
@@ -947,19 +862,7 @@ def test_save_removes_stale_artefacts(tmp_path):
 )
 def test_save_rejects_traversal_before_writing(tmp_path, overrides, match):
     """save raises on a traversal name or resample id and writes nothing."""
-    result = _make_result(
-        **{
-            "partition": 0,
-            "dataset": "ds",
-            "configuration": "clf",
-            "best_params": {},
-            "train_metrics": {"mae_train": 0.1},
-            "test_metrics": {"mae_test": 0.1},
-            "train_predicted_y": np.array([1]),
-            "test_predicted_y": np.array([1]),
-            **overrides,
-        }
-    )
+    result = _make_result(**overrides)
     with pytest.raises(ValueError, match=match):
         Results(tmp_path).save(result, save_model=False)
     assert list(tmp_path.iterdir()) == []
@@ -970,29 +873,15 @@ def test_report_row_round_trip_precision(tmp_path):
     value = 0.12345678901234566
     r = Results(tmp_path)
     r.save(
-        _make_result(
-            partition=0,
-            dataset="ds",
-            configuration="clf",
-            best_params={},
-            train_metrics={"mae_train": value},
-            test_metrics={"mae_test": 0.1},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
-        ),
+        _make_result(train_metrics={"mae_train": value}),
         save_model=False,
     )
     # Second save reads report.csv back through the round-trip reader
     r.save(
         _make_result(
             partition=1,
-            dataset="ds",
-            configuration="clf",
-            best_params={},
             train_metrics={"mae_train": 0.2},
             test_metrics={"mae_test": 0.2},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
         ),
         save_model=False,
     )
@@ -1004,27 +893,6 @@ def test_report_row_round_trip_precision(tmp_path):
     assert df.loc[0, "mae_train"] == value
 
 
-def test_resave_is_idempotent_no_duplicate_row(tmp_path):
-    """Re-saving the same resample keeps exactly one report row."""
-    r = Results(tmp_path)
-    for _ in range(2):
-        r.save(
-            _make_result(
-                partition=0,
-                dataset="ds",
-                configuration="clf",
-                best_params={},
-                train_metrics={"mae_train": 0.1},
-                test_metrics={"mae_test": 0.1},
-                train_predicted_y=np.array([1]),
-                test_predicted_y=np.array([1]),
-            ),
-            save_model=False,
-        )
-    df = pd.read_csv(tmp_path / "clf" / "ds" / "report.csv", index_col=0)
-    assert df.shape[0] == 1
-
-
 def test_orphan_temp_file_swept_on_save(tmp_path):
     """A leftover temp file under the pair dir is removed by save."""
     pair = tmp_path / "clf" / "ds"
@@ -1032,16 +900,7 @@ def test_orphan_temp_file_swept_on_save(tmp_path):
     stale = pair / f"{_TEMP_PREFIX}leftover.tmp"
     stale.write_text("junk")
     Results(tmp_path).save(
-        _make_result(
-            partition=0,
-            dataset="ds",
-            configuration="clf",
-            best_params={},
-            train_metrics={"mae_train": 0.1},
-            test_metrics={"mae_test": 0.1},
-            train_predicted_y=np.array([1]),
-            test_predicted_y=np.array([1]),
-        ),
+        _make_result(),
         save_model=False,
     )
     assert not stale.exists()
@@ -1050,47 +909,27 @@ def test_orphan_temp_file_swept_on_save(tmp_path):
 def test_crash_between_predictions_and_report_not_committed(tmp_path, monkeypatch):
     """A crash before the report write leaves exists() False; rerun fixes it."""
     r = Results(tmp_path)
-    kwargs = dict(
-        partition=0,
-        dataset="ds",
-        configuration="clf",
-        best_params={},
-        train_metrics={"mae_train": 0.1},
-        test_metrics={"mae_test": 0.1},
-        train_predicted_y=np.array([1]),
-        test_predicted_y=np.array([1]),
-    )
     monkeypatch.setattr(
         Results,
         "_append_report_row",
         lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("crash")),
     )
     with pytest.raises(RuntimeError):
-        r.save(_make_result(**kwargs), save_model=False)
+        r.save(_make_result(), save_model=False)
     # Predictions were written but no report row was committed
     seed = tmp_path / "clf" / "ds" / "predictions_by_seed" / "seed_0"
     assert (seed / "train_predictions.csv").is_file()
     assert r.exists("clf", "ds", "0") is False
     # A normal rerun commits the row
     monkeypatch.undo()
-    r.save(_make_result(**kwargs), save_model=False)
+    r.save(_make_result(), save_model=False)
     assert r.exists("clf", "ds", "0") is True
 
 
 def test_stale_report_row_uncommitted_on_crash_resave(tmp_path, monkeypatch):
     """Re-saving a resample uncommits its row; a crash leaves it uncommitted."""
     r = Results(tmp_path)
-    kwargs = dict(
-        partition=0,
-        dataset="ds",
-        configuration="clf",
-        best_params={},
-        train_metrics={"mae_train": 0.1},
-        test_metrics={"mae_test": 0.1},
-        train_predicted_y=np.array([1]),
-        test_predicted_y=np.array([1]),
-    )
-    r.save(_make_result(**kwargs), save_model=False)
+    r.save(_make_result(), save_model=False)
     assert r.exists("clf", "ds", "0") is True
     # Crash on re-save after the uncommit but before the recommit
     monkeypatch.setattr(
@@ -1099,34 +938,24 @@ def test_stale_report_row_uncommitted_on_crash_resave(tmp_path, monkeypatch):
         lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("crash")),
     )
     with pytest.raises(RuntimeError):
-        r.save(_make_result(**kwargs), save_model=False)
+        r.save(_make_result(), save_model=False)
     assert r.exists("clf", "ds", "0") is False
     monkeypatch.undo()
-    r.save(_make_result(**kwargs), save_model=False)
+    r.save(_make_result(), save_model=False)
     assert r.exists("clf", "ds", "0") is True
 
 
 def test_resave_crash_before_uncommit_leaves_prior_run_intact(tmp_path, monkeypatch):
     """A re-save that crashes at the uncommit deletes nothing from the prior run."""
     r = Results(tmp_path)
-    kwargs = dict(
-        partition=0,
-        dataset="ds",
-        configuration="clf",
-        best_params={},
-        train_metrics={"mae_train": 0.1},
-        test_metrics={"mae_test": 0.1},
-        train_predicted_y=np.array([1]),
-        test_predicted_y=np.array([1]),
-    )
-    r.save(_make_result(**kwargs), save_model=False)
+    r.save(_make_result(), save_model=False)
     monkeypatch.setattr(
         Results,
         "_uncommit_report_row",
         lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("crash")),
     )
     with pytest.raises(RuntimeError):
-        r.save(_make_result(**kwargs), save_model=False)
+        r.save(_make_result(), save_model=False)
     # The committed row must never outlive the files it describes
     assert r.exists("clf", "ds", "0") is True
     seed = tmp_path / "clf" / "ds" / "predictions_by_seed" / "seed_0"
@@ -1143,10 +972,8 @@ def test_save_composes_the_scaler_into_the_model_artefact(tmp_path):
     results = Results(tmp_path)
     results.save(
         _make_result(
-            partition=0,
             dataset="toy",
             configuration="conf_1",
-            best_params={},
             train_metrics={},
             test_metrics={},
             train_predicted_y=estimator.predict(scaler.transform(raw)),

--- a/skordinal/experiments/tests/test_results.py
+++ b/skordinal/experiments/tests/test_results.py
@@ -18,7 +18,6 @@ from skordinal.experiments import (
     Results,
 )
 from skordinal.experiments._io import _TEMP_PREFIX
-from skordinal.experiments._results import _write_split_files
 from skordinal.metrics import accuracy_score, mean_absolute_error
 
 
@@ -427,31 +426,6 @@ def test_save_writes_confusion_matrices(tmp_path):
     assert text.endswith("\n")
     body = text.split("\n", 2)[2].rstrip("\n")
     assert body == np.array2string(expected, separator=", ")
-
-
-def test_confusion_matrix_not_elided_for_many_classes(tmp_path):
-    """A large confusion matrix is written in full, without summarising."""
-    labels = np.arange(40)
-    _write_split_files(
-        tmp_path,
-        "train",
-        index=None,
-        true_y=labels,
-        predicted_y=labels,
-        proba=None,
-        classes=labels,
-        resample_id=0,
-    )
-
-    body = (
-        (tmp_path / "train_confusion_matrix.txt")
-        .read_text()
-        .split("\n", 2)[2]
-        .rstrip("\n")
-    )
-    assert "..." not in body
-    # Check the matrix keeps one physical line per row (no wrapping)
-    assert body.count("\n") == 39
 
 
 @pytest.mark.parametrize("with_indices", [False, True])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`Benchmark` and `Experiment` now validate `eval_metrics` and `tuning_metric` at construction. An unregistered name fails immediately, not mid-run. `Benchmark` also rejects model labels and dataset names that are not safe path components. `input_preprocessing` takes a transformer instance (e.g. `StandardScaler()`, a `Pipeline`) instead of the `"std"`/`"norm"` string tokens.

Also fixes three defects:

- Ordinal-distance metrics (e.g. `accuracy_off1_score`) now score against the model's full class set, so a split missing one class no longer looks adjacent to its neighbours.
- A searched float hyperparameter no longer collapses to an int in the saved CSV.
- The example `run_recipe.py`'s `--overwrite` flag, declared but never forwarded, now reaches the benchmark.

Progress reporting moves from `print` to `logging`, with an optional `tqdm` bar (`pip install skordinal[progress]`).

#### Any other comments?

Breaking: `input_preprocessing="std"` / `"norm"` are removed with no deprecation alias. Pass a transformer instance instead.