### PR TITLE
FIX: Clarify malformed mask file errors

### DIFF
--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -211,7 +211,21 @@ def _load_keyed_masks(csv_dir):
     ):
         if candidate.exists():
             with candidate.open("r", encoding="utf-8") as fh:
-                return json.load(fh)
+                try:
+                    keyed = json.load(fh)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Mask file {candidate} is not valid JSON: {exc}"
+                    ) from exc
+            # A payload like null or a bare list must not be mistaken for
+            # "no mask file", which would silently fall back to freshly
+            # generated holdout splits
+            if not isinstance(keyed, dict):
+                raise ValueError(
+                    f"Mask file {candidate} must hold a JSON object keyed "
+                    f"by '<stem>_seed_<k>'; got {type(keyed).__name__}."
+                )
+            return keyed
     return None
 
 
@@ -270,7 +284,17 @@ def _resolve_train_masks(csv_path, X, y, ids, test_size, random_state):
     per_dataset_path = csv_path.parent / f"{csv_path.stem}.masks.json"
     if per_dataset_path.exists():
         with per_dataset_path.open("r", encoding="utf-8") as fh:
-            masks_list = json.load(fh)
+            try:
+                masks_list = json.load(fh)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Mask file {per_dataset_path} is not valid JSON: {exc}"
+                ) from exc
+        if not isinstance(masks_list, list):
+            raise ValueError(
+                f"Mask file {per_dataset_path} must hold a JSON list of "
+                f"masks; got {type(masks_list).__name__}."
+            )
         masks = []
         for rid in ids:
             if not (0 <= rid < len(masks_list)):

--- a/skordinal/datasets/tests/test_base.py
+++ b/skordinal/datasets/tests/test_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 from pathlib import Path
 
@@ -613,6 +614,14 @@ def _setup_single_member_class(tmp_path):
     return name, {"resamples": 1}
 
 
+def _setup_malformed_mask_file(tmp_path, filename, content):
+    """Return args for a mask file written verbatim with ``content``."""
+    name = "ds_malformed_mask"
+    _write_csv(tmp_path, name)
+    (tmp_path / filename.format(name=name)).write_text(content, encoding="utf-8")
+    return name, {"resamples": 1}
+
+
 def _setup_short_per_dataset_masks(tmp_path):
     """Return args for short per-dataset-masks IndexError case."""
     name = "ds_short_masks"
@@ -629,6 +638,40 @@ def _setup_short_per_dataset_masks(tmp_path):
         (_setup_bad_mask, ValueError, "Mask for resample 0"),
         (_setup_missing_keyed_entry, KeyError, r"_seed_1"),
         (_setup_short_per_dataset_masks, IndexError, r"\.masks\.json"),
+        (
+            functools.partial(
+                _setup_malformed_mask_file,
+                filename="train_masks.json",
+                content=str({"seed_0": [True] * 14 + [False] * 6}),
+            ),
+            ValueError,
+            "is not valid JSON",
+        ),
+        (
+            functools.partial(
+                _setup_malformed_mask_file, filename="train_masks.json", content="null"
+            ),
+            ValueError,
+            "JSON object",
+        ),
+        (
+            functools.partial(
+                _setup_malformed_mask_file,
+                filename="{name}.masks.json",
+                content="{truncated",
+            ),
+            ValueError,
+            "is not valid JSON",
+        ),
+        (
+            functools.partial(
+                _setup_malformed_mask_file,
+                filename="{name}.masks.json",
+                content=json.dumps({"0": [True] * 14 + [False] * 6}),
+            ),
+            ValueError,
+            "JSON list",
+        ),
         (_setup_single_member_class, ValueError, "least populated"),
     ],
     ids=[
@@ -636,6 +679,10 @@ def _setup_short_per_dataset_masks(tmp_path):
         "mask-length-mismatch",
         "missing-keyed-entry",
         "short-per-dataset-masks",
+        "non-json-keyed-masks",
+        "null-keyed-masks",
+        "non-json-per-dataset-masks",
+        "dict-per-dataset-masks",
         "single-member-class",
     ],
 )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

`_load_keyed_masks` and `_resolve_train_masks` called `json.load` directly on `train_masks.json` and `<stem>.masks.json`, so a truncated file raised a bare `JSONDecodeError` naming neither file. A `train_masks.json` body of `null` parsed to `None`, indistinguishable from no mask file, so `load_partitions` silently fell back to a randomly generated holdout instead of the canonical partitions. Both readers now raise a `ValueError` naming the file and the expected JSON shape: an object for the keyed file, a list for the per-dataset file.