### PR TITLE
ENH: Add TOCUCO tests

### DIFF
--- a/skordinal/datasets/__init__.py
+++ b/skordinal/datasets/__init__.py
@@ -14,6 +14,7 @@ from ._loaders import (
     load_swd,
 )
 from ._samples_generator import make_ordinal_classification
+from ._tocuco import load_tocuco_partitions
 
 __all__ = [
     "clear_data_home",
@@ -26,4 +27,5 @@ __all__ = [
     "load_partitions",
     "load_swd",
     "make_ordinal_classification",
+    "load_tocuco_partitions",
 ]

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -655,6 +655,12 @@ def load_partitions(
     >>> for bunch in load_partitions("era", resamples=3):  # doctest: +SKIP
     ...     print(bunch.resample_id, bunch.data_train.shape[0])
     """
+    if str(name).startswith("tocuco"):
+        from ._tocuco import load_tocuco_partitions
+
+        return load_tocuco_partitions(name.replace("tocuco_", ""), resamples=resamples)
+        # return load_tocuco_partitions(name.replace("tocuco_", ""), data_home=str(Path(data_home)), resamples=resamples)
+
     csv_path, _ = _resolve_csv_path(name, data_home)
     if not csv_path.exists():
         raise FileNotFoundError(f"Dataset file not found: {csv_path}")

--- a/skordinal/datasets/_tocuco.py
+++ b/skordinal/datasets/_tocuco.py
@@ -1,0 +1,147 @@
+import json
+import tempfile
+import urllib.request
+from numbers import Integral
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+from sklearn.utils import Bunch
+
+
+def load_tocuco_partitions(
+    name,
+    *,
+    resamples=30,
+):
+    """Yield one train/test partition per resample for 'tocuco' style datasets.
+    This method downloads pre-computed train masks from a ``train_masks.json`` file
+    and the corresponding CSV dataset from the remote server to a temporary directory.
+    Once loaded into memory, the temporary files are automatically deleted. It then
+    applies a standard scaler to the features, and yields train/test splits accordingly.
+
+    Parameters
+    ----------
+    name : str or path-like
+        Dataset name (e.g. ``"dr04_forestfires"``) to be downloaded.
+
+    resamples : int or list of int, default=30
+        When an ``int``, resample IDs are ``range(resamples)``. When a
+        list, those IDs are used directly.
+
+    Yields
+    ------
+    bunch : ``sklearn.utils.Bunch``
+        Dictionary-like object with train/test datasets and metadata.
+
+    Raises
+    ------
+    urllib.error.URLError
+        When the dataset or mask file cannot be downloaded from the server.
+    KeyError
+        When a requested resample key does not exist in the mask file.
+    """
+
+    dataset_name = str(name)
+    base_url = f"https://www.uco.es/ayrna/tocuco/files/{dataset_name}"
+
+    csv_url = f"{base_url}/{dataset_name}.csv"
+    masks_url = f"{base_url}/train_masks.json"
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_path = Path(tmpdirname)
+
+        csv_path = tmp_path / f"{dataset_name}.csv"
+        masks_path = tmp_path / "train_masks.json"
+
+        try:
+            urllib.request.urlretrieve(csv_url, csv_path)
+            urllib.request.urlretrieve(masks_url, masks_path)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                raise ValueError(
+                    f"Dataset '{dataset_name}' not found. "
+                    f"Check that the name is correct (attempted URL: {csv_url})"
+                ) from None
+            raise RuntimeError(
+                f"HTTP error {e.code} while downloading dataset '{dataset_name}'."
+            ) from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(
+                f"Connection error while downloading dataset '{dataset_name}': {e.reason}"
+            ) from e
+
+        with open(csv_path, "r", encoding="utf-8", errors="ignore") as check_file:
+            first_chars = check_file.read(200).lower()
+            if "<html" in first_chars or "<!doctype" in first_chars:
+                raise ValueError(
+                    f"Dataset '{dataset_name}' not found. "
+                    f"The server returned an HTML web page instead of the dataset file. "
+                    f"Check that the name is correct (attempted URL: {csv_url})"
+                )
+
+        try:
+            dataset = pd.read_csv(csv_path)
+        except pd.errors.ParserError as e:
+            raise ValueError(
+                f"Could not parse the CSV file for '{dataset_name}'. The file might be corrupted."
+            ) from e
+
+        dataset = pd.read_csv(csv_path)
+
+        with open(masks_path, "r", encoding="utf-8") as f:
+            train_masks = json.load(f)
+
+    feature_names = list(dataset.drop(columns=["y"]).columns)
+    y = dataset["y"].values
+    target_names = np.unique(y).astype(str)
+    n_classes = len(target_names)
+
+    ids = list(range(resamples)) if isinstance(resamples, Integral) else list(resamples)
+
+    def _iter():
+        for resample_id in ids:
+            mask_key = str(resample_id)
+
+            if mask_key not in train_masks:
+                raise KeyError(f"Mask key '{mask_key}' not found in train_masks.json")
+
+            dataset_seed_train_mask = np.array(train_masks[mask_key], dtype=bool)
+
+            train = dataset.loc[dataset_seed_train_mask]
+            test = dataset.loc[~dataset_seed_train_mask]
+
+            X_train = train.drop(columns=["y"])
+            X_test = test.drop(columns=["y"])
+            y_train = train["y"].values
+            y_test = test["y"].values
+
+            scaler = StandardScaler()
+            X_train_scaled = scaler.fit_transform(X_train)
+            X_test_scaled = scaler.transform(X_test)
+
+            n_train = int(dataset_seed_train_mask.sum())
+            n_test = int((~dataset_seed_train_mask).sum())
+
+            yield Bunch(
+                data_train=X_train_scaled,
+                target_train=y_train,
+                data_test=X_test_scaled,
+                target_test=y_test,
+                feature_names=feature_names,
+                target_names=target_names,
+                dataset_name=dataset_name,
+                resample_id=int(resample_id),
+                train_index=np.flatnonzero(dataset_seed_train_mask),
+                test_index=np.flatnonzero(~dataset_seed_train_mask),
+                n_classes=n_classes,
+                DESCR=(
+                    f"{dataset_name} resample {resample_id}: "
+                    f"{n_train}/{n_test} samples, {n_classes} classes."
+                ),
+            )
+
+    return _iter()
+

--- a/skordinal/datasets/tests/test_tocuco.py
+++ b/skordinal/datasets/tests/test_tocuco.py
@@ -1,0 +1,365 @@
+"""Tests for the remote Tocuco dataset loader."""
+
+import json
+import urllib
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import numpy as np
+import pytest
+from sklearn.utils import Bunch
+
+from skordinal.datasets import load_partitions, load_tocuco_partitions
+
+_CSV = """\
+x_0,x_1,y
+1.0,10.0,0
+2.0,20.0,0
+3.0,30.0,1
+4.0,40.0,1
+5.0,50.0,2
+6.0,60.0,2
+"""
+_MASKS = {
+    "0": [True, True, True, False, False, False],
+    "1": [True, False, True, False, True, False],
+}
+_EXPECTED_BASE_URL = "https://www.uco.es/ayrna/tocuco/files/toy"
+
+
+def _fake_downloader(csv_content=_CSV, masks=_MASKS):
+    """Return a ``urlretrieve`` replacement backed by in-memory fixtures."""
+
+    def download(url, filename):
+        destination = Path(filename)
+        if url.endswith(".csv"):
+            destination.write_text(csv_content, encoding="utf-8")
+        else:
+            destination.write_text(json.dumps(masks), encoding="utf-8")
+        return str(destination), None
+
+    return download
+
+
+def test_load_tocuco_partitions_downloads_and_returns_valid_bunch(monkeypatch):
+    """A downloaded dataset produces scaled, disjoint train/test partitions."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    result = list(load_tocuco_partitions("toy", resamples=[0]))
+
+    assert len(result) == 1
+    bunch = result[0]
+    assert isinstance(bunch, Bunch)
+    assert bunch.dataset_name == "toy"
+    assert bunch.resample_id == 0
+    assert bunch.data_train.shape == (3, 2)
+    assert bunch.data_test.shape == (3, 2)
+    assert bunch.target_train.shape == (3,)
+    assert bunch.target_test.shape == (3,)
+    assert bunch.feature_names == ["x_0", "x_1"]
+    np.testing.assert_array_equal(bunch.target_names, ["0", "1", "2"])
+    assert bunch.n_classes == 3
+    assert np.isfinite(bunch.data_train).all()
+    assert np.isfinite(bunch.data_test).all()
+    np.testing.assert_array_equal(bunch.train_index, [0, 1, 2])
+    np.testing.assert_array_equal(bunch.test_index, [3, 4, 5])
+    assert set(bunch.train_index).isdisjoint(bunch.test_index)
+    np.testing.assert_allclose(bunch.data_train.mean(axis=0), 0)
+    assert "toy resample 0" in bunch.DESCR
+
+
+def test_load_tocuco_partitions_uses_expected_remote_files(monkeypatch):
+    """The loader downloads the dataset CSV and its keyed mask file."""
+    calls = []
+
+    def download(url, filename):
+        calls.append(url)
+        _fake_downloader()(url, filename)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", download
+    )
+
+    next(load_tocuco_partitions("toy", resamples=1))
+
+    assert calls == [
+        f"{_EXPECTED_BASE_URL}/toy.csv",
+        f"{_EXPECTED_BASE_URL}/train_masks.json",
+    ]
+
+
+def test_load_tocuco_partitions_accepts_count_and_selected_resamples(monkeypatch):
+    """An integer requests IDs from zero, while a sequence preserves its IDs."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    results = list(load_tocuco_partitions("toy", resamples=2))
+    selected = list(load_tocuco_partitions("toy", resamples=[1]))
+
+    assert [item.resample_id for item in results] == [0, 1]
+    assert [item.resample_id for item in selected] == [1]
+    np.testing.assert_array_equal(selected[0].train_index, [0, 2, 4])
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["toy", Path("toy")],
+    ids=["string_name", "path_like_name"],
+)
+def test_load_tocuco_partitions_normalizes_dataset_name(monkeypatch, name):
+    """String and path-like names produce the same metadata and URLs."""
+    calls = []
+
+    def download(url, filename):
+        calls.append(url)
+        _fake_downloader()(url, filename)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", download
+    )
+
+    bunch = next(load_tocuco_partitions(name, resamples=1))
+
+    assert bunch.dataset_name == "toy"
+    assert calls[0].endswith("/toy/toy.csv")
+
+
+def test_load_partitions_routes_tocuco_names(monkeypatch):
+    """The generic partition API removes the ``tocuco_`` prefix."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    result = next(load_partitions("tocuco_toy", resamples=1))
+
+    assert result.dataset_name == "toy"
+
+
+def test_load_tocuco_partitions_rejects_missing_resample(monkeypatch):
+    """A resample absent from the downloaded mask file raises ``KeyError``."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    with pytest.raises(KeyError, match="Mask key '2'"):
+        next(load_tocuco_partitions("toy", resamples=[2]))
+
+
+@pytest.mark.parametrize(
+    "masks",
+    [
+        {"0": [True] * 4 + [False]},
+        {"0": [True] * 7},
+        {"0": [True] * 6},
+    ],
+    ids=["short_mask", "long_mask", "all_train"],
+)
+def test_load_tocuco_partitions_does_not_accept_invalid_mask_shape(monkeypatch, masks):
+    """A mask must describe exactly one non-degenerate split per sample."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(masks=masks),
+    )
+
+    with pytest.raises((IndexError, ValueError)):
+        next(load_tocuco_partitions("toy", resamples=1))
+
+
+def test_load_tocuco_partitions_rejects_csv_without_target(monkeypatch):
+    """A downloaded CSV without the required ``y`` column is invalid."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(csv_content="x_0,x_1,label\n1,2,0\n3,4,1\n"),
+    )
+
+    with pytest.raises(KeyError, match="y"):
+        next(load_tocuco_partitions("toy", resamples=1))
+
+
+def test_load_tocuco_partitions_rejects_corrupt_csv(monkeypatch):
+    """Malformed CSV content is reported as a value error."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(csv_content="x_0,x_1,y\n1,2\nnot,csv,content,extra\n"),
+    )
+
+    with pytest.raises(ValueError):
+        next(load_tocuco_partitions("toy", resamples=1))
+
+
+def test_load_tocuco_partitions_rejects_corrupt_masks(monkeypatch):
+    """Invalid JSON in the mask download is not silently ignored."""
+
+    def corrupt_download(url, filename):
+        if url.endswith("train_masks.json"):
+            Path(filename).write_text("{not valid json", encoding="utf-8")
+        else:
+            _fake_downloader()(url, filename)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", corrupt_download
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        next(load_tocuco_partitions("toy", resamples=1))
+
+
+def test_load_tocuco_partitions_translates_non_404_http_error(monkeypatch):
+    """HTTP errors other than 404 are surfaced with their status code."""
+
+    def server_error(url, filename):
+        raise HTTPError(url, 503, "Unavailable", hdrs=None, fp=None)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", server_error
+    )
+
+    with pytest.raises(RuntimeError, match="HTTP error 503"):
+        next(load_tocuco_partitions("toy", resamples=1))
+
+
+def test_load_tocuco_partitions_downloads_masks_before_iteration(monkeypatch):
+    """Both remote files are loaded before the first partition is yielded."""
+    calls = []
+
+    def download(url, filename):
+        calls.append(url)
+        _fake_downloader()(url, filename)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", download
+    )
+
+    partitions = load_tocuco_partitions("toy", resamples=[0, 1])
+    assert len(calls) == 2
+    next(partitions)
+    assert len(calls) == 2
+
+
+def test_load_tocuco_partitions_scales_test_using_train_statistics(monkeypatch):
+    """Test features are transformed with the training scaler, not refit."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    bunch = next(load_tocuco_partitions("toy", resamples=1))
+
+    np.testing.assert_allclose(bunch.data_train.mean(axis=0), 0)
+    np.testing.assert_allclose(bunch.data_train.std(axis=0), 1)
+    assert not np.allclose(bunch.data_test.mean(axis=0), 0)
+
+
+def test_load_tocuco_partitions_preserves_original_targets(monkeypatch):
+    """Scaling changes features only; target values and row membership remain intact."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    bunch = next(load_tocuco_partitions("toy", resamples=1))
+
+    np.testing.assert_array_equal(bunch.target_train, [0, 0, 1])
+    np.testing.assert_array_equal(bunch.target_test, [1, 2, 2])
+    np.testing.assert_array_equal(
+        np.sort(np.concatenate((bunch.train_index, bunch.test_index))),
+        np.arange(6),
+    )
+
+
+def test_load_tocuco_partitions_rejects_html_dataset(monkeypatch):
+    """A successful HTTP response containing an error page is rejected."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(csv_content="<html>not found</html>\n"),
+    )
+
+    with pytest.raises(ValueError, match="HTML web page"):
+        next(load_tocuco_partitions("missing", resamples=1))
+
+
+def test_load_tocuco_partitions_translates_http_404(monkeypatch):
+    """A missing remote dataset has an actionable ``ValueError``."""
+
+    def not_found(url, filename):
+        raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", not_found
+    )
+
+    with pytest.raises(ValueError, match="Dataset 'missing' not found"):
+        next(load_tocuco_partitions("missing", resamples=1))
+
+
+def test_load_tocuco_partitions_translates_connection_error(monkeypatch):
+    """Network failures are surfaced as a runtime error with the reason."""
+
+    def unavailable(url, filename):
+        raise URLError("offline")
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", unavailable
+    )
+
+    with pytest.raises(RuntimeError, match="Connection error.*offline"):
+        next(load_tocuco_partitions("toy", resamples=1))
+
+
+@pytest.mark.network
+@pytest.mark.parametrize("name", ["dr04_forestfires", "oc03_newthyroid"])
+def test_real_tocuco_dataset_is_available_and_valid(name):
+    """Known Tocuco datasets can be downloaded and yield a usable partition."""
+    bunch = next(load_tocuco_partitions(name, resamples=1))
+
+    assert bunch.data_train.ndim == bunch.data_test.ndim == 2
+    assert bunch.data_train.shape[1] == bunch.data_test.shape[1]
+    assert bunch.target_train.shape == (bunch.data_train.shape[0],)
+    assert bunch.target_test.shape == (bunch.data_test.shape[0],)
+    assert bunch.n_classes >= 2
+    assert len(bunch.feature_names) == bunch.data_train.shape[1]
+    assert np.isfinite(bunch.data_train).all()
+    assert np.isfinite(bunch.data_test).all()
+    assert set(bunch.train_index).isdisjoint(bunch.test_index)
+
+
+@pytest.mark.network
+def test_real_tocuco_dataset_has_all_thirty_valid_resamples():
+    """The canonical Tocuco masks expose thirty complete holdout partitions."""
+    partitions = list(load_tocuco_partitions("dr04_forestfires", resamples=30))
+
+    assert [partition.resample_id for partition in partitions] == list(range(30))
+    for partition in partitions:
+        assert partition.data_train.shape[1] == partition.data_test.shape[1]
+        assert partition.data_train.shape[0] == partition.train_index.size
+        assert partition.data_test.shape[0] == partition.test_index.size
+        assert set(partition.train_index).isdisjoint(partition.test_index)
+        indices = np.sort(np.concatenate((partition.train_index, partition.test_index)))
+        np.testing.assert_array_equal(indices, np.arange(indices.size))
+        assert np.isfinite(partition.data_train).all()
+        assert np.isfinite(partition.data_test).all()
+
+
+@pytest.mark.network
+def test_real_tocuco_dataset_not_found():
+    """A request for a non-existent dataset on the real server is handled correctly."""
+    with pytest.raises((ValueError, urllib.error.HTTPError)):
+        next(load_tocuco_partitions("dataset_inventado_12345", resamples=1))
+
+
+@pytest.mark.network
+def test_real_tocuco_dataset_dtypes():
+    """Real datasets have float64 features and integer targets."""
+    bunch = next(load_tocuco_partitions("dr04_forestfires", resamples=1))
+
+    assert bunch.data_train.dtype == np.float64
+    assert bunch.data_test.dtype == np.float64
+    assert np.issubdtype(bunch.target_train.dtype, np.integer)
+    assert np.issubdtype(bunch.target_test.dtype, np.integer)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Adds a `pytest` test suite for the TOCUCO remote dataset loader (`_tocuco.py`). It uses `monkeypatch` to mock downloads, ensuring correct data splitting, scaling (preventing data leakage), and robust error handling (HTTP errors, corrupted files).

#### Any other comments?

Resolves #161 
