### PR TITLE
ENH: Load full TOC-UCO datasets

### DIFF
--- a/skordinal/datasets/__init__.py
+++ b/skordinal/datasets/__init__.py
@@ -14,7 +14,7 @@ from ._loaders import (
     load_swd,
 )
 from ._samples_generator import make_ordinal_classification
-from ._tocuco import load_tocuco_partitions
+from ._tocuco import load_tocuco_dataset, load_tocuco_partitions
 
 __all__ = [
     "clear_data_home",
@@ -28,4 +28,5 @@ __all__ = [
     "load_swd",
     "make_ordinal_classification",
     "load_tocuco_partitions",
+    "load_tocuco_dataset",
 ]

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -17,8 +17,6 @@ from sklearn.utils import Bunch, check_random_state
 from sklearn.utils._param_validation import Interval, validate_params
 from sklearn.utils.multiclass import check_classification_targets
 
-from ._tocuco import load_tocuco_dataset, load_tocuco_partitions
-
 DATA_MODULE = "skordinal.datasets.data"
 DESCR_MODULE = "skordinal.datasets.descr"
 
@@ -542,6 +540,8 @@ def load_dataset(name, *, data_home=None, return_X_y=False, as_frame=False):
     (1000, 4)
     """
     if str(name).startswith("tocuco"):
+        from ._tocuco import load_tocuco_dataset
+
         return load_tocuco_dataset(
             name=name.replace("tocuco_", ""), return_X_y=return_X_y, as_frame=as_frame
         )
@@ -687,6 +687,8 @@ def load_partitions(
     ...     print(bunch.resample_id, bunch.data_train.shape[0])
     """
     if str(name).startswith("tocuco"):
+        from ._tocuco import load_tocuco_partitions
+
         return load_tocuco_partitions(name.replace("tocuco_", ""), resamples=resamples)
 
     csv_path, _ = _resolve_csv_path(name, data_home)

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -539,6 +539,13 @@ def load_dataset(name, *, data_home=None, return_X_y=False, as_frame=False):
     >>> load_dataset("era", data_home="/my/data").data.shape  # doctest: +SKIP
     (1000, 4)
     """
+    if str(name).startswith("tocuco"):
+        from ._tocuco import load_tocuco_dataset
+
+        return load_tocuco_dataset(
+            name=name.replace("tocuco_", ""), return_X_y=return_X_y, as_frame=as_frame
+        )
+
     path, data_module_value = _resolve_csv_path(name, data_home)
     return _bunch_from_csv(
         path,

--- a/skordinal/datasets/_base.py
+++ b/skordinal/datasets/_base.py
@@ -17,6 +17,8 @@ from sklearn.utils import Bunch, check_random_state
 from sklearn.utils._param_validation import Interval, validate_params
 from sklearn.utils.multiclass import check_classification_targets
 
+from ._tocuco import load_tocuco_dataset, load_tocuco_partitions
+
 DATA_MODULE = "skordinal.datasets.data"
 DESCR_MODULE = "skordinal.datasets.descr"
 
@@ -540,8 +542,6 @@ def load_dataset(name, *, data_home=None, return_X_y=False, as_frame=False):
     (1000, 4)
     """
     if str(name).startswith("tocuco"):
-        from ._tocuco import load_tocuco_dataset
-
         return load_tocuco_dataset(
             name=name.replace("tocuco_", ""), return_X_y=return_X_y, as_frame=as_frame
         )
@@ -687,8 +687,6 @@ def load_partitions(
     ...     print(bunch.resample_id, bunch.data_train.shape[0])
     """
     if str(name).startswith("tocuco"):
-        from ._tocuco import load_tocuco_partitions
-
         return load_tocuco_partitions(name.replace("tocuco_", ""), resamples=resamples)
 
     csv_path, _ = _resolve_csv_path(name, data_home)

--- a/skordinal/datasets/_tocuco.py
+++ b/skordinal/datasets/_tocuco.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+import urllib.error
 import urllib.request
 from numbers import Integral
 from pathlib import Path
@@ -9,13 +10,74 @@ import pandas as pd
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import Bunch
 
+from skordinal.datasets._base import (
+    _convert_data_dataframe,
+    _read_csv_any,
+    _resolve_target_names,
+)
 
-def load_tocuco_partitions(
-    name,
-    *,
-    resamples=30,
-):
-    """Yield one train/test partition per resample for 'tocuco' style datasets.
+
+def _download_tocuco_dataset(dataset_name, filename, dest_dir):
+    """Download and validate a file from a TOC-UCO dataset.
+    A URL is constructed for a given TOC-UCO dataset and filename, downloads
+    the file to the specified destination directory, and performs a validation
+    to ensure the server did not return an HTML page instead of the expected data file.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of the dataset.
+    filename : str
+        The specific file to download.
+    dest_dir : pathlib.Path
+        The local directory path where the downloaded file should be saved.
+
+    Returns
+    -------
+    dest_path : pathlib.Path
+        The full path to the downloaded local file.
+
+    Raises
+    ------
+    ValueError
+        If the file is not found (404 error) or if the downloaded file appears
+        to be an HTML page rather than the expected raw data.
+    RuntimeError
+        If an HTTP error (other than 404) or a connection error occurs during download.
+    """
+    url = f"https://www.uco.es/ayrna/tocuco/files/{dataset_name}/{filename}"
+    dest_path = dest_dir / filename
+
+    try:
+        urllib.request.urlretrieve(url, dest_path)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            raise ValueError(
+                f"File '{filename}' for dataset '{dataset_name}' not found. "
+                f"Check that the name is correct (attempted URL: {url})"
+            ) from None
+        raise RuntimeError(
+            f"HTTP error {e.code} while downloading '{filename}' for dataset '{dataset_name}'."
+        ) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"Connection error while downloading '{filename}' for dataset '{dataset_name}': {e.reason}"
+        ) from e
+
+    with open(dest_path, "r", encoding="utf-8", errors="ignore") as check_file:
+        first_chars = check_file.read(200).lower()
+        if "<html" in first_chars or "<!doctype" in first_chars:
+            raise ValueError(
+                f"File '{filename}' for dataset '{dataset_name}' not found. "
+                f"The server returned an HTML web page instead of the valid file. "
+                f"(attempted URL: {url})"
+            )
+
+    return dest_path
+
+
+def load_tocuco_partitions(name, *, resamples=30):
+    """Yield one train/test partition per resample for `TOC-UCO` datasets.
     This method downloads pre-computed train masks from a ``train_masks.json`` file
     and the corresponding CSV dataset from the remote server to a temporary directory.
     Once loaded into memory, the temporary files are automatically deleted. It then
@@ -42,44 +104,17 @@ def load_tocuco_partitions(
     KeyError
         When a requested resample key does not exist in the mask file.
     """
-
     dataset_name = str(name)
-    base_url = f"https://www.uco.es/ayrna/tocuco/files/{dataset_name}"
-
-    csv_url = f"{base_url}/{dataset_name}.csv"
-    masks_url = f"{base_url}/train_masks.json"
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmp_path = Path(tmpdirname)
 
-        csv_path = tmp_path / f"{dataset_name}.csv"
-        masks_path = tmp_path / "train_masks.json"
-
-        try:
-            urllib.request.urlretrieve(csv_url, csv_path)
-            urllib.request.urlretrieve(masks_url, masks_path)
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                raise ValueError(
-                    f"Dataset '{dataset_name}' not found. "
-                    f"Check that the name is correct (attempted URL: {csv_url})"
-                ) from None
-            raise RuntimeError(
-                f"HTTP error {e.code} while downloading dataset '{dataset_name}'."
-            ) from e
-        except urllib.error.URLError as e:
-            raise RuntimeError(
-                f"Connection error while downloading dataset '{dataset_name}': {e.reason}"
-            ) from e
-
-        with open(csv_path, "r", encoding="utf-8", errors="ignore") as check_file:
-            first_chars = check_file.read(200).lower()
-            if "<html" in first_chars or "<!doctype" in first_chars:
-                raise ValueError(
-                    f"Dataset '{dataset_name}' not found. "
-                    f"The server returned an HTML web page instead of the dataset file. "
-                    f"Check that the name is correct (attempted URL: {csv_url})"
-                )
+        csv_path = _download_tocuco_dataset(
+            dataset_name, f"{dataset_name}.csv", tmp_path
+        )
+        masks_path = _download_tocuco_dataset(
+            dataset_name, "train_masks.json", tmp_path
+        )
 
         try:
             dataset = pd.read_csv(csv_path)
@@ -87,8 +122,6 @@ def load_tocuco_partitions(
             raise ValueError(
                 f"Could not parse the CSV file for '{dataset_name}'. The file might be corrupted."
             ) from e
-
-        dataset = pd.read_csv(csv_path)
 
         with open(masks_path, "r", encoding="utf-8") as f:
             train_masks = json.load(f)
@@ -143,3 +176,95 @@ def load_tocuco_partitions(
             )
 
     return _iter()
+
+
+def load_tocuco_dataset(name, *, return_X_y=False, as_frame=False):
+    """Load a `TOC-UCO` dataset by name.
+
+    This method downloads the corresponding CSV dataset.
+    Once loaded into memory, the temporary files are automatically deleted.
+    It returns the data using the exact same structure as ``load_dataset``.
+
+    Parameters
+    ----------
+    name : str or path-like
+        Dataset name (e.g. ``"dr04_forestfires"``) to be downloaded.
+
+    return_X_y : bool, default=False
+        If ``True``, returns ``(data, target)`` instead of a Bunch.
+
+    as_frame : bool, default=False
+        If ``True``, ``data`` is a ``pandas.DataFrame`` and ``target``
+        is a ``pandas.Series``.
+
+    Returns
+    -------
+    bunch : ``sklearn.utils.Bunch``
+        Object with the following attributes.
+
+        data : ndarray of shape (n_samples, n_features)
+            Feature matrix (float64). A DataFrame when ``as_frame`` is True.
+        target : ndarray of shape (n_samples,)
+            Integer target labels (int64). A Series when ``as_frame`` is True.
+        frame : DataFrame or None
+            Combined frame when ``as_frame`` is True; otherwise ``None``.
+        feature_names : list of str
+            One name per feature column.
+        target_names : ndarray of str
+            Class names from the metadata header when present; otherwise
+            the sorted unique target values as strings.
+        n_classes : int
+            Number of distinct classes.
+        DESCR : str
+            Human-readable description generated automatically.
+        filename : str
+            Basename of the CSV file.
+        data_module : str or None
+            Always ``None`` for datasets downloaded from the web.
+
+    (data, target) : tuple if ``return_X_y`` is True
+
+    Raises
+    ------
+    urllib.error.URLError
+        When the dataset cannot be downloaded from the server.
+    ValueError
+        When the server returns an HTML page (e.g. 404 page or redirect) instead of a CSV.
+    """
+    dataset_name = str(name)
+    filename = f"{dataset_name}.csv"
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_path = Path(tmpdirname)
+
+        csv_path = _download_tocuco_dataset(dataset_name, filename, tmp_path)
+
+        data, target, feature_names, header_class_names = _read_csv_any(csv_path)
+        target_names = _resolve_target_names(header_class_names, target)
+        n_classes = len(target_names)
+
+        descr = (
+            f"TOC-UCO Dataset '{dataset_name}': {data.shape[0]} samples, "
+            f"{data.shape[1]} features, {n_classes} classes."
+        )
+
+    frame = None
+    if as_frame:
+        frame, data, target = _convert_data_dataframe(
+            "load_tocuco_dataset", data, target, feature_names, ["target"]
+        )
+
+    if return_X_y:
+        return data, target
+
+    return Bunch(
+        data=data,
+        target=target,
+        frame=frame,
+        feature_names=feature_names,
+        target_names=target_names,
+        n_classes=n_classes,
+        DESCR=descr,
+        filename=filename,
+        data_module=None,
+    )

--- a/skordinal/datasets/_tocuco.py
+++ b/skordinal/datasets/_tocuco.py
@@ -10,12 +10,6 @@ import pandas as pd
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import Bunch
 
-from ._base import (
-    _convert_data_dataframe,
-    _read_csv_any,
-    _resolve_target_names,
-)
-
 
 def _download_tocuco_dataset(dataset_name, filename, dest_dir):
     """Download and validate a file from a TOC-UCO dataset.
@@ -231,6 +225,8 @@ def load_tocuco_dataset(name, *, return_X_y=False, as_frame=False):
     ValueError
         When the server returns an HTML page (e.g. 404 page or redirect) instead of a CSV.
     """
+    from ._base import _convert_data_dataframe, _read_csv_any, _resolve_target_names
+
     dataset_name = str(name)
     filename = f"{dataset_name}.csv"
 

--- a/skordinal/datasets/_tocuco.py
+++ b/skordinal/datasets/_tocuco.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from _base import (
+from ._base import (
     _convert_data_dataframe,
     _read_csv_any,
     _resolve_target_names,

--- a/skordinal/datasets/_tocuco.py
+++ b/skordinal/datasets/_tocuco.py
@@ -7,14 +7,13 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import StandardScaler
-from sklearn.utils import Bunch
-
-from skordinal.datasets._base import (
+from _base import (
     _convert_data_dataframe,
     _read_csv_any,
     _resolve_target_names,
 )
+from sklearn.preprocessing import StandardScaler
+from sklearn.utils import Bunch
 
 
 def _download_tocuco_dataset(dataset_name, filename, dest_dir):

--- a/skordinal/datasets/_tocuco.py
+++ b/skordinal/datasets/_tocuco.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from sklearn.preprocessing import StandardScaler
+from sklearn.utils import Bunch
+
 from ._base import (
     _convert_data_dataframe,
     _read_csv_any,
     _resolve_target_names,
 )
-from sklearn.preprocessing import StandardScaler
-from sklearn.utils import Bunch
 
 
 def _download_tocuco_dataset(dataset_name, filename, dest_dir):

--- a/skordinal/datasets/tests/test_tocuco.py
+++ b/skordinal/datasets/tests/test_tocuco.py
@@ -9,7 +9,11 @@ import numpy as np
 import pytest
 from sklearn.utils import Bunch
 
-from skordinal.datasets import load_partitions, load_tocuco_partitions
+from skordinal.datasets import (
+    load_partitions,
+    load_tocuco_dataset,
+    load_tocuco_partitions,
+)
 
 _CSV = """\
 x_0,x_1,y
@@ -295,7 +299,7 @@ def test_load_tocuco_partitions_translates_http_404(monkeypatch):
         "skordinal.datasets._tocuco.urllib.request.urlretrieve", not_found
     )
 
-    with pytest.raises(ValueError, match="Dataset 'missing' not found"):
+    with pytest.raises(ValueError, match="dataset 'missing' not found"):
         next(load_tocuco_partitions("missing", resamples=1))
 
 
@@ -363,3 +367,149 @@ def test_real_tocuco_dataset_dtypes():
     assert bunch.data_test.dtype == np.float64
     assert np.issubdtype(bunch.target_train.dtype, np.integer)
     assert np.issubdtype(bunch.target_test.dtype, np.integer)
+
+
+def test_load_tocuco_dataset_downloads_and_returns_valid_bunch(monkeypatch):
+    """A downloaded dataset produces a standard Bunch."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    bunch = load_tocuco_dataset("toy")
+
+    assert isinstance(bunch, Bunch)
+    assert bunch.data.shape == (6, 2)
+    assert bunch.target.shape == (6,)
+    assert bunch.feature_names == ["x_0", "x_1"]
+    np.testing.assert_array_equal(bunch.target_names, ["0", "1", "2"])
+    assert bunch.n_classes == 3
+    assert bunch.filename == "toy.csv"
+    assert bunch.data_module is None
+    assert bunch.frame is None
+    assert "TOC-UCO Dataset 'toy': 6 samples, 2 features, 3 classes" in bunch.DESCR
+
+
+def test_load_tocuco_dataset_return_X_y(monkeypatch):
+    """The return_X_y parameter yields exactly a (data, target) tuple."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    result = load_tocuco_dataset("toy", return_X_y=True)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    X, y = result
+    assert X.shape == (6, 2)
+    assert y.shape == (6,)
+
+
+def test_load_tocuco_dataset_as_frame(monkeypatch):
+    """The as_frame parameter wraps the dataset into pandas objects."""
+    import pandas as pd
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(),
+    )
+
+    bunch = load_tocuco_dataset("toy", as_frame=True)
+
+    assert isinstance(bunch.frame, pd.DataFrame)
+    assert isinstance(bunch.data, pd.DataFrame)
+    assert isinstance(bunch.target, pd.Series)
+    assert bunch.frame.shape == (6, 3)
+    assert list(bunch.data.columns) == ["x_0", "x_1"]
+    assert bunch.target.name == "target"
+
+
+def test_load_tocuco_dataset_uses_expected_remote_files(monkeypatch):
+    """The loader downloads only the dataset CSV, not the mask file."""
+    calls = []
+
+    def download(url, filename):
+        calls.append(url)
+        _fake_downloader()(url, filename)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", download
+    )
+
+    load_tocuco_dataset("toy")
+
+    assert calls == [f"{_EXPECTED_BASE_URL}/toy.csv"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["toy", Path("toy")],
+    ids=["string_name", "path_like_name"],
+)
+def test_load_tocuco_dataset_normalizes_dataset_name(monkeypatch, name):
+    """String and path-like names produce the same dataset."""
+    calls = []
+
+    def download(url, filename):
+        calls.append(url)
+        _fake_downloader()(url, filename)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", download
+    )
+
+    bunch = load_tocuco_dataset(name)
+
+    assert bunch.filename == "toy.csv"
+    assert calls[0].endswith("/toy/toy.csv")
+
+
+def test_load_tocuco_dataset_rejects_html_dataset(monkeypatch):
+    """A successful HTTP response containing an error page is rejected."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(csv_content="<html>not found</html>\n"),
+    )
+
+    with pytest.raises(ValueError, match="HTML web page"):
+        load_tocuco_dataset("missing")
+
+
+def test_load_tocuco_dataset_translates_http_404(monkeypatch):
+    """A missing remote dataset raises a clear ValueError for the user."""
+
+    def not_found(url, filename):
+        raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve", not_found
+    )
+
+    with pytest.raises(ValueError, match="not found"):
+        load_tocuco_dataset("missing")
+
+
+def test_load_tocuco_dataset_rejects_corrupt_csv(monkeypatch):
+    """Malformed CSV content raises a parsing error."""
+    monkeypatch.setattr(
+        "skordinal.datasets._tocuco.urllib.request.urlretrieve",
+        _fake_downloader(csv_content="x_0,x_1,y\n1,2\nnot,csv,content,extra\n"),
+    )
+
+    with pytest.raises(ValueError):
+        load_tocuco_dataset("toy")
+
+
+@pytest.mark.network
+@pytest.mark.parametrize("name", ["dr04_forestfires", "oc03_newthyroid"])
+def test_real_tocuco_dataset_load_dataset_is_available(name):
+    """A real Tocuco dataset can be downloaded as a full bunch without partitions."""
+    bunch = load_tocuco_dataset(name)
+
+    assert bunch.data.ndim == 2
+    assert bunch.target.shape == (bunch.data.shape[0],)
+    assert bunch.n_classes >= 2
+    assert len(bunch.feature_names) == bunch.data.shape[1]
+    assert np.isfinite(bunch.data).all()
+    assert np.issubdtype(bunch.target.dtype, np.integer)


### PR DESCRIPTION
#### Reference Issues/PRs

Follows #162 and resolves #167

#### What does this implement/fix? Explain your changes

Adds support for downloading full TOC-UCO datasets directly through `load_dataset` by using the `tocuco_` prefix. It also includes tests to ensure robust handling of network errors, missing files, and corrupted CSVs.