### PR TITLE
ENH: Add MLP base class and tests

### DIFF
--- a/skordinal/classifiers/_mlp_base.py
+++ b/skordinal/classifiers/_mlp_base.py
@@ -1,0 +1,209 @@
+"""Base class for Multi-Layer Perceptron classifiers."""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+import scipy.optimize
+from numbers import Integral, Real
+
+from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
+from sklearn.utils import compute_sample_weight, check_random_state
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from skordinal.utils.validation import check_ordinal_targets
+
+
+class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
+    """Base class for Multi-Layer Perceptron classifiers.
+
+    Parameters
+    ----------
+    n_hidden_layers : int, default=1
+        Number of hidden layers in the network.
+        
+    n_hidden_units : int, default=64
+        Number of neurons per hidden layer.
+        
+    alpha : float, default=0.01
+        L2 regularization parameter.
+        
+    class_weight : dict, "balanced", or None, default=None
+        Weights associated with classes. 
+        
+    max_iter : int, default=500
+        Maximum number of iterations for the solver.
+        
+    random_state : int, RandomState instance or None, default=None
+        Determines random number generation for weight initialization.
+        
+    verbose : bool, default=False
+        Whether to print progress messages to stdout during training.
+    """
+
+    _parameter_constraints: dict = {
+        "n_hidden_layers": [Interval(Integral, 1, None, closed="left")],
+        "n_hidden_units": [Interval(Integral, 1, None, closed="left")],
+        "alpha": [Interval(Real, 0.0, None, closed="left")],
+        "class_weight": [None, dict, StrOptions({"balanced"})],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
+        "random_state": ["random_state", None],
+        "verbose": ["boolean"],
+    }
+
+    def __init__(
+        self,
+        n_hidden_layers=1,
+        n_hidden_units=64,
+        alpha=0.01,
+        class_weight=None,
+        max_iter=500,
+        random_state=None,
+        verbose=False,
+    ):
+        self.n_hidden_layers = n_hidden_layers
+        self.n_hidden_units = n_hidden_units
+        self.alpha = alpha
+        self.class_weight = class_weight
+        self.max_iter = max_iter
+        self.random_state = random_state
+        self.verbose = verbose
+
+    @abstractmethod
+    def _initialize_parameters(self, rng: np.random.RandomState) -> np.ndarray:
+        """Initialize and return all network weights as a single 1D array.
+        
+        Parameters
+        ----------
+        rng : RandomState instance
+            Random number generator for reproducible weight initialization.
+        """
+        pass
+
+    @abstractmethod
+    def _unpack_parameters(self, params: np.ndarray):
+        """Unpack the 1D parameter array into specific layer weights/biases."""
+        pass
+
+    @abstractmethod
+    def _cost_and_grad(
+        self, 
+        params: np.ndarray, 
+        X: np.ndarray, 
+        Y: np.ndarray, 
+        sample_weight: np.ndarray
+    ) -> tuple[float, np.ndarray]:
+        """Compute the cost and gradients.
+        
+        Parameters
+        ----------
+        params : ndarray
+            1D array containing all unconstrained parameters.
+        X : ndarray of shape (n_samples, n_features)
+            Training data.
+        Y : ndarray of shape (n_samples, n_classes)
+            Target matrix.
+        sample_weight : ndarray of shape (n_samples,)
+            Sample weights.
+
+        Returns
+        -------
+        J : float
+            The scalar cost (loss + L2 penalty).
+        grad : ndarray
+            The gradient of the cost with respect to all parameters (1D array).
+        """
+        pass
+
+    @abstractmethod
+    def _predict_proba(self, X: np.ndarray) -> np.ndarray:
+        """Compute class probabilities using the optimized parameters (internal)."""
+        pass
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y):
+        """Fit the model using L-BFGS-B optimizer.
+        
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The training input samples.
+            
+        y : array-like of shape (n_samples,)
+            The target values (class labels).
+            
+        Returns
+        -------
+        self : object
+            Returns a fitted instance of self.
+        """
+        X, y = validate_data(self, X=X, y=y, reset=True)
+        
+        self.classes_, y_encoded = check_ordinal_targets(y)
+        
+        self.num_classes_ = len(self.classes_)
+        self.input_shape_ = X.shape[1]
+        n_samples = X.shape[0]
+
+        Y_target = np.zeros((n_samples, self.num_classes_))
+        Y_target[np.arange(n_samples), y_encoded] = 1.0
+
+        sample_weight = np.ones(n_samples)
+        if self.class_weight is not None:
+            sw = compute_sample_weight(class_weight=self.class_weight, y=y)
+            sample_weight *= sw
+
+        rng = check_random_state(self.random_state)
+        
+        params0 = self._initialize_parameters(rng)
+
+        res = scipy.optimize.minimize(
+            fun=self._cost_and_grad,
+            x0=params0,
+            args=(X, Y_target, sample_weight),
+            method="L-BFGS-B",
+            jac=True,
+            options={"maxiter": self.max_iter, "disp": self.verbose},
+        )
+
+        self.loss_ = res.fun
+        self.n_iter_ = res.nit
+
+        self._unpack_parameters(res.x)
+
+        return self
+
+    def predict_proba(self, X):
+        """Predict class probabilities for X.
+        
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+            
+        Returns
+        -------
+        p : ndarray of shape (n_samples, n_classes)
+            The class probabilities.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X=X, reset=False)
+        return self._predict_proba(X)
+
+    def predict(self, X):
+        """Predict the class for the samples in X.
+        
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+            
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            The predicted classes.
+        """
+        probas = self.predict_proba(X)
+        indices = np.argmax(probas, axis=1)
+        
+        return self.classes_[indices]

--- a/skordinal/classifiers/_mlp_base.py
+++ b/skordinal/classifiers/_mlp_base.py
@@ -162,7 +162,7 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
             args=(X, Y_target, sample_weight),
             method="L-BFGS-B",
             jac=True,
-            options={"maxiter": self.max_iter, "disp": self.verbose},
+            options={"maxiter": self.max_iter},
         )
 
         self.loss_ = res.fun

--- a/skordinal/classifiers/_mlp_base.py
+++ b/skordinal/classifiers/_mlp_base.py
@@ -1,14 +1,13 @@
 """Base class for Multi-Layer Perceptron classifiers."""
 
 from abc import ABC, abstractmethod
+from numbers import Integral, Real
 
 import numpy as np
 import scipy.optimize
-from numbers import Integral, Real
-
-from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
-from sklearn.utils import compute_sample_weight, check_random_state
+from sklearn.utils import check_random_state, compute_sample_weight
+from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 from skordinal.utils.validation import check_ordinal_targets
@@ -21,22 +20,22 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
     ----------
     n_hidden_layers : int, default=1
         Number of hidden layers in the network.
-        
+
     n_hidden_units : int, default=64
         Number of neurons per hidden layer.
-        
+
     alpha : float, default=0.01
         L2 regularization parameter.
-        
+
     class_weight : dict, "balanced", or None, default=None
-        Weights associated with classes. 
-        
+        Weights associated with classes.
+
     max_iter : int, default=500
         Maximum number of iterations for the solver.
-        
+
     random_state : int, RandomState instance or None, default=None
         Determines random number generation for weight initialization.
-        
+
     verbose : bool, default=False
         Whether to print progress messages to stdout during training.
     """
@@ -72,7 +71,7 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
     @abstractmethod
     def _initialize_parameters(self, rng: np.random.RandomState) -> np.ndarray:
         """Initialize and return all network weights as a single 1D array.
-        
+
         Parameters
         ----------
         rng : RandomState instance
@@ -87,14 +86,14 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
 
     @abstractmethod
     def _cost_and_grad(
-        self, 
-        params: np.ndarray, 
-        X: np.ndarray, 
-        Y: np.ndarray, 
-        sample_weight: np.ndarray
+        self,
+        params: np.ndarray,
+        X: np.ndarray,
+        Y: np.ndarray,
+        sample_weight: np.ndarray,
     ) -> tuple[float, np.ndarray]:
         """Compute the cost and gradients.
-        
+
         Parameters
         ----------
         params : ndarray
@@ -123,24 +122,24 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y):
         """Fit the model using L-BFGS-B optimizer.
-        
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The training input samples.
-            
+
         y : array-like of shape (n_samples,)
             The target values (class labels).
-            
+
         Returns
         -------
         self : object
             Returns a fitted instance of self.
         """
         X, y = validate_data(self, X=X, y=y, reset=True)
-        
+
         self.classes_, y_encoded = check_ordinal_targets(y)
-        
+
         self.num_classes_ = len(self.classes_)
         self.input_shape_ = X.shape[1]
         n_samples = X.shape[0]
@@ -154,7 +153,7 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
             sample_weight *= sw
 
         rng = check_random_state(self.random_state)
-        
+
         params0 = self._initialize_parameters(rng)
 
         res = scipy.optimize.minimize(
@@ -175,12 +174,12 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
 
     def predict_proba(self, X):
         """Predict class probabilities for X.
-        
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The input data.
-            
+
         Returns
         -------
         p : ndarray of shape (n_samples, n_classes)
@@ -192,12 +191,12 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
 
     def predict(self, X):
         """Predict the class for the samples in X.
-        
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The input data.
-            
+
         Returns
         -------
         y_pred : ndarray of shape (n_samples,)
@@ -205,5 +204,5 @@ class MLPBaseClassifier(ClassifierMixin, BaseEstimator, ABC):
         """
         probas = self.predict_proba(X)
         indices = np.argmax(probas, axis=1)
-        
+
         return self.classes_[indices]

--- a/skordinal/classifiers/tests/test_mlp_base.py
+++ b/skordinal/classifiers/tests/test_mlp_base.py
@@ -1,0 +1,157 @@
+"""Tests for the shared MLP classifier base class."""
+
+import numpy as np
+import pytest
+from scipy.special import softmax
+from sklearn.exceptions import NotFittedError
+
+from skordinal.classifiers._mlp_base import MLPBaseClassifier
+
+
+class DummyMLP(MLPBaseClassifier):
+    """Small implementation used to test the base class."""
+
+    last_sample_weight = None
+
+    def _initialize_parameters(self, rng):
+        return rng.normal(size=self.input_shape_ * self.num_classes_)
+
+    def _unpack_parameters(self, params):
+        self.weights_ = params.reshape(self.input_shape_, self.num_classes_)
+
+    def _cost_and_grad(self, params, X, Y, sample_weight):
+        type(self).last_sample_weight = sample_weight.copy()
+        return 0.5 * np.dot(params, params), params.copy()
+
+    def _predict_proba(self, X):
+        return softmax(X @ self.weights_, axis=1)
+
+
+@pytest.fixture
+def data():
+    """Return a small ordinal classification dataset."""
+    X = np.array([[0.0, 1.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]])
+    y = np.array([10, 20, 30, 20])
+    return X, y
+
+
+def test_fit_returns_self_and_sets_fitted_attributes(data):
+    """Fitting returns the estimator and exposes the shared fitted state."""
+    X, y = data
+
+    estimator = DummyMLP(max_iter=10, random_state=0)
+    clf = estimator.fit(X, y)
+
+    assert clf is estimator
+    assert clf.classes_.tolist() == [10, 20, 30]
+    assert clf.num_classes_ == 3
+    assert clf.input_shape_ == X.shape[1]
+    assert np.isfinite(clf.loss_)
+    assert clf.n_iter_ >= 0
+    assert clf.weights_.shape == (X.shape[1], len(clf.classes_))
+
+
+def test_fit_preserves_original_labels_in_predict(data):
+    """Predictions use the original ordinal labels rather than encoded indices."""
+    X, y = data
+
+    clf = DummyMLP(max_iter=1, random_state=0).fit(X, y)
+
+    assert set(clf.predict(X)).issubset(set(y))
+
+
+def test_predict_proba_has_valid_shape_and_values(data):
+    """Predicted probabilities have one valid distribution per sample."""
+    X, y = data
+
+    proba = DummyMLP(max_iter=1, random_state=0).fit(X, y).predict_proba(X)
+
+    assert proba.shape == (len(X), len(np.unique(y)))
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0)
+    assert np.all((proba >= 0.0) & (proba <= 1.0))
+
+
+def test_predict_before_fit_raises(data):
+    """Prediction methods reject an unfitted estimator."""
+    X, _ = data
+    clf = DummyMLP()
+
+    with pytest.raises(NotFittedError):
+        clf.predict(X)
+    with pytest.raises(NotFittedError):
+        clf.predict_proba(X)
+
+
+def test_predict_rejects_wrong_number_of_features(data):
+    """Prediction validates the feature count seen during fitting."""
+    X, y = data
+    clf = DummyMLP(max_iter=1).fit(X, y)
+
+    with pytest.raises(ValueError):
+        clf.predict(X[:, :1])
+
+
+def test_random_state_reproduces_initialization(data):
+    """The same random state produces the same fitted parameters."""
+    X, y = data
+
+    first = DummyMLP(max_iter=1, random_state=42).fit(X, y)
+    second = DummyMLP(max_iter=1, random_state=42).fit(X, y)
+
+    np.testing.assert_array_equal(first.weights_, second.weights_)
+
+
+@pytest.mark.parametrize(
+    "parameter, value",
+    [
+        ("n_hidden_layers", 0),
+        ("n_hidden_units", 0),
+        ("alpha", -1.0),
+        ("max_iter", 0),
+        ("verbose", "yes"),
+    ],
+)
+def test_invalid_hyperparameters_are_rejected(data, parameter, value):
+    """Parameter constraints are enforced when fitting."""
+    X, y = data
+
+    with pytest.raises(ValueError, match=rf"The '{parameter}' parameter"):
+        DummyMLP(**{parameter: value}).fit(X, y)
+
+
+def test_class_weight_is_converted_to_sample_weight(data):
+    """Class weights reach the objective as per-sample weights."""
+    X, y = data
+
+    DummyMLP(class_weight={10: 2.0, 20: 1.0, 30: 3.0}, max_iter=1).fit(X, y)
+
+    np.testing.assert_array_equal(
+        DummyMLP.last_sample_weight, np.array([2.0, 1.0, 3.0, 1.0])
+    )
+
+
+def test_optimizer_uses_lbfgs_and_unpacks_result(data, monkeypatch):
+    """The base class configures L-BFGS-B and stores its optimized parameters."""
+    X, y = data
+    calls = {}
+
+    def fake_minimize(fun, x0, args, method, jac, options):
+        calls.update(method=method, jac=jac, options=options)
+        cost, gradient = fun(x0, *args)
+        assert gradient.shape == x0.shape
+        return type("Result", (), {"fun": cost, "nit": 4, "x": np.ones_like(x0)})()
+
+    monkeypatch.setattr(
+        "skordinal.classifiers._mlp_base.scipy.optimize.minimize", fake_minimize
+    )
+
+    clf = DummyMLP(max_iter=17, verbose=True).fit(X, y)
+
+    assert calls == {
+        "method": "L-BFGS-B",
+        "jac": True,
+        "options": {"maxiter": 17, "disp": True},
+    }
+    assert clf.n_iter_ == 4
+    np.testing.assert_array_equal(clf.weights_, np.ones_like(clf.weights_))

--- a/skordinal/classifiers/tests/test_mlp_base.py
+++ b/skordinal/classifiers/tests/test_mlp_base.py
@@ -146,12 +146,12 @@ def test_optimizer_uses_lbfgs_and_unpacks_result(data, monkeypatch):
         "skordinal.classifiers._mlp_base.scipy.optimize.minimize", fake_minimize
     )
 
-    clf = DummyMLP(max_iter=17, verbose=True).fit(X, y)
+    clf = DummyMLP(max_iter=17).fit(X, y)
 
     assert calls == {
         "method": "L-BFGS-B",
         "jac": True,
-        "options": {"maxiter": 17, "disp": True},
+        "options": {"maxiter": 17},
     }
     assert clf.n_iter_ == 4
     np.testing.assert_array_equal(clf.weights_, np.ones_like(clf.weights_))


### PR DESCRIPTION
#### Reference Issues/PRs

Resolves #173  

#### What does this implement/fix? Explain your changes

Adds `MLPBaseClassifier`, an abstract base class for MLP classifiers. It handles the main fit loop using `L-BFGS-B ` optimizer, parameter validation, and class weights. Child classes now only need to implement parameter initialization/unpacking, cost/gradient computation, and internal probability predictions.


