### PR TITLE
CI: Harden the docs, coverage and lint workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Docs
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Build the documentation
+        run: sphinx-build -b html -W docs docs/_build/html

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,10 +31,10 @@ jobs:
           pip install "ruff>=0.4" "mypy>=1.9" pytest
 
       - name: Ruff check
-        run: ruff check skordinal/
+        run: ruff check .
 
       - name: Ruff format
-        run: ruff format --check skordinal/
+        run: ruff format --check .
 
       - name: mypy
         run: mypy skordinal/

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,11 +26,6 @@ jobs:
           # Python 3.14 is a pre-release, skip macOS until it reaches GA
           - os: macos-latest
             python-version: "3.14"
-        include:
-          # Extra job: verify compatibility with NumPy 2.x.
-          - os: ubuntu-latest
-            python-version: "3.12"
-            numpy-constraint: ">=2.0,<3"
     steps:
       - uses: actions/checkout@v7
 
@@ -44,9 +39,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-          if [ -n "${{ matrix.numpy-constraint }}" ]; then
-            pip install "numpy${{ matrix.numpy-constraint }}"
-          fi
 
       - name: Run tests
         run: pytest -m "not network"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           disable_search: true
           fail_ci_if_error: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 python:
   install:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

Hardens the docs, coverage and lint workflows:

- Adds a docs-build workflow running `sphinx-build -b html -W`, plus the matching `fail_on_warning: true` in `.readthedocs.yaml`. Only a warning-level issue, such as an unresolved cross-reference, needs `-W` to fail the build. A raising gallery example already fails without it.
- Passes a Codecov upload token to the coverage job.
- Drops a NumPy 2.x pin merged into the ubuntu/3.12 job: every interpreter in the matrix already resolves NumPy 2.x by default, so it tested nothing extra.
- Widens `ruff check`/`ruff format` in CI to the whole repo, matching `.pre-commit-config.yaml`'s scope.